### PR TITLE
Fix proof review buttons not working after updates

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -181,18 +181,14 @@ module Admin
       # Flow: handle_success_response -> responds with redirect for HTML or turbo streams for AJAX
       # For Turbo Streams, updates specified elements and removes open modals
       # For HTML: redirects with notice message
-      #
-      # NOTE: Native <dialog> elements can maintain their open state even when HTML is replaced,
-      # so we must explicitly remove the modals via turbo_stream.remove() before replacing them.
-      handle_success_response(
+      handle_success_response
         html_redirect_path: admin_application_path(@application),
         html_message: message,
         turbo_updates: {
           'attachments-section' => 'attachments',      # Updates attachment display
           'audit-logs' => 'audit_logs',                # Updates audit log section
           'modals' => 'modals'                         # Replaces modals with fresh versions
-        },
-        turbo_modals_to_remove: standard_application_modals # Explicitly close open dialogs
+        }
       )
     end
 

--- a/app/controllers/concerns/turbo_stream_response_handling.rb
+++ b/app/controllers/concerns/turbo_stream_response_handling.rb
@@ -25,7 +25,9 @@ module TurboStreamResponseHandling
   # @param updates [Hash] Hash of element_id => partial_name for updates
   # @param modals_to_remove [Array<String>] Array of modal IDs to remove
   # @return [Array] Array of turbo stream objects
-  def build_success_turbo_streams(updates = {}, modals_to_remove = [])
+  # 
+  # NOTE: modals_to_remove is ignored if updates includes 'modals' (container replacement)
+def build_success_turbo_streams(updates = {}, modals_to_remove = [])
     streams = []
 
     # Always update flash messages

--- a/app/controllers/concerns/turbo_stream_response_handling.rb
+++ b/app/controllers/concerns/turbo_stream_response_handling.rb
@@ -36,9 +36,11 @@ module TurboStreamResponseHandling
       streams << turbo_stream.update(element_id, partial: partial_name)
     end
 
-    # Remove specified modals
-    modals_to_remove.each do |modal_id|
-      streams << turbo_stream.remove(modal_id)
+    # Remove specified modals unless they were recently updated
+    unless updates.key?('modals')
+      modals_to_remove.each do |modal_id|
+        streams << turbo_stream.remove(modal_id)
+      end
     end
 
     streams


### PR DESCRIPTION
## Problem
When updating proof review status (approve/reject), the application was attempting to both:
1. Update the entire modals container (`'modals' => 'modals'`)
2. Remove individual modals via `turbo_modals_to_remove`

This created conflicting Turbo Stream commands that was causing the buttons for the proof review modals to be unclickable after one proof review was updated.

## Solution
Implements a conditional check in app/controllers/concerns/turbo_stream_response_handling.rb:build_success_turbo_streams to skip individual modal removals when the modals container is being replaced:

```ruby
unless updates.key?('modals')
  modals_to_remove.each do |modal_id|
    streams << turbo_stream.remove(modal_id)
  end
end
```
Removes turbo_modals_to_remove from app/controllers/admin/applications_controller.rb:handle_success_response.