### PR TITLE
Email template variable edit

### DIFF
--- a/app/helpers/admin/email_templates_helper.rb
+++ b/app/helpers/admin/email_templates_helper.rb
@@ -27,6 +27,7 @@ module Admin
         'vendor_portal_url' => 'http://example.com/vendor',
         'application_id' => '12345',
         'user_first_name' => 'Alex',
+        'user_full_name' => 'Alex Johnson',
         'user_email' => 'alex@example.com',
         'constituent_first_name' => 'Jamie',
         'constituent_full_name' => 'Jamie Doe',
@@ -133,7 +134,6 @@ module Admin
       end
     end
 
-    # Vendor-specific data methods
     def vendor_invoice_data
       {
         'header_title' => 'Vendor Notification: Invoice Generated',
@@ -156,6 +156,137 @@ module Admin
         'vendor_contact_email' => 'morgan@baltimoreats.com',
         'invoice_number' => 'INV-2025-042',
         'total_amount_formatted' => '$1,875.50'
+      }
+    end
+
+    def vendor_w9_data(template_name)
+      {
+        'header_title' => "Vendor Notification: W9 #{template_name.to_s.split('_').last.capitalize}",
+        'vendor_business_name' => 'Baltimore Accessible Tech Solutions',
+        'vendor_contact_name' => 'Morgan Johnson',
+        'vendor_contact_email' => 'morgan@baltimoreats.com',
+        'days_until_expiry' => 30
+      }
+    end
+
+    def email_header_data
+      {
+        'title' => 'Sample Email Title',
+        'subtitle' => 'Sample Subtitle'
+      }
+    end
+
+    def email_footer_data
+      {
+        'contact_email' => 'support@example.com',
+        'footer_website_url' => 'http://example.com',
+        'show_automated_message' => true
+      }
+    end
+
+    def application_account_created_data
+      {
+        'title' => 'Account Created',
+        'constituent_first_name' => 'Jamie',
+        'constituent_email' => 'jamie.doe@example.com',
+        'sign_in_url' => 'http://example.com/sign_in',
+        'temp_password' => 'temporaryP@ssw0rd'
+      }
+    end
+
+    def income_threshold_data
+      {
+        'header_title' => 'Income Threshold Exceeded',
+        'constituent_first_name' => 'Jamie',
+        'annual_income_formatted' => '$65,000.00',
+        'threshold_formatted' => '$55,000.00'
+      }
+    end
+
+    def registration_confirmation_data
+      {
+        'header_title' => 'Registration Confirmation',
+        'new_application_url' => 'http://example.com/applications/12'
+      }
+    end
+
+    def proof_submission_error_data
+      {
+        'header_title' => 'Proof Submission Error',
+        'constituent_first_name' => 'Jamie',
+        'proof_type_formatted' => 'Income Verification',
+        'message' => 'The document could not be processed. Please try again.',
+        'additional_instructions' => 'Please ensure the document is clear and readable.'
+      }
+    end
+
+    def certification_submission_error_data
+      {
+        'header_title' => 'Medical Certification Submission Error',
+        'error_message' => 'The medical certification could not be processed.',
+        'medical_provider_email' => 'medical.provider@example.com'
+      }
+    end
+
+    def training_scheduled_data
+      {
+        'header_title' => 'Training Scheduled',
+        'constituent_first_name' => 'Jamie',
+        'trainer_full_name' => 'Training Specialist',
+        'submission_date_formatted' => Date.current.strftime('%B %d, %Y'),
+        'request_count_message' => '(Request #1)'
+      }
+    end
+
+    def training_cancelled_data
+      {
+        'header_title' => 'Training Cancelled',
+        'constituent_first_name' => 'Jamie',
+        'trainer_full_name' => 'Training Specialist',
+        'rejection_reason' => 'Training session was cancelled due to scheduling conflict.',
+        'support_email' => 'trainingsupport@example.com',
+        'scheduled_date_time_formatted' => Date.current.strftime('%B %d, %Y at %I:%M %p %Z')
+      }
+    end
+
+    def training_completed_data
+      {
+        'header_title' => 'Training Completed',
+        'constituent_first_name' => 'Jamie',
+        'completed_date_formatted' => Date.current.strftime('%B %d, %Y'),
+        'trainer_full_name' => 'Training Specialist',
+        'trainer_email' => 'trainingsupport@example.com',
+        'trainer_phone_formatted' => '555-123-4567',
+        'submission_date_formatted' => Date.current.strftime('%B %d, %Y')
+      }
+    end
+
+    def training_no_show_data
+      {
+        'header_title' => 'Training Session Missed',
+        'constituent_first_name' => 'Jamie',
+        'trainer_full_name' => 'Training Specialist',
+        'submission_date_formatted' => Date.current.strftime('%B %d, %Y'),
+        'remaining_attempts_message_text' => 'You have 2 attempts remaining.'
+      }
+    end
+
+    def voucher_redeemed_data
+      {
+        'header_title' => 'Voucher Redeemed',
+        'constituent_first_name' => 'Jamie',
+        'voucher_code' => 'VOUCHER123XYZ',
+        'transaction_amount_formatted' => '$150.00',
+        'remaining_balance_formatted' => '$350.00'
+      }
+    end
+
+    def stale_reviews_data
+      {
+        'header_title' => 'Stale Reviews Summary',
+        'admin_full_name' => 'Sally Smythe',
+        'stale_reviews_count' => 5,
+        'stale_reviews_text_list' => "- Application #1001\n- Application #1002\n- Application #1003\n- Application #1004\n- Application #1005"
       }
     end
   end

