### PR TITLE
Fix dashboard applications table applications link bug

### DIFF
--- a/app/views/admin/applications/_applications_table.html.erb
+++ b/app/views/admin/applications/_applications_table.html.erb
@@ -128,6 +128,7 @@
           <td class="px-2 py-2 text-sm font-medium overflow-hidden">
             <%= link_to "View",
                 admin_application_path(id: application.id),
+                data: { turbo_frame: "_top" },
                 class: "text-indigo-600 hover:text-indigo-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 whitespace-nowrap",
                 aria: { label: "View details for #{application.user&.full_name || 'Unknown User'}" } %>
           </td>


### PR DESCRIPTION
Adds `data: {turbo_frame}: _top` to the applications_table partial application view link because the link was trying to load in the data frame before, resulting in the user being directed back to the dashboard seeing an error in the applications table of `Content missing`.
<img width="990" height="182" alt="Screenshot 2025-12-03 at 4 08 22 PM" src="https://github.com/user-attachments/assets/49ec6ed7-2573-4b25-83d1-7fab9980e3c5" />
