### PR TITLE
Skip validation on user role update

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -605,7 +605,7 @@ module Admin
     end
 
     def save_converted_user(converted_user, original_user)
-      if converted_user.save
+      if converted_user.save(validate: false)
         handle_successful_user_conversion(converted_user)
       else
         handle_failed_user_conversion(converted_user, original_user)


### PR DESCRIPTION
Allow role changes for users with incomplete data

Skip validations when converting user roles to prevent failures from incomplete user profiles. 
Role conversion only updates the type column, so validation is unnecessary and adds overhead.