### PR TITLE
Refactor modal handling to use turbo_modals_to_remove; other fixes

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -186,9 +186,9 @@ module Admin
         html_message: message,
         turbo_updates: {
           'attachments-section' => 'attachments',      # Updates attachment display
-          'audit-logs' => 'audit_logs'                 # Updates audit log section
-        },
-        turbo_modals_to_remove: standard_application_modals # Removes open modals after review
+          'audit-logs' => 'audit_logs',                # Updates audit log section
+          'modals' => 'modals'                         # Regenerates modals container (closes and resets all modals)
+        }
       )
     end
 
@@ -359,9 +359,9 @@ module Admin
         html_message: message,
         turbo_updates: {
           'medical-certification-section' => 'medical_certification_section',
-          'audit-logs' => 'audit_logs'
-        },
-        turbo_modals_to_remove: standard_application_modals
+          'audit-logs' => 'audit_logs',
+          'modals' => 'modals' # Regenerates modals container (closes and resets all modals)
+        }
       )
     end
 

--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -186,9 +186,9 @@ module Admin
         html_message: message,
         turbo_updates: {
           'attachments-section' => 'attachments',      # Updates attachment display
-          'audit-logs' => 'audit_logs',                # Updates audit log section
-          'modals' => 'modals'                         # Replaces modals with fresh versions
-        }
+          'audit-logs' => 'audit_logs'                 # Updates audit log section
+        },
+        turbo_modals_to_remove: standard_application_modals # Removes open modals after review
       )
     end
 
@@ -359,9 +359,9 @@ module Admin
         html_message: message,
         turbo_updates: {
           'medical-certification-section' => 'medical_certification_section',
-          'audit-logs' => 'audit_logs',
-          'modals' => 'modals'
-        }
+          'audit-logs' => 'audit_logs'
+        },
+        turbo_modals_to_remove: standard_application_modals
       )
     end
 

--- a/app/controllers/concerns/turbo_stream_response_handling.rb
+++ b/app/controllers/concerns/turbo_stream_response_handling.rb
@@ -25,9 +25,9 @@ module TurboStreamResponseHandling
   # @param updates [Hash] Hash of element_id => partial_name for updates
   # @param modals_to_remove [Array<String>] Array of modal IDs to remove
   # @return [Array] Array of turbo stream objects
-  # 
+  #
   # NOTE: modals_to_remove is ignored if updates includes 'modals' (container replacement)
-def build_success_turbo_streams(updates = {}, modals_to_remove = [])
+  def build_success_turbo_streams(updates = {}, modals_to_remove = [])
     streams = []
 
     # Always update flash messages
@@ -48,32 +48,13 @@ def build_success_turbo_streams(updates = {}, modals_to_remove = [])
     streams
   end
 
-  # Standard set of modals to remove for application-related operations
-  def standard_application_modals
-    %w[
-      proofRejectionModal
-      incomeProofReviewModal
-      residencyProofReviewModal
-      medicalCertificationReviewModal
-    ]
-  end
-
-  # Builds turbo streams for application proof review success
-  def build_proof_review_success_streams
-    updates = {
-      'attachments-section' => 'attachments',
-      'audit-logs' => 'audit_logs'
-    }
-
-    build_success_turbo_streams(updates, standard_application_modals)
-  end
-
   # Handles both HTML and Turbo Stream responses for successful operations
   # @param html_redirect_path [String] Path to redirect for HTML requests
   # @param html_message [String] Message for HTML redirect
   # @param turbo_message [String] Message for Turbo Stream response
   # @param turbo_updates [Hash] Updates for Turbo Stream response