--- a/app/javascript/controllers/admin/protected_variables_controller.js
+++ b/app/javascript/controllers/admin/protected_variables_controller.js
@@ -1,0 +1,74 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["textarea", "editor"]
+  
+  connect() {
+    this.renderProtectedVariables()
+    this.editorTarget.addEventListener("input", () => {
+      this.syncToTextarea()
+      this.renderProtectedVariables()
+    })
+    this.editorTarget.addEventListener("keydown", (e) => this.preventCursorInVariable(e))
+    this.textareaTarget.addEventListener("change", () => this.renderProtectedVariables())
+  }
+  
+  preventCursorInVariable(e) {
+    // Only prevent if directly clicking on a protected variable
+    if (e.target.classList?.contains("protected-variable")) {
+      e.preventDefault()
+      
+      // Move cursor to after the variable
+      const selection = window.getSelection()
+      const range = document.createRange()
+      const nextNode = e.target.nextSibling || e.target.parentNode.nextSibling
+      
+      if (nextNode) {
+        range.setStart(nextNode, 0)
+      } else {
+        range.setStart(this.editorTarget, this.editorTarget.childNodes.length)
+      }
+      range.collapse(true)
+      selection.removeAllRanges()
+      selection.addRange(range)
+    }
+  }
+  
+  renderProtectedVariables() {
+    const text = this.textareaTarget.value
+    
+    // Split text into parts: variables and regular text
+    const parts = text.split(/(%<[a-zA-Z0-9_]+>s)/g)
+    
+    // Create HTML with variables as non-editable and text as editable
+    const html = parts.map((part) => {
+      if (part.match(/^%<[a-zA-Z0-9_]+>s$/)) {
+        // This is a variable - make it non-editable with grey background
+        return `<span class="protected-variable" contenteditable="false" style="background-color: #e5e7eb; color: #6b7280; padding: 2px 4px; border-radius: 3px; cursor: not-allowed; user-select: none;">${this.escapeHtml(part)}</span>`
+      } else {
+        // This is regular text - keep it editable
+        return this.escapeHtml(part)
+      }
+    }).join("")
+    
+    this.editorTarget.innerHTML = html
+  }
+  
+  syncToTextarea() {
+    // Extract all text content, preserving variable spans
+    const content = Array.from(this.editorTarget.childNodes)
+      .map(node => {
+        if (node.nodeType === Node.TEXT_NODE) return node.textContent
+        if (node.classList?.contains("protected-variable")) return node.textContent
+        return node.textContent
+      })
+      .join("")
+    this.textareaTarget.value = content
+  }
+  
+  escapeHtml(text) {
+    const div = document.createElement("div")
+    div.textContent = text
+    return div.innerHTML
+  }
+}

