### PR TITLE
Add production-safe policy seeding rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,43 @@ After seeding (`bin/rails db:seed`), the following test users are available:
 
 **Note**: Email templates must be seeded separately with `rake db:seed_manual_email_templates`.
 
+## Production Deployment
+
+For production environments (e.g., Heroku), use the rake tasks that don't require FactoryBot:
+
+```bash
+# Seed policies (required for application functionality)
+rails db:seed_policies
+
+# Seed email templates (required for notifications)
+rails db:seed_manual_email_templates
+```
+
+**On Heroku:**
+
+```bash
+heroku run rails db:seed_policies --app your-app-name
+heroku run rails db:seed_manual_email_templates --app your-app-name
+```
+
+**Important**: Do NOT run `rails db:seed` in production, as it requires FactoryBot (test dependency) and will clear existing data.
+
+To create an admin user in production, use the Rails console:
+
+```bash
+# Heroku
+heroku run rails console --app your-app-name
+
+# In console
+Users::Administrator.create!(
+  email: 'admin@yourdomain.com',
+  password: 'secure_password_here',
+  first_name: 'Admin',
+  last_name: 'User',
+  email_verified: true
+)
+```
+
 ## Contributing
 
 1. Fork the repository

--- a/lib/tasks/seed_policies.rake
+++ b/lib/tasks/seed_policies.rake
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+namespace :db do
+  desc 'Seed policies for production (does not require FactoryBot)'
+  task seed_policies: :environment do
+    puts '📋 Creating policies...'
+
+    # IMPORTANT: All policy keys used in the application MUST be defined here
+    # If a policy is missing from this list, Policy.get('key') will return nil
+    # This causes unexpected behavior in mailboxes, controllers, and other logic
+    policies = {
+      'fpl_modifier_percentage' => 400,
+      'fpl_1_person' => 15_650,
+      'fpl_2_person' => 21_150,
+      'fpl_3_person' => 26_650,
+      'fpl_4_person' => 32_150,
+      'fpl_5_person' => 37_650,
+      'fpl_6_person' => 43_150,
+      'fpl_7_person' => 48_650,
+      'fpl_8_person' => 54_150,
+      'max_training_sessions' => 3,
+      'waiting_period_years' => 3,
+      'proof_submission_rate_limit_web' => 10,
+      'proof_submission_rate_limit_email' => 5,
+      'proof_submission_rate_period' => 24,
+      'max_proof_rejections' => 3,
+      # Voucher policies
+      'voucher_value_hearing_disability' => 500,
+      'voucher_value_vision_disability' => 500,
+      'voucher_value_speech_disability' => 500,
+      'voucher_value_mobility_disability' => 500,
+      'voucher_value_cognition_disability' => 500,
+      'voucher_validity_period_months' => 6,
+      'voucher_minimum_redemption_amount' => 10
+    }
+
+    created_count = 0
+    updated_count = 0
+
+    policies.each do |key, value|
+      policy = Policy.find_or_initialize_by(key: key)
+
+      if policy.new_record?
+        policy.value = value
+        policy.save!
+        created_count += 1
+        puts "  ✓ Created policy: #{key} = #{value}"
+      elsif policy.value != value
+        old_value = policy.value
+        policy.value = value
+        policy.save!
+        updated_count += 1
+        puts "  ✓ Updated policy: #{key} (#{old_value} → #{value})"
+      else
+        puts "  - Policy already exists: #{key} = #{value}"
+      end
+    end
+
+    puts "\n📊 Summary:"
+    puts "  Total policies: #{Policy.count}"
+    puts "  Created: #{created_count}"
+    puts "  Updated: #{updated_count}"
+    puts '✅ Policy seeding completed successfully!'
+  rescue StandardError => e
+    puts "❌ Error seeding policies: #{e.message}"
+    puts e.backtrace.first(5)
+    raise
+  end
+end


### PR DESCRIPTION
Creates a production-safe rake task for seeding Policy records that doesn't require FactoryBot, enabling deployment on Heroku and similar platforms. The existing `rails db:seed` command requires `factory_bot_rails`, which is only available in the test group. Running it in production causes a `LoadError: cannot load such file -- factory_bot_rails`.

- Add `lib/tasks/seed_policies.rake` with `db:seed_policies` task
- Uses `find_or_initialize_by` for idempotent execution
- Includes all 18 policy keys needed for application functionality
- Update README.md with Production Deployment section
- Ready to test on Heroku: `heroku run rake db:seed_policies`