### PR TITLE
Fix evaluators dashboard redirect

### DIFF
--- a/app/controllers/evaluators/dashboards_controller.rb
+++ b/app/controllers/evaluators/dashboards_controller.rb
@@ -22,12 +22,6 @@ module Evaluators
 
       # Load display data (always needed)
       load_display_data
-
-      # Handle different format requests appropriately
-      respond_to do |format|
-        format.html # renders show.html.erb as usual
-        format.turbo_stream # renders show.turbo_stream.erb if it exists
-      end
     end
 
     private

--- a/app/controllers/evaluators/evaluations_controller.rb
+++ b/app/controllers/evaluators/evaluations_controller.rb
@@ -249,22 +249,22 @@ module Evaluators
     end
 
     def process_attendees_param
-      return if params[:evaluation][:attendees_field].blank?
+      return if params[:attendees_field].blank?
 
-      attendees = params[:evaluation][:attendees_field].split(',').map do |attendee_str|
+      attendees = params[:attendees_field].split(',').map do |attendee_str|
         name, relationship = attendee_str.strip.split('-').map(&:strip)
         { 'name' => name, 'relationship' => relationship }
       end
-      params[:evaluation][:attendees] = attendees
+      params[:attendees] = attendees
     end
 
     def process_products_tried_param
-      return if params[:evaluation][:products_tried_field].blank?
+      return if params[:products_tried_field].blank?
 
-      products_tried = params[:evaluation][:products_tried_field].map do |product_id|
+      products_tried = params[:products_tried_field].map do |product_id|
         { 'product_id' => product_id, 'reaction' => 'Recorded during evaluation' }
       end
-      params[:evaluation][:products_tried] = products_tried
+      params[:products_tried] = products_tried
     end
   end
 end

--- a/app/views/evaluators/evaluations/show.html.erb
+++ b/app/views/evaluators/evaluations/show.html.erb
@@ -170,7 +170,7 @@
             Manage Evaluation
           </h3>
           
-          <%= form_with(url: update_evaluators_evaluation_path(@evaluation), method: :patch, local: true, class: "space-y-4") do |f| %>
+          <%= form_with(url: evaluators_evaluation_path(@evaluation), method: :patch, local: true, class: "space-y-4") do |f| %>
             <div>
               <%= f.label :status, "Status", class: "block text-sm font-medium text-gray-700" %>
               <%= f.select :status, 


### PR DESCRIPTION
There was no turbo_stream response available so I removed the respond_to. This fixes a sign in bug for evaluators. Can re-implement the respond_to if there are any specific turbo_stream calls for this endpoint.