--- a/app/javascript/controllers/admin/protected_variables_controller.js
+++ b/app/javascript/controllers/admin/protected_variables_controller.js
@@ -28,7 +28,6 @@ export default class extends Controller {
   }
   
   preventCursorInVariable(e) {
-    console.log('preventCursorInVariable')
     // Only prevent if directly clicking on a protected variable
     if (e.target.classList?.contains("protected-variable")) {
       e.preventDefault()

--- a/app/javascript/controllers/admin/protected_variables_controller.js
+++ b/app/javascript/controllers/admin/protected_variables_controller.js
@@ -1,19 +1,34 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["textarea", "editor"]
+  static targets = ["textarea", "editor", "variableSelect"]
   
   connect() {
     this.renderProtectedVariables()
     this.editorTarget.addEventListener("input", () => {
       this.syncToTextarea()
-      this.renderProtectedVariables()
     })
-    this.editorTarget.addEventListener("keydown", (e) => this.preventCursorInVariable(e))
+    this.editorTarget.addEventListener("keydown", (e) => this.handleKeydown(e))
     this.textareaTarget.addEventListener("change", () => this.renderProtectedVariables())
+    // Handle variable dropdown selection
+    this.variableSelectTarget.addEventListener("change", (e) => this.insertVariable(e))
+  }
+  
+  handleKeydown(e) {
+    // Allow deleting selected variables with backspace/delete
+    if ((e.key === 'Backspace' || e.key === 'Delete') && e.target.classList?.contains('protected-variable')) {
+      e.preventDefault()
+      e.target.remove()
+      this.syncToTextarea()
+      return
+    }
+    
+    // Prevent cursor inside variables
+    this.preventCursorInVariable(e)
   }
   
   preventCursorInVariable(e) {
+    console.log('preventCursorInVariable')
     // Only prevent if directly clicking on a protected variable
     if (e.target.classList?.contains("protected-variable")) {
       e.preventDefault()
@@ -33,6 +48,111 @@ export default class extends Controller {
       selection.addRange(range)
     }
   }
+
+  handleDragStart(e) {
+    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.setData('text/html', e.target.outerHTML)
+    e.dataTransfer.setData('text/plain', e.target.textContent)
+    // Store reference to the original element so we can remove it later
+    this.draggedElement = e.target
+    e.target.style.opacity = '0.5'
+  }
+  
+  handleDragEnd(e) {
+    e.target.style.opacity = '1'
+  }
+  
+  handleDragOver(e) {
+    e.preventDefault()
+    // Only allow dropping on text nodes or the editor itself, not on other variables
+    if (e.target === this.editorTarget || (e.target.nodeType === Node.TEXT_NODE)) {
+      e.dataTransfer.dropEffect = 'move'
+    } else if (!e.target.classList?.contains('protected-variable')) {
+      e.dataTransfer.dropEffect = 'move'
+    } else {
+      e.dataTransfer.dropEffect = 'none'
+    }
+  }
+  
+  handleDrop(e) {
+    e.preventDefault()
+    
+    // Don't allow dropping into other variables
+    if (e.target.classList?.contains('protected-variable')) {
+      return
+    }
+    
+    e.target.style.opacity = '1'
+    
+    // Get the variable text being dragged
+    const variableText = e.dataTransfer.getData('text/plain')
+    
+    // Get the position where we dropped
+    const range = document.caretRangeFromPoint(e.clientX, e.clientY)
+    
+    if (range && (range.commonAncestorContainer.parentElement === this.editorTarget || this.editorTarget.contains(range.commonAncestorContainer))) {
+      // Create a new span for the variable
+      const span = document.createElement('span')
+      span.className = 'protected-variable'
+      span.draggable = true
+      span.contentEditable = false
+      span.style.cssText = 'background-color: #e5e7eb; color: #6b7280; padding: 2px 4px; border-radius: 3px; cursor: move; user-select: none;'
+      span.textContent = variableText
+      
+      // Insert at the drop position
+      range.insertNode(span)
+      
+      // Add drag listeners to the new variable
+      span.addEventListener('dragstart', (e) => this.handleDragStart(e))
+      span.addEventListener('dragend', (e) => this.handleDragEnd(e))
+      
+      // Remove the original variable if it's different from the new one
+      if (this.draggedElement && this.draggedElement !== span) {
+        this.draggedElement.remove()
+      }
+
+      // Sync to textarea
+      this.syncToTextarea()      
+    }
+    
+    this.draggedElement = null
+  }
+
+  insertVariable(e) {
+    const variableText = e.target.value
+    if (!variableText) return
+    
+    // Focus the editor
+    this.editorTarget.focus()
+    
+    // Get current selection/cursor position
+    const selection = window.getSelection()
+    if (selection.rangeCount === 0) return
+    
+    const range = selection.getRangeAt(0)
+    
+    // Create a span for the variable
+    const span = document.createElement('span')
+    span.className = 'protected-variable'
+    span.draggable = true
+    span.contentEditable = false
+    span.style.cssText = 'background-color: #e5e7eb; color: #6b7280; padding: 2px 4px; border-radius: 3px; cursor: move; user-select: none;'
+    span.textContent = variableText
+    
+    // Insert at cursor
+    range.insertNode(span)
+    
+    // Add drag listeners
+    span.addEventListener('dragstart', (e) => this.handleDragStart(e))
+    span.addEventListener('dragend', (e) => this.handleDragEnd(e))
+    
+    // Reset dropdown
+    e.target.value = ''
+    
+    // Sync to textarea
+    this.syncToTextarea()
+  }
+
   
   renderProtectedVariables() {
     const text = this.textareaTarget.value
@@ -44,7 +164,7 @@ export default class extends Controller {
     const html = parts.map((part) => {
       if (part.match(/^%<[a-zA-Z0-9_]+>s$/)) {
         // This is a variable - make it non-editable with grey background
-        return `<span class="protected-variable" contenteditable="false" style="background-color: #e5e7eb; color: #6b7280; padding: 2px 4px; border-radius: 3px; cursor: not-allowed; user-select: none;">${this.escapeHtml(part)}</span>`
+        return `<span class="protected-variable" draggable="true" contenteditable="false" style="background-color: #e5e7eb; color: #6b7280; padding: 2px 4px; border-radius: 3px; cursor: not-allowed; user-select: none;">${this.escapeHtml(part)}</span>`
       } else {
         // This is regular text - keep it editable
         return this.escapeHtml(part)
@@ -52,8 +172,17 @@ export default class extends Controller {
     }).join("")
     
     this.editorTarget.innerHTML = html
+    // Add drag event listeners to all protected variables
+    this.editorTarget.querySelectorAll('.protected-variable').forEach(variable => {
+      variable.addEventListener('dragstart', (e) => this.handleDragStart(e))
+      variable.addEventListener('dragend', (e) => this.handleDragEnd(e))
+    })
+
+    // Add drop zone listeners to editor
+    this.editorTarget.addEventListener('dragover', (e) => this.handleDragOver(e))
+    this.editorTarget.addEventListener('drop', (e) => this.handleDrop(e))
   }
-  
+
   syncToTextarea() {
     // Extract all text content, preserving variable spans
     const content = Array.from(this.editorTarget.childNodes)
@@ -61,8 +190,7 @@ export default class extends Controller {
         if (node.nodeType === Node.TEXT_NODE) return node.textContent
         if (node.classList?.contains("protected-variable")) return node.textContent
         return node.textContent
-      })
-      .join("")
+     }).join("")
     this.textareaTarget.value = content
   }
   

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -3,6 +3,7 @@ import { application } from "./application"
 // Admin Controllers
 import RoleSelectController from "./admin/role_select_controller"
 import AdminUserSearchController from "./admin/user_search_controller"
+import ProtectedVariablesController from "./admin/protected_variables_controller"
 
 // Auth Controllers
 import AddCredentialController from "./auth/add_credential_controller"
@@ -58,6 +59,7 @@ if (process.env?.NODE_ENV === "development") {
 // Admin Controllers
 application.register("role-select", RoleSelectController)
 application.register("admin-user-search", AdminUserSearchController)
+application.register("protected-variables", ProtectedVariablesController)
 
 // Auth Controllers
 application.register("add-credential", AddCredentialController)

--- a/app/mailers/voucher_notifications_mailer.rb
+++ b/app/mailers/voucher_notifications_mailer.rb
@@ -229,6 +229,7 @@ class VoucherNotificationsMailer < ApplicationMailer
     # Use Policy.get for configuration values
     expiration_date_formatted = (voucher.issued_at + (Policy.get('voucher_validity_period_months') || 6).months).strftime('%B %d, %Y')
     minimum_redemption_amount_formatted = number_to_currency(Policy.get('minimum_voucher_redemption_amount') || 0)
+    redeemed_value_formatted = number_to_currency(transaction.amount)
 
     # Optional message blocks (text only)
     remaining_value_message_text = ''
@@ -252,6 +253,7 @@ class VoucherNotificationsMailer < ApplicationMailer
       expiration_date_formatted: expiration_date_formatted,
       # Optional variables
       remaining_value_message_text: remaining_value_message_text,
+      redeemed_value_formatted: redeemed_value_formatted,
       fully_redeemed_message_text: fully_redeemed_message_text,
       minimum_redemption_amount_formatted: minimum_redemption_amount_formatted # Often used within optional blocks
     }.compact

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -18,7 +18,7 @@ class EmailTemplate < ApplicationRecord
   validates :version, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
   validate :validate_variables_in_body
 
-  # Store previous version and check for user inputted variables before saving changes
+  # Store previous version before saving changes
   before_update :store_previous_content
   before_update :increment_version
 

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -146,7 +146,7 @@ class EmailTemplate < ApplicationRecord
     'vendor_notifications_w9_expired' => {
       description: 'Sent to a vendor when their W9 form has expired.',
       required_vars: %w[vendor_business_name expiration_date_formatted vendor_portal_url
-                        status_box_warning_text status_box_info_text header_text footer_text],
+                        status_box_warning_text status_box_info_text status_box_error_text header_text footer_text],
       optional_vars: %w[vendor_association_message title logo subtitle show_automated_message] # title was required before, now optional helper arg
     },
 
@@ -167,26 +167,26 @@ class EmailTemplate < ApplicationRecord
       description: 'Sent to a constituent when their voucher is redeemed.',
       required_vars: %w[user_first_name transaction_date_formatted transaction_amount_formatted vendor_business_name
                         transaction_reference_number voucher_code remaining_balance_formatted expiration_date_formatted
-                        remaining_value_message_text fully_redeemed_message_text], # Removed HTML vars
-      optional_vars: %w[minimum_redemption_amount_formatted] # No header/footer used in this template
+                        remaining_value_message_text fully_redeemed_message_text redeemed_value_formatted], # Removed HTML vars
+      optional_vars: %w[minimum_redemption_amount_formatted header_text footer_text] # No header/footer used in this template
     },
 
     # TrainingSessionNotificationsMailer Templates
     'training_session_notifications_trainer_assigned' => {
       description: 'Sent to a trainer when a new training session is assigned to them.',
-      required_vars: %w[trainer_full_name constituent_full_name constituent_address_formatted constituent_phone_formatted
+      required_vars: %w[trainer_full_name trainer_email trainer_phone_formatted constituent_full_name constituent_address_formatted constituent_phone_formatted
                         constituent_email training_session_schedule_text header_text footer_text constituent_disabilities_text_list status_box_text],
       optional_vars: %w[title logo subtitle show_automated_message]
     },
     'training_session_notifications_training_scheduled' => {
       description: 'Sent to a constituent when their training session is scheduled.',
-      required_vars: %w[constituent_full_name trainer_full_name scheduled_date_formatted scheduled_time_formatted trainer_email
+      required_vars: %w[constituent_full_name trainer_full_name trainer_email trainer_phone_formatted scheduled_date_formatted scheduled_time_formatted trainer_email
                         trainer_phone_formatted header_text footer_text],
       optional_vars: %w[title logo subtitle show_automated_message]
     },
     'training_session_notifications_training_completed' => {
       description: 'Sent to a constituent when their training session is marked as completed.',
-      required_vars: %w[constituent_full_name trainer_full_name completed_date_formatted application_id trainer_email
+      required_vars: %w[constituent_full_name trainer_full_name trainer_email trainer_phone_formatted completed_date_formatted application_id trainer_email
                         trainer_phone_formatted header_text footer_text],
       optional_vars: %w[title logo subtitle show_automated_message]
     },
@@ -197,7 +197,7 @@ class EmailTemplate < ApplicationRecord
     },
     'training_session_notifications_training_no_show' => { # NOTE: Mailer uses 'training_no_show' in find_by, but we use full name here
       description: 'Sent to a constituent if they are marked as a no-show for their training session.',
-      required_vars: %w[constituent_full_name scheduled_date_time_formatted support_email header_text footer_text],
+      required_vars: %w[constituent_full_name trainer_email scheduled_date_time_formatted support_email header_text footer_text],
       optional_vars: %w[title logo subtitle show_automated_message]
     }
   }.freeze

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -248,6 +248,11 @@ class EmailTemplate < ApplicationRecord
     raise
   end
 
+  # Extract all variables used in the template body
+  def extract_variables
+    body.scan(/%[{<](\w+)[}>]/).flatten.uniq
+  end
+
   private
 
   def set_default_version

--- a/app/views/admin/email_templates/_form.html.erb
+++ b/app/views/admin/email_templates/_form.html.erb
@@ -54,9 +54,38 @@
     </style>
     
     <p class="mt-2 text-sm text-gray-500">
-      Use <code class="text-sm bg-gray-100 px-1 py-0.5 rounded">%{variable_name}s</code> syntax. Variables are highlighted in blue and cannot be edited or deleted.
+      Variables are highlighted in gray and cannot be edited.
     </p>
+
+    <!-- Available Variables Dropdown -->
+    <div class="mt-4">
+      <label for="variable-insert" class="block text-sm font-medium text-gray-700 mb-2">
+        Insert Variable
+      </label>
+      <select id="variable-insert" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" data-protected-variables-target="variableSelect">
+        <option value="">-- Select a variable to insert --</option>
+        <% required_vars = template_definition[:required_vars] || [] %>
+        <% optional_vars = template_definition[:optional_vars] || [] %>
+        <% if required_vars.any? %>
+          <optgroup label="Required Variables">
+            <% required_vars.each do |var| %>
+              <option value="%&lt;<%= var %>&gt;s"><%= var %></option>
+            <% end %>
+          </optgroup>
+        <% end %>
+        <% if optional_vars.any? %>
+          <optgroup label="Optional Variables">
+            <% optional_vars.each do |var| %>
+              <option value="%&lt;<%= var %>&gt;s"><%= var %></option>
+            <% end %>
+          </optgroup>
+        <% end %>
+      </select>
+    </div>
+  
   </div>
+
+
 
   <%# Preview Section %>
   <div class="mt-6 mb-6 p-4 border border-gray-200 rounded-md bg-white">
@@ -106,39 +135,6 @@
     
     <div class="text-sm text-gray-600 mt-2 italic">
       <p>Preview uses sample data with placeholder values. All variables, headers, and footers are rendered.</p>
-    </div>
-  </div>
-
-  <%# Available Variables Section (for reference during editing) %>
-  <div class="mt-6 p-4 border border-gray-200 rounded-md bg-gray-50">
-    <h3 class="text-lg font-medium text-gray-700 mb-3">Available Variables Reference</h3>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-      <div>
-        <h4 class="text-md font-medium text-gray-600 mb-2">Required Variables</h4>
-        <% required_vars = template_definition[:required_vars] || [] %>
-        <% if required_vars.any? %>
-          <ul class="list-disc list-inside space-y-1">
-            <% required_vars.each do |var| %>
-              <li class="text-sm"><code class="text-sm bg-gray-200 px-1 py-0.5 rounded"><%= var %></code></li>
-            <% end %>
-          </ul>
-        <% else %>
-          <p class="text-sm text-gray-500">None defined.</p>
-        <% end %>
-      </div>
-      <div>
-        <h4 class="text-md font-medium text-gray-600 mb-2">Optional Variables</h4>
-        <% optional_vars = template_definition[:optional_vars] || [] %>
-        <% if optional_vars.any? %>
-          <ul class="list-disc list-inside space-y-1">
-            <% optional_vars.each do |var| %>
-              <li class="text-sm"><code class="text-sm bg-gray-200 px-1 py-0.5 rounded"><%= var %></code></li>
-            <% end %>
-          </ul>
-        <% else %>
-          <p class="text-sm text-gray-500">None defined.</p>
-        <% end %>
-      </div>
     </div>
   </div>
 

--- a/app/views/admin/email_templates/_form.html.erb
+++ b/app/views/admin/email_templates/_form.html.erb
@@ -24,11 +24,37 @@
     <%= form.text_field :subject, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
   </div>
 
-  <div>
+  <div data-controller="protected-variables">
     <%= form.label :body, class: "block text-sm font-medium text-gray-700" %>
-    <%= form.text_area :body, rows: 20, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm font-mono" %>
+    
+    <!-- Hidden textarea that stores actual data -->
+    <%= form.text_area :body, 
+        rows: 20, 
+        class: "hidden",
+        data: { "protected-variables-target": "textarea" } %>
+    
+    <!-- Visible editable div -->
+    <div 
+      data-protected-variables-target="editor"
+      class="mt-1 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm font-mono p-3 min-h-96 bg-white"
+      contenteditable="true"
+      style="white-space: pre-wrap; word-wrap: break-word; outline: none;">
+    </div>
+    
+    <style>
+      .protected-variable {
+        background-color: #e0e7ff;
+        color: #4f46e5;
+        padding: 2px 4px;
+        border-radius: 3px;
+        font-weight: 500;
+        cursor: not-allowed;
+        user-select: none;
+      }
+    </style>
+    
     <p class="mt-2 text-sm text-gray-500">
-      Use <code class="text-sm bg-gray-100 px-1 py-0.5 rounded">%{variable_name}</code> syntax for interpolation.
+      Use <code class="text-sm bg-gray-100 px-1 py-0.5 rounded">%{variable_name}s</code> syntax. Variables are highlighted in blue and cannot be edited or deleted.
     </p>
   </div>
 

--- a/app/views/admin/email_templates/_form.html.erb
+++ b/app/views/admin/email_templates/_form.html.erb
@@ -53,16 +53,14 @@
       }
     </style>
     
