### PR TITLE
Fixed broken dashboard link in trainer view

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -19,6 +19,8 @@
                        evaluators_dashboard_path
                      elsif user.vendor?
                        vendor_portal_dashboard_path
+                     elsif user.trainer?
+                       trainers_dashboard_path
                      else
                        admin_applications_path
                      end


### PR DESCRIPTION
The dashboard link on login for trainers was directing to the admin dashboard. It now directs to the trainers dashboard.