### PR TITLE
Email templates check variables

### DIFF
--- a/app/mailers/application_notifications_mailer.rb
+++ b/app/mailers/application_notifications_mailer.rb
@@ -622,6 +622,8 @@ class ApplicationNotificationsMailer < ApplicationMailer
     organization_name = Policy.get('organization_name') || 'MAT Program'
     proof_type_formatted = format_proof_type(proof_type)
     header_title = "Document Received: #{proof_type_formatted.capitalize}"
+    # all_proofs_approved_message_text = 
+    # Need to add this
 
     base_variables = build_base_email_variables(header_title, organization_name)
     received_variables = {

--- a/app/mailers/application_notifications_mailer.rb
+++ b/app/mailers/application_notifications_mailer.rb
@@ -624,8 +624,6 @@ class ApplicationNotificationsMailer < ApplicationMailer
     organization_name = Policy.get('organization_name') || 'MAT Program'
     proof_type_formatted = format_proof_type(proof_type)
     header_title = "Document Received: #{proof_type_formatted.capitalize}"
-    # all_proofs_approved_message_text = 
-    # Need to add this
 
     base_variables = build_base_email_variables(header_title, organization_name)
     received_variables = {

--- a/app/mailers/application_notifications_mailer.rb
+++ b/app/mailers/application_notifications_mailer.rb
@@ -376,8 +376,8 @@ class ApplicationNotificationsMailer < ApplicationMailer
     organization_name = Policy.get('organization_name') || 'MAT Program'
     proof_type_formatted = format_proof_type(proof_review.proof_type)
     all_proofs_approved = application.respond_to?(:all_proofs_approved?) && application.all_proofs_approved?
+    all_proofs_approved_message_text = all_proofs_approved ? 'All required documents for your application have now been approved.' : ''
     header_title = "Document Review Update: #{proof_type_formatted.capitalize} Approved"
-    all_proofs_approved_message_text = all_proofs_approved ? 'All required documents for your application have now been approved.' : nil
 
     base_variables = build_base_email_variables(header_title, 'MAT Program')
     proof_variables = {

--- a/app/mailers/application_notifications_mailer.rb
+++ b/app/mailers/application_notifications_mailer.rb
@@ -187,7 +187,7 @@ class ApplicationNotificationsMailer < ApplicationMailer
   end
 
   def proof_received(application, proof_type)
-    template_name = 'application_notifications_proof_approved'
+    template_name = 'application_notifications_proof_received'
     text_template = find_email_template(template_name)
 
     variables = build_proof_received_variables(application, proof_type)
@@ -373,16 +373,18 @@ class ApplicationNotificationsMailer < ApplicationMailer
 
   def build_proof_approved_variables(application, proof_review)
     user = application.user
+    organization_name = Policy.get('organization_name') || 'MAT Program'
     proof_type_formatted = format_proof_type(proof_review.proof_type)
     all_proofs_approved = application.respond_to?(:all_proofs_approved?) && application.all_proofs_approved?
     header_title = "Document Review Update: #{proof_type_formatted.capitalize} Approved"
+    all_proofs_approved_message_text = all_proofs_approved ? 'All required documents for your application have now been approved.' : nil
 
     base_variables = build_base_email_variables(header_title, 'MAT Program')
     proof_variables = {
       user_first_name: user.first_name,
-      organization_name: 'MAT Program',
+      organization_name: organization_name,
       proof_type_formatted: proof_type_formatted,
-      all_proofs_approved_message_text: all_proofs_approved ? 'All required documents for your application have now been approved.' : nil
+      all_proofs_approved_message_text: all_proofs_approved_message_text
     }
 
     base_variables.merge(proof_variables).compact
@@ -629,8 +631,7 @@ class ApplicationNotificationsMailer < ApplicationMailer
     received_variables = {
       user_first_name: user.first_name,
       organization_name: organization_name,
-      proof_type_formatted: proof_type_formatted,
-      all_proofs_approved_message_text: nil
+      proof_type_formatted: proof_type_formatted
     }
 
     base_variables.merge(received_variables).compact

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -51,6 +51,11 @@ class EmailTemplate < ApplicationRecord
       required_vars: %w[user_first_name organization_name proof_type_formatted header_text footer_text],
       optional_vars: %w[all_proofs_approved_message_text title logo subtitle show_automated_message]
     },
+    'application_notifications_proof_received' => {
+      description: 'Sent when a submitted proof document is received.',
+      required_vars: %w[user_first_name organization_name proof_type_formatted header_text footer_text],
+      optional_vars: %w[title logo subtitle show_automated_message]
+    },
     'application_notifications_proof_needs_review_reminder' => {
       description: 'Sent to admins as a reminder about applications awaiting proof review.',
       required_vars: %w[admin_full_name stale_reviews_count stale_reviews_text_list admin_dashboard_url header_text footer_text],

--- a/app/services/letters/text_template_to_pdf_service.rb
+++ b/app/services/letters/text_template_to_pdf_service.rb
@@ -204,6 +204,8 @@ module Letters
         'Income Eligibility Review'
       when 'application_notifications_proof_approved'
         'Document Verification Approved'
+      when 'application_notifications_proof_received'
+        'Document Verification Received'
       when 'application_notifications_max_rejections_reached'
         'Important Application Status Update'
       when 'application_notifications_proof_submission_error'

--- a/db/seeds/email_templates/application_notifications_proof_received.rb
+++ b/db/seeds/email_templates/application_notifications_proof_received.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Seed File for "application_notifications_proof_received"
+# --------------------------------------------------
+EmailTemplate.create_or_find_by!(name: 'application_notifications_proof_received', format: :text) do |template|
+  template.subject = 'Document Received'
+  template.description = 'Sent when a piece of documentation submitted by the applicant has been received and is awaiting review.'
+  template.body = <<~TEXT
+    %<header_text>s
+
+    Dear %<user_first_name>s,
+
+    Thank you for submitting your application to %<organization_name>s. We appreciate your interest in our services and look forward to assisting you.
+
+    ==================================================
+    ✓ DOCUMENTATION RECEIVED
+    ==================================================
+
+    We have received your %<proof_type_formatted>s documentation and it is now under review.
+
+    We will notify you once our review is complete. Thank you for your patience.
+
+    %<footer_text>s
+  TEXT
+  template.variables = %w[header_text user_first_name organization_name proof_type_formatted footer_text]
+  template.version = 1
+end
+Rails.logger.debug 'Seeded application_notifications_proof_received (text)' if ENV['VERBOSE_TESTS'] || Rails.env.development?


### PR DESCRIPTION
This pull request:
- Adds a template for proof_received rather than re-using proof_approved (I thought I'd done this already but can't find where I did this)
- Changes all_proofs_approved_message from a nil value to an empty string as a nil value caused the variable name to be rendered in the email