-    <p class="mt-2 text-sm text-gray-500">
-      Variables are highlighted in gray and cannot be edited.
-    </p>
+    <div class="mt-2 flex items-start gap-4">
+      <div class="flex-1">
 
-    <!-- Available Variables Dropdown -->
-    <div class="mt-4">
-      <label for="variable-insert" class="block text-sm font-medium text-gray-700 mb-2">
-        Insert Variable
-      </label>
-      <select id="variable-insert" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" data-protected-variables-target="variableSelect">
+    <!-- Insert Variable Dropdown -->
+        <label for="variable-insert" class="block text-sm font-medium text-gray-700 mb-2">
+          Insert Variable
+        </label>
+        <select id="variable-insert" class="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500 focus:ring-1 text-sm" data-protected-variables-target="variableSelect">
         <option value="">-- Select a variable to insert --</option>
         <% required_vars = template_definition[:required_vars] || [] %>
         <% optional_vars = template_definition[:optional_vars] || [] %>
@@ -81,8 +79,12 @@
           </optgroup>
         <% end %>
       </select>
+      </div>
+        <!-- Variable Help text -->
+        <p class="text-sm text-gray-500 flex-1">
+          Variables are highlighted in gray and cannot be edited.
+        </p>  
     </div>
-  
   </div>
 
 


### PR DESCRIPTION
Previously, users could easily edit variable names.

Now, variables are clearly not-editable--greyed out and the cursor can't go in them, and can be inserted through a drop down menu. Variables can be dragged and dropped within the textarea.

Also validates in email_template.rb that the user is not adding new variables.

<img width="796" height="707" alt="Screenshot 2025-12-16 at 10 57 02 AM" src="https://github.com/user-attachments/assets/e18f9ae5-06c6-43ad-9051-c9f360824a5a" />

<img width="792" height="357" alt="Screenshot 2025-12-16 at 10 57 08 AM" src="https://github.com/user-attachments/assets/6fecdd28-5f7f-4507-8a2d-584f13106f45" />