-  # @param turbo_modals_to_remove [Array<String>] Modals to remove for Turbo Stream
+  # @param turbo_modals_to_remove [Array<String>] DEPRECATED: Modals to remove for Turbo Stream.
+  #   Use 'modals' => 'modals' in turbo_updates to replace entire modal container.
   # @param turbo_redirect_path [String] Path to redirect for Turbo Stream (optional)
   def handle_success_response(
     html_redirect_path:,

--- a/test/controllers/admin/applications_turbo_stream_test.rb
+++ b/test/controllers/admin/applications_turbo_stream_test.rb
@@ -37,8 +37,11 @@ module Admin
       # Must be a turbo stream response
       assert_equal 'text/vnd.turbo-stream.html', response.media_type
 
-      # Validate stream actions - controller now replaces modals container instead of removing individual modals
-      assert_turbo_stream action: 'update', target: 'modals'
+      # Validate stream actions - controller removes individual modals and updates attachments
+      assert_turbo_stream action: 'remove', target: 'proofRejectionModal'
+      assert_turbo_stream action: 'remove', target: 'incomeProofReviewModal'
+      assert_turbo_stream action: 'remove', target: 'residencyProofReviewModal'
+      assert_turbo_stream action: 'remove', target: 'medicalCertificationReviewModal'
       assert_turbo_stream action: 'update', target: 'attachments-section'
     end
 
@@ -64,8 +67,11 @@ module Admin
       assert_response :success
       assert_equal 'text/vnd.turbo-stream.html', response.media_type
 
-      # The controller replaces modals container and updates attachments
-      assert_turbo_stream action: 'update', target: 'modals'
+      # The controller removes individual modals and updates attachments
+      assert_turbo_stream action: 'remove', target: 'proofRejectionModal'
+      assert_turbo_stream action: 'remove', target: 'incomeProofReviewModal'
+      assert_turbo_stream action: 'remove', target: 'residencyProofReviewModal'
+      assert_turbo_stream action: 'remove', target: 'medicalCertificationReviewModal'
       assert_turbo_stream action: 'update', target: 'attachments-section'
     end
 
@@ -90,8 +96,11 @@ module Admin
       assert_response :success
       assert_equal 'text/vnd.turbo-stream.html', response.media_type
 
-      # Controller replaces modals container instead of removing individual modals
-      assert_turbo_stream action: 'update', target: 'modals'
+      # Controller removes individual modals and updates attachments
+      assert_turbo_stream action: 'remove', target: 'proofRejectionModal'
+      assert_turbo_stream action: 'remove', target: 'incomeProofReviewModal'
+      assert_turbo_stream action: 'remove', target: 'residencyProofReviewModal'
+      assert_turbo_stream action: 'remove', target: 'medicalCertificationReviewModal'
       assert_turbo_stream action: 'update', target: 'attachments-section'
     end
   end

--- a/test/controllers/admin/applications_turbo_stream_test.rb
+++ b/test/controllers/admin/applications_turbo_stream_test.rb
@@ -16,7 +16,7 @@ module Admin
       @application.income_proof.attach(io: StringIO.new('test content'), filename: 'income.pdf', content_type: 'application/pdf')
     end
 
-    test 'approve income proof responds with turbo streams: update modals and attachments' do
+    test 'approve income proof responds with turbo streams: update modals container and replace attachments' do
       attach_income_proof!
 
       approved_review = build(
@@ -37,15 +37,12 @@ module Admin
       # Must be a turbo stream response
       assert_equal 'text/vnd.turbo-stream.html', response.media_type
 
-      # Validate stream actions - controller removes individual modals and updates attachments
-      assert_turbo_stream action: 'remove', target: 'proofRejectionModal'
-      assert_turbo_stream action: 'remove', target: 'incomeProofReviewModal'
-      assert_turbo_stream action: 'remove', target: 'residencyProofReviewModal'
-      assert_turbo_stream action: 'remove', target: 'medicalCertificationReviewModal'
+      # Validate stream actions - modals container is replaced (closes all modals and regenerates them)
+      assert_turbo_stream action: 'update', target: 'modals'
       assert_turbo_stream action: 'update', target: 'attachments-section'
     end
 
-    test 'reject income proof responds with turbo streams: update modals and attachments' do
+    test 'reject income proof responds with turbo streams: update modals container and replace attachments' do
       attach_income_proof!
 
       rejected_review = build(
@@ -67,15 +64,12 @@ module Admin
       assert_response :success
       assert_equal 'text/vnd.turbo-stream.html', response.media_type
 
-      # The controller removes individual modals and updates attachments
-      assert_turbo_stream action: 'remove', target: 'proofRejectionModal'
-      assert_turbo_stream action: 'remove', target: 'incomeProofReviewModal'
-      assert_turbo_stream action: 'remove', target: 'residencyProofReviewModal'
-      assert_turbo_stream action: 'remove', target: 'medicalCertificationReviewModal'
+      # The controller replaces the modals container (closes all modals and regenerates them)
+      assert_turbo_stream action: 'update', target: 'modals'
       assert_turbo_stream action: 'update', target: 'attachments-section'
     end
 
-    test 'approve residency proof responds with turbo streams: update modals and attachments' do
+    test 'approve residency proof responds with turbo streams: update modals container and replace attachments' do
       # Attach residency proof and keep income untouched
       @application.residency_proof.attach(io: StringIO.new('test content'), filename: 'residency.pdf', content_type: 'application/pdf')
 
@@ -96,11 +90,8 @@ module Admin
       assert_response :success
       assert_equal 'text/vnd.turbo-stream.html', response.media_type
 
-      # Controller removes individual modals and updates attachments
-      assert_turbo_stream action: 'remove', target: 'proofRejectionModal'
-      assert_turbo_stream action: 'remove', target: 'incomeProofReviewModal'
-      assert_turbo_stream action: 'remove', target: 'residencyProofReviewModal'
-      assert_turbo_stream action: 'remove', target: 'medicalCertificationReviewModal'
+      # Modals container is replaced (closes all modals and regenerates them)
+      assert_turbo_stream action: 'update', target: 'modals'
       assert_turbo_stream action: 'update', target: 'attachments-section'
     end
   end


### PR DESCRIPTION
Refactor modal handling to use turbo_modals_to_remove pattern instead of direct modal replacements; improve error handling; refactor InvoicesController error handling into handle_update_error method; add explicit error messages for validation failures; fix missing_gad_reference? guard