### PR TITLE
Disable emails

### DIFF
--- a/app/controllers/constituent_portal/applications_controller.rb
+++ b/app/controllers/constituent_portal/applications_controller.rb
@@ -155,7 +155,7 @@ module ConstituentPortal
     def submit
       @application = current_user.applications.find(params[:id])
       if @application.update(submission_params.merge(status: :in_progress))
-        ApplicationNotificationsMailer.submission_confirmation(@application).deliver_later
+        ApplicationNotificationsMailer.application_submitted(@application).deliver_later
         redirect_with_notice(constituent_portal_application_path(@application),
                              'Application submitted successfully!')
       else

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -10,6 +10,31 @@ class ApplicationMailer < ActionMailer::Base
   layout 'mailer'
   before_action :set_common_variables
 
+  # Common email sender used by all mailers
+  # Checks if template is enabled before sending and logs warnings if disabled
+  def send_email(recipient_email, template, variables, mail_options = {})
+    if !template.enabled?
+      Rails.logger.warn("Email template '#{template.name}' is disabled. Skipping email to #{recipient_email}")
+      return
+    end
+
+    rendered_subject, rendered_text_body = template.render(**variables)
+
+    # Apply subject override if provided
+    subject_override = mail_options.delete(:subject_override)
+    rendered_subject = subject_override.call(rendered_subject) if subject_override.present?
+
+    default_options = {
+      to: recipient_email,
+      subject: rendered_subject,
+      message_stream: 'notifications'
+    }
+
+    mail(default_options.merge(mail_options)) do |format|
+      format.text { render plain: rendered_text_body }
+    end
+  end
+
   private
 
   def set_common_variables

--- a/app/mailers/application_notifications_mailer.rb
+++ b/app/mailers/application_notifications_mailer.rb
@@ -253,6 +253,11 @@ class ApplicationNotificationsMailer < ApplicationMailer
 
   # Common email sender
   def send_email(recipient_email, template, variables, mail_options = {})
+    if !template.enabled?
+      Rails.logger.warn("Email template '#{template.name}' is disabled. Skipping email to #{recipient_email}")
+      return
+    end
+
     rendered_subject, rendered_text_body = template.render(**variables)
 
     default_options = {

--- a/app/mailers/application_notifications_mailer.rb
+++ b/app/mailers/application_notifications_mailer.rb
@@ -240,29 +240,6 @@ class ApplicationNotificationsMailer < ApplicationMailer
     }
   end
 
-  # Common email sender
-  def send_email(recipient_email, template, variables, mail_options = {})
-    if !template.enabled?
-      Rails.logger.warn("Email template '#{template.name}' is disabled. Skipping email to #{recipient_email}")
-      return
-    end
-
-    rendered_subject, rendered_text_body = template.render(**variables)
-
-    # Apply subject override if provided
-    subject_override = mail_options.delete(:subject_override)
-    rendered_subject = subject_override.call(rendered_subject) if subject_override.present?
-
-    default_options = {
-      to: recipient_email,
-      subject: rendered_subject,
-      message_stream: 'notifications'
-    }
-
-    mail(default_options.merge(mail_options)) do |format|
-      format.text { render plain: rendered_text_body }
-    end
-  end
 
   def safe_asset_path(asset_name)
     ActionController::Base.helpers.asset_path(asset_name, host: default_url_options[:host])

--- a/app/mailers/application_notifications_mailer.rb
+++ b/app/mailers/application_notifications_mailer.rb
@@ -14,17 +14,22 @@ class ApplicationNotificationsMailer < ApplicationMailer
     @application = application
     @user = application.user
 
+    template_name = 'application_notifications_application_submitted'
+    text_template = find_email_template(template_name)
+
+    variables = build_application_submitted_variables(application)
+
     # Set up mail options with CC for alternate contact if provided
     mail_options = {
-      to: @user.effective_email,
-      subject: 'Your Application Has Been Submitted',
       message_stream: 'notifications'
     }
-
-    # Add CC for alternate contact if email is provided
     mail_options[:cc] = @application.alternate_contact_email if @application.alternate_contact_email.present?
 
-    mail(mail_options)
+    send_email(@user.effective_email, text_template, variables, mail_options)
+  rescue StandardError => e
+    Rails.logger.error("Failed to send application submitted email for application #{application&.id}: #{e.message}")
+    Rails.logger.error(e.backtrace.join("\n"))
+    raise e
   end
 
   # A helper method that handles common logging, instance variable setup,
@@ -167,19 +172,8 @@ class ApplicationNotificationsMailer < ApplicationMailer
     text_template = find_email_template(template_name)
 
     variables = build_registration_variables(user, active_vendors_text_list)
-    rendered_subject, rendered_text_body = text_template.render(**variables)
 
-    message = mail(
-      to: user.effective_email,
-      subject: rendered_subject,
-      message_stream: 'notifications'
-    ) do |format|
-      format.text { render plain: rendered_text_body }
-    end
-
-    message.subject = rendered_subject if Rails.env.test?
-    Rails.logger.debug { "[Registration Mailer] Rendered subject: #{rendered_subject.inspect}" }
-    message
+    send_email(user.effective_email, text_template, variables)
   rescue StandardError => e
     Rails.logger.error("Failed to send registration confirmation email for user #{user&.id}: #{e.message}")
     Rails.logger.error(e.backtrace.join("\n"))
@@ -191,18 +185,13 @@ class ApplicationNotificationsMailer < ApplicationMailer
     text_template = find_email_template(template_name)
 
     variables = build_proof_received_variables(application, proof_type)
-    rendered_subject, rendered_text_body = text_template.render(**variables)
 
     # Customize the subject to be more appropriate for "received" vs "approved"
-    rendered_subject = rendered_subject.gsub(/approved/i, 'received').gsub(/Approved/i, 'Received')
-
-    mail(
-      to: application.user.effective_email,
-      subject: rendered_subject,
-      message_stream: 'notifications'
-    ) do |format|
-      format.text { render plain: rendered_text_body }
+    subject_override = proc do |subject|
+      subject.gsub(/approved/i, 'received').gsub(/Approved/i, 'Received')
     end
+
+    send_email(application.user.effective_email, text_template, variables, { subject_override: subject_override })
   rescue StandardError => e
     Rails.logger.error("Failed to send proof received email for application #{application&.id}: #{e.message}")
     Rails.logger.error(e.backtrace.join("\n"))
@@ -259,6 +248,10 @@ class ApplicationNotificationsMailer < ApplicationMailer
     end
 
     rendered_subject, rendered_text_body = template.render(**variables)
+
+    # Apply subject override if provided
+    subject_override = mail_options.delete(:subject_override)
+    rendered_subject = subject_override.call(rendered_subject) if subject_override.present?
 
     default_options = {
       to: recipient_email,
@@ -622,6 +615,20 @@ class ApplicationNotificationsMailer < ApplicationMailer
     }
 
     base_variables.merge(registration_variables).compact
+  end
+
+  # Application submitted specific methods
+  def build_application_submitted_variables(application)
+    header_title = 'Your Application Has Been Submitted'
+
+    base_variables = build_base_email_variables(header_title)
+    submitted_variables = {
+      user_first_name: application.user.first_name,
+      application_id: application.id,
+      submission_date_formatted: application.application_date&.strftime('%B %d, %Y') || Time.current.strftime('%B %d, %Y')
+    }
+
+    base_variables.merge(submitted_variables).compact
   end
 
   # Proof received specific methods

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -6,108 +6,69 @@ class UserMailer < ApplicationMailer
   def password_reset
     user = params[:user]
     token = user.generate_token_for(:password_reset)
-    reset_url = edit_password_url(token: token, host: default_url_options[:host]) # Ensure host is included
+    reset_url = edit_password_url(token: token, host: default_url_options[:host])
 
     template_name = 'user_mailer_password_reset'
-    begin
-      # Only find the text template as per project strategy
-      text_template = EmailTemplate.find_by!(name: template_name, format: :text)
-    rescue ActiveRecord::RecordNotFound => e
-      Rails.logger.error "Missing EmailTemplate (text format) for #{template_name}: #{e.message}"
-      raise "Email template (text format) not found for #{template_name}"
-    end
+    text_template = EmailTemplate.find_by!(name: template_name, format: :text)
 
-    # Prepare variables
     variables = {
       user_email: user.email,
       reset_url: reset_url
     }.compact
 
-    Rails.logger.debug { "DEBUG: About to call render on text_template: #{text_template.inspect}" } # Debug line
-    # Render subject and body from the text template
-    rendered_subject, rendered_text_body = text_template.render(**variables)
-
-    # Send email
-    text_body = rendered_text_body.to_s
-    Rails.logger.debug { "DEBUG: Preparing to send password_reset email with content: #{text_body.inspect}" }
-
-    mail(
-      to: user.email,
-      subject: rendered_subject,
-      message_stream: 'user-email',
-      body: text_body,
-      content_type: 'text/plain'
-    )
+    send_email(user.email, text_template, variables, { message_stream: 'user-email' })
+  rescue ActiveRecord::RecordNotFound => e
+    Rails.logger.error "Missing EmailTemplate (text format) for #{template_name}: #{e.message}"
+    raise "Email template (text format) not found for #{template_name}"
   rescue StandardError => e
-    # Log error with more details
     Event.create!(
-      user: user, # Use local variable if available
+      user: user,
       action: 'email_delivery_error',
       user_agent: Current.user_agent,
       ip_address: Current.ip_address,
       metadata: {
         error_message: e.message,
         error_class: e.class.name,
-        template_name: template_name, # Use local variable
-        variables: variables, # Use local variable
+        template_name: template_name,
+        variables: variables,
         backtrace: e.backtrace&.first(5)
       }
     )
-    raise e # Re-raise after logging
+    raise e
   end
 
   def email_verification
     user = params[:user]
     token = user.generate_token_for(:email_verification)
-    # Using the user verification path within constituent portal - ensure host is included
     verification_url = verify_constituent_portal_application_url(id: user.id, token: token,
                                                                  host: default_url_options[:host])
 
     template_name = 'user_mailer_email_verification'
-    begin
-      # Only find the text template as per project strategy
-      text_template = EmailTemplate.find_by!(name: template_name, format: :text)
-    rescue ActiveRecord::RecordNotFound => e
-      Rails.logger.error "Missing EmailTemplate (text format) for #{template_name}: #{e.message}"
-      raise "Email template (text format) not found for #{template_name}"
-    end
+    text_template = EmailTemplate.find_by!(name: template_name, format: :text)
 
-    # Prepare variables
     variables = {
       user_email: user.email,
       verification_url: verification_url
     }.compact
 
-    Rails.logger.debug { "DEBUG: About to call render on text_template: #{text_template.inspect}" } # Debug line
-    # Render subject and body from the text template
-    rendered_subject, rendered_text_body = text_template.render(**variables)
-
-    # Send email
-    text_body = rendered_text_body.to_s
-    Rails.logger.debug { "DEBUG: Preparing to send email_verification email with content: #{text_body.inspect}" }
-
-    mail(
-      to: user.email,
-      subject: rendered_subject,
-      message_stream: 'outbound', # Keep existing stream or adjust if needed
-      body: text_body,
-      content_type: 'text/plain'
-    )
+    send_email(user.email, text_template, variables, { message_stream: 'outbound' })
+  rescue ActiveRecord::RecordNotFound => e
+    Rails.logger.error "Missing EmailTemplate (text format) for #{template_name}: #{e.message}"
+    raise "Email template (text format) not found for #{template_name}"
   rescue StandardError => e
-    # Log error with more details
     Event.create!(
-      user: user, # Use local variable if available
+      user: user,
       action: 'email_delivery_error',
       user_agent: Current.user_agent,
       ip_address: Current.ip_address,
       metadata: {
         error_message: e.message,
         error_class: e.class.name,
-        template_name: template_name, # Use local variable
-        variables: variables, # Use local variable
+        template_name: template_name,
+        variables: variables,
         backtrace: e.backtrace&.first(5)
       }
     )
-    raise e # Re-raise after logging
+    raise e
   end
 end

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -29,6 +29,11 @@ class EmailTemplate < ApplicationRecord
   # This list is populated based on the analysis in doc/mailer_template_management.md
   AVAILABLE_TEMPLATES = {
     # ApplicationNotificationsMailer Templates
+    'application_notifications_application_submitted' => {
+      description: 'Sent when an application is submitted.',
+      required_vars: %w[user_first_name application_id submission_date_formatted header_text footer_text],
+      optional_vars: %w[title logo subtitle show_automated_message]
+    },
     'application_notifications_account_created' => {
       description: 'Sent when a new user account is created (e.g., by an admin).',
       # Text-only variables

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -9,6 +9,9 @@ class EmailTemplate < ApplicationRecord
 
   belongs_to :updated_by, class_name: 'User', optional: true
 
+  scope :enabled, -> { where(enabled: true) }
+  scope :disabled_templates, -> { where(enabled: false) }
+
   # Ensure name is unique within the scope of its format (e.g., 'welcome.html' and 'welcome.text' are distinct)
   validates :name, presence: true, uniqueness: { scope: :format }
   validates :subject, presence: true

--- a/app/views/admin/email_templates/index.html.erb
+++ b/app/views/admin/email_templates/index.html.erb
@@ -15,7 +15,7 @@
           <%= button_to bulk_disable_admin_email_templates_path, method: :patch, class: "px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-600 text-sm font-medium", data: { confirm: "Disable all email templates? They will not be sent until re-enabled." } do %>
             Disable All
           <% end %>
-          <%= button_to bulk_enable_admin_email_templates_path, method: :patch, class: "px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-green-600 text-sm font-medium" do %>
+          <%= button_to bulk_enable_admin_email_templates_path, method: :patch, class: "px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-green-600 text-sm font-medium", data: { confirm: "Enable all email templates? They will be sent to users." } do %>
             Enable All
           <% end %>
         </div>

--- a/app/views/admin/email_templates/index.html.erb
+++ b/app/views/admin/email_templates/index.html.erb
@@ -9,14 +9,14 @@
     <div class="mb-6">
       <div class="flex items-center justify-between mb-4">
         <h1 class="text-3xl font-bold" id="page-title">
-          Email Templates
+          <%= t('admin.email_templates.index.page_title') %>
         </h1>
         <div class="flex gap-2">
-          <%= button_to bulk_disable_admin_email_templates_path, method: :patch, class: "px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-600 text-sm font-medium", data: { confirm: "Disable all email templates? They will not be sent until re-enabled." } do %>
-            Disable All
+          <%= button_to bulk_disable_admin_email_templates_path, method: :patch, class: "px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-600 text-sm font-medium", data: { confirm: t('admin.email_templates.index.disable_all_confirm') } do %>
+            <%= t('admin.email_templates.index.disable_all') %>
           <% end %>
-          <%= button_to bulk_enable_admin_email_templates_path, method: :patch, class: "px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-green-600 text-sm font-medium", data: { confirm: "Enable all email templates? They will be sent to users." } do %>
-            Enable All
+          <%= button_to bulk_enable_admin_email_templates_path, method: :patch, class: "px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-green-600 text-sm font-medium", data: { confirm: t('admin.email_templates.index.enable_all_confirm') } do %>
+            <%= t('admin.email_templates.index.enable_all') %>
           <% end %>
         </div>
       </div>
@@ -46,7 +46,7 @@
                     Ver.
                   </th>
                   <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-20">
-                    Status
+                    <%= t('admin.email_templates.index.status_column') %>
                   </th>
                   <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-20">
                     Updated
@@ -85,11 +85,11 @@
                     <td class="px-6 py-4 whitespace-nowrap text-sm">
                       <% if template.enabled %>
                         <span class="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-800">
-                          Enabled
+                          <%= t('shared.enabled') %>
                         </span>
                       <% else %>
                         <span class="inline-flex items-center rounded-full bg-red-100 px-3 py-1 text-xs font-medium text-red-800">
-                          Disabled
+                          <%= t('shared.disabled') %>
                         </span>
                       <% end %>
                     </td>
@@ -97,12 +97,12 @@
                       <%= time_ago_in_words(template.updated_at) %> ago
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
-                      <%= link_to 'View', admin_email_template_path(template), class: "text-indigo-600 hover:text-indigo-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600", aria: { label: "View #{template.name} template" } %>
-                      <%= link_to 'Edit', edit_admin_email_template_path(template), class: "text-indigo-600 hover:text-indigo-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600", aria: { label: "Edit #{template.name} template" } %>
+                      <%= link_to t('shared.view'), admin_email_template_path(template), class: "text-indigo-600 hover:text-indigo-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600", aria: { label: t('admin.email_templates.index.view_aria', template_name: template.name) } %>
+                      <%= link_to t('shared.edit'), edit_admin_email_template_path(template), class: "text-indigo-600 hover:text-indigo-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600", aria: { label: t('admin.email_templates.index.edit_aria', template_name: template.name) } %>
                       <% if template.enabled %>
-                        <%= button_to 'Disable', toggle_disabled_admin_email_template_path(template), method: :patch, class: "text-red-600 hover:text-red-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-600 inline", aria: { label: "Disable #{template.name} template" } %>
+                        <%= button_to t('shared.disable'), toggle_disabled_admin_email_template_path(template), method: :patch, class: "text-red-600 hover:text-red-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-600 inline", aria: { label: t('admin.email_templates.index.disable_aria', template_name: template.name) } %>
                       <% else %>
-                        <%= button_to 'Enable', toggle_disabled_admin_email_template_path(template), method: :patch, class: "text-green-600 hover:text-green-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-green-600 inline", aria: { label: "Enable #{template.name} template" } %>
+                        <%= button_to t('shared.enable'), toggle_disabled_admin_email_template_path(template), method: :patch, class: "text-green-600 hover:text-green-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-green-600 inline", aria: { label: t('admin.email_templates.index.enable_aria', template_name: template.name) } %>
                       <% end %>
                     </td>
                   </tr>
@@ -140,24 +140,24 @@
                       <span>v<%= template.version %> · Updated <%= time_ago_in_words(template.updated_at) %> ago</span>
                       <% if template.enabled %>
                         <span class="inline-flex items-center rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-800">
-                          Enabled
+                          <%= t('shared.enabled') %>
                         </span>
                       <% else %>
                         <span class="inline-flex items-center rounded-full bg-red-100 px-2 py-1 text-xs font-medium text-red-800">
-                          Disabled
+                          <%= t('shared.disabled') %>
                         </span>
                       <% end %>
                     </div>
                     <div class="flex justify-between items-center gap-2">
-                      <div class="space-x-2">
-                        <%= link_to 'View', admin_email_template_path(template), class: "text-indigo-600 hover:text-indigo-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600 text-sm", aria: { label: "View #{template.name} template" } %>
-                        <%= link_to 'Edit', edit_admin_email_template_path(template), class: "text-indigo-600 hover:text-indigo-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600 text-sm", aria: { label: "Edit #{template.name} template" } %>
+                      <div class="space-x-4">
+                        <%= link_to t('shared.view'), admin_email_template_path(template), class: "text-indigo-600 hover:text-indigo-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600 text-sm", aria: { label: t('admin.email_templates.index.view_aria', template_name: template.name) } %>
+                        <%= link_to t('shared.edit'), edit_admin_email_template_path(template), class: "text-indigo-600 hover:text-indigo-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600 text-sm", aria: { label: t('admin.email_templates.index.edit_aria', template_name: template.name) } %>
                       </div>
                       <div>
                         <% if template.enabled %>
-                          <%= button_to 'Disable', toggle_disabled_admin_email_template_path(template), method: :patch, class: "text-red-600 hover:text-red-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-600 text-sm inline", aria: { label: "Disable #{template.name} template" } %>
+                          <%= button_to t('shared.disable'), toggle_disabled_admin_email_template_path(template), method: :patch, class: "text-red-600 hover:text-red-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-600 text-sm inline", aria: { label: t('admin.email_templates.index.disable_aria', template_name: template.name) } %>
                         <% else %>
-                          <%= button_to 'Enable', toggle_disabled_admin_email_template_path(template), method: :patch, class: "text-green-600 hover:text-green-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-green-600 text-sm inline", aria: { label: "Enable #{template.name} template" } %>
+                          <%= button_to t('shared.enable'), toggle_disabled_admin_email_template_path(template), method: :patch, class: "text-green-600 hover:text-green-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-green-600 text-sm inline", aria: { label: t('admin.email_templates.index.enable_aria', template_name: template.name) } %>
                         <% end %>
                       </div>
                     </div>

--- a/app/views/admin/email_templates/index.html.erb
+++ b/app/views/admin/email_templates/index.html.erb
@@ -7,9 +7,19 @@
 
     <%# Header Section %>
     <div class="mb-6">
-      <h1 class="text-3xl font-bold mb-4" id="page-title">
-        Email Templates
-      </h1>
+      <div class="flex items-center justify-between mb-4">
+        <h1 class="text-3xl font-bold" id="page-title">
+          Email Templates
+        </h1>
+        <div class="flex gap-2">
+          <%= button_to bulk_disable_admin_email_templates_path, method: :patch, class: "px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-600 text-sm font-medium", data: { confirm: "Disable all email templates? They will not be sent until re-enabled." } do %>
+            Disable All
+          <% end %>
+          <%= button_to bulk_enable_admin_email_templates_path, method: :patch, class: "px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-green-600 text-sm font-medium" do %>
+            Enable All
+          <% end %>
+        </div>
+      </div>
     </div>
 
     <%# Templates Table Section %>
@@ -23,22 +33,25 @@
               <caption class="sr-only">List of email templates</caption>
               <thead class="bg-gray-50">
                 <tr>
-                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-1/2 lg:w-[55%]">
+                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-1/2 lg:w-[45%]">
                     Template Purpose
                   </th>
-                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-1/4 lg:w-[25%]">
+                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-1/4 lg:w-[20%]">
                     Email Subject
                   </th>
-                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-32 lg:w-40">
+                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-32 lg:w-32">
                     Template ID
                   </th>
                   <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-16">
                     Ver.
                   </th>
-                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-24">
+                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-20">
+                    Status
+                  </th>
+                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-20">
                     Updated
                   </th>
-                  <th scope="col" class="relative px-6 py-3 w-24">
+                  <th scope="col" class="relative px-6 py-3 w-32">
                     <span class="sr-only">Actions</span>
                   </th>
                 </tr>
@@ -69,12 +82,28 @@
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
                       <%= template.version %>
                     </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm">
+                      <% if template.enabled %>
+                        <span class="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-800">
+                          Enabled
+                        </span>
+                      <% else %>
+                        <span class="inline-flex items-center rounded-full bg-red-100 px-3 py-1 text-xs font-medium text-red-800">
+                          Disabled
+                        </span>
+                      <% end %>
+                    </td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
                       <%= time_ago_in_words(template.updated_at) %> ago
                     </td>
-                    <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                    <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
                       <%= link_to 'View', admin_email_template_path(template), class: "text-indigo-600 hover:text-indigo-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600", aria: { label: "View #{template.name} template" } %>
-                      <%= link_to 'Edit', edit_admin_email_template_path(template), class: "ml-4 text-indigo-600 hover:text-indigo-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600", aria: { label: "Edit #{template.name} template" } %>
+                      <%= link_to 'Edit', edit_admin_email_template_path(template), class: "text-indigo-600 hover:text-indigo-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600", aria: { label: "Edit #{template.name} template" } %>
+                      <% if template.enabled %>
+                        <%= button_to 'Disable', toggle_disabled_admin_email_template_path(template), method: :patch, class: "text-red-600 hover:text-red-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-600 inline", aria: { label: "Disable #{template.name} template" } %>
+                      <% else %>
+                        <%= button_to 'Enable', toggle_disabled_admin_email_template_path(template), method: :patch, class: "text-green-600 hover:text-green-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-green-600 inline", aria: { label: "Enable #{template.name} template" } %>
+                      <% end %>
                     </td>
                   </tr>
                 <% end %>
@@ -107,11 +136,29 @@
                       <%= template.name %>
                     </p>
 
-                    <div class="flex justify-between items-center text-xs text-gray-600">
+                    <div class="flex justify-between items-center text-xs text-gray-600 mb-2">
                       <span>v<%= template.version %> · Updated <%= time_ago_in_words(template.updated_at) %> ago</span>
+                      <% if template.enabled %>
+                        <span class="inline-flex items-center rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-800">
+                          Enabled
+                        </span>
+                      <% else %>
+                        <span class="inline-flex items-center rounded-full bg-red-100 px-2 py-1 text-xs font-medium text-red-800">
+                          Disabled
+                        </span>
+                      <% end %>
+                    </div>
+                    <div class="flex justify-between items-center gap-2">
+                      <div class="space-x-2">
+                        <%= link_to 'View', admin_email_template_path(template), class: "text-indigo-600 hover:text-indigo-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600 text-sm", aria: { label: "View #{template.name} template" } %>
+                        <%= link_to 'Edit', edit_admin_email_template_path(template), class: "text-indigo-600 hover:text-indigo-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600 text-sm", aria: { label: "Edit #{template.name} template" } %>
+                      </div>
                       <div>
-                        <%= link_to 'View', admin_email_template_path(template), class: "text-indigo-600 hover:text-indigo-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600", aria: { label: "View #{template.name} template" } %>
-                        <%= link_to 'Edit', edit_admin_email_template_path(template), class: "ml-4 text-indigo-600 hover:text-indigo-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600", aria: { label: "Edit #{template.name} template" } %>
+                        <% if template.enabled %>
+                          <%= button_to 'Disable', toggle_disabled_admin_email_template_path(template), method: :patch, class: "text-red-600 hover:text-red-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-red-600 text-sm inline", aria: { label: "Disable #{template.name} template" } %>
+                        <% else %>
+                          <%= button_to 'Enable', toggle_disabled_admin_email_template_path(template), method: :patch, class: "text-green-600 hover:text-green-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-green-600 text-sm inline", aria: { label: "Enable #{template.name} template" } %>
+                        <% end %>
                       </div>
                     </div>
                   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,12 @@
 en:
   shared:
     unauthorized: "Not authorized"
+    enabled: "Enabled"
+    disabled: "Disabled"
+    view: "View"
+    edit: "Edit"
+    enable: "Enable"
+    disable: "Disable"
   alerts:
     invalid_voucher_code: "Invalid voucher code"
     session_fail: "Unable to create session"
@@ -86,8 +92,26 @@ en:
         c_file_select: "Please select a file to upload"
         c_upload_pass: "Medical certification successfully uploaded and approved."
     email_templates:
+      index:
+        page_title: "Email Templates"
+        disable_all: "Disable All"
+        enable_all: "Enable All"
+        disable_all_confirm: "Disable all email templates? They will not be sent until re-enabled."
+        enable_all_confirm: "Enable all email templates? They will be sent to users."
+        status_column: "Status"
+        view_aria: "View %{template_name} template"
+        edit_aria: "Edit %{template_name} template"
+        disable_aria: "Disable %{template_name} template"
+        enable_aria: "Enable %{template_name} template"
       update:
         e_template_update_pass: "Email template was successfully updated."
+        toggled_enabled: "Email template '%{template_name}' has been enabled."
+        toggled_disabled: "Email template '%{template_name}' has been disabled."
+        toggle_failed: "Failed to update template: %{error_messages}"
+      bulk_disable:
+        success: "All email templates have been disabled."
+      bulk_enable:
+        success: "All email templates have been enabled."
     guardian_relationships:
       create:
         dependent_not_found: "Email template not found"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,6 +174,11 @@ Rails.application.routes.draw do
       member do
         get :new_test_email
         post :send_test
+        patch :toggle_disabled
+      end
+      collection do
+        patch :bulk_disable
+        patch :bulk_enable
       end
     end
 

--- a/db/migrate/20250102101300_add_enabled_to_email_templates.rb
+++ b/db/migrate/20250102101300_add_enabled_to_email_templates.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddEnabledToEmailTemplates < ActiveRecord::Migration[8.0]
+  def change
+    add_column :email_templates, :enabled, :boolean, default: true, null: false
+    add_index :email_templates, :enabled
+  end
+end

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -174,6 +174,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_15_215117) do
     t.integer "version", default: 1
     t.string "previous_subject"
     t.text "previous_body"
+    t.boolean "enabled", default: true, null: false
+    t.index ["enabled"], name: "index_email_templates_on_enabled"
     t.index ["name"], name: "index_email_templates_on_name", unique: true
     t.index ["updated_by_id"], name: "index_email_templates_on_updated_by_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -174,6 +174,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_15_215117) do
     t.integer "version", default: 1
     t.string "previous_subject"
     t.text "previous_body"
+    t.boolean "enabled", default: true, null: false
+    t.index ["enabled"], name: "index_email_templates_on_enabled"
     t.index ["name"], name: "index_email_templates_on_name", unique: true
     t.index ["updated_by_id"], name: "index_email_templates_on_updated_by_id"
   end

--- a/db/seeds/email_templates/application_notifications_application_submitted.rb
+++ b/db/seeds/email_templates/application_notifications_application_submitted.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Seed File for "application_notifications_application_submitted"
+# --------------------------------------------------
+EmailTemplate.create_or_find_by!(name: 'application_notifications_application_submitted', format: :text) do |template|
+  template.subject = 'Your Application Has Been Submitted'
+  template.description = 'Sent when an application is submitted.'
+  template.body = <<~TEXT
+    %<header_text>s
+
+    Dear %<user_first_name>s,
+
+    Thank you for submitting your application to Maryland Accessible Telecommunications. We have received your submission and will review your application as soon as possible.
+
+    Application ID: %<application_id>s
+    Submission Date: %<submission_date_formatted>s
+
+    You can track the status of your application at any time by logging into your account. We will send you updates as we progress through the review process.
+
+    If you need to submit additional documentation or have any questions about your application, please log into your account or contact our support team.
+
+    %<footer_text>s
+  TEXT
+  template.variables = %w[header_text user_first_name application_id submission_date_formatted footer_text]
+  template.version = 1
+end
+Rails.logger.debug 'Seeded application_notifications_application_submitted (text)' if ENV['VERBOSE_TESTS'] || Rails.env.development?

--- a/test/factories/email_templates.rb
+++ b/test/factories/email_templates.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     description { 'A default email template.' }
     format { :html } # Default format
     version { 1 }
+    enabled { true }
     updated_by factory: %i[admin]
 
     trait :html do

--- a/test/mailboxes/edge_cases_test.rb
+++ b/test/mailboxes/edge_cases_test.rb
@@ -40,10 +40,12 @@ class EdgeCasesTest < ActionMailbox::TestCase
     # Create a specific mock for the proof_submission_error template
     proof_submission_error_template = mock('EmailTemplate')
     proof_submission_error_template.stubs(:render).returns(['Error Processing Your Proof Submission', 'Test Email Body'])
+    proof_submission_error_template.stubs(:enabled?).returns(true)
 
     # Create a generic mock for other templates
     generic_template = mock('EmailTemplate')
     generic_template.stubs(:render).returns(['Test Email Subject', 'Test Email Body'])
+    generic_template.stubs(:enabled?).returns(true)
 
     # Ensure the template lookup uses the correct template based on name
     EmailTemplate.stubs(:find_by!).with(name: 'application_notifications_proof_submission_error',

--- a/test/mailers/email_template_mock_helper.rb
+++ b/test/mailers/email_template_mock_helper.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module EmailTemplateMockHelper
+  # Helper to create mock templates that performs interpolation
+  # Mimics the behavior of EmailTemplate.render() which uses gsub for substitution
+  def mock_template(subject_format, body_format)
+    template = mock('email_template')
+
+    # Stub render to perform gsub-based interpolation matching the real EmailTemplate.render behavior
+      # Stub the render method to perform interpolation
+      template.define_singleton_method(:render) do |**vars|
+        rendered_body = body.dup
+        rendered_subject = subject.dup
+
+        vars.each do |key, value|
+          # Handle both "%{key}" and "%<key>s" format strings
+          rendered_body = rendered_body.gsub("%{#{key}}", value.to_s)
+          rendered_body = rendered_body.gsub("%<#{key}>s", value.to_s)
+
+          rendered_subject = rendered_subject.gsub("%{#{key}}", value.to_s)
+          rendered_subject = rendered_subject.gsub("%<#{key}>s", value.to_s)
+        end
+
+        [rendered_subject, rendered_body]
+      end
+
+    # Stub subject and body for inspection if needed
+    template.stubs(:subject).returns(subject_format)
+    template.stubs(:body).returns(body_format)
+
+    template.stubs(:enabled?).returns(true)
+
+    template
+  end
+end

--- a/test/mailers/evaluator_mailer_test.rb
+++ b/test/mailers/evaluator_mailer_test.rb
@@ -15,6 +15,8 @@ class EvaluatorMailerTest < ActionMailer::TestCase
     template_instance.stubs(:subject).returns(subject_format)
     template_instance.stubs(:body).returns(body_format)
 
+    template_instance.stubs(:enabled?).returns(true)
+
     template_instance
   end
 

--- a/test/mailers/evaluator_mailer_test.rb
+++ b/test/mailers/evaluator_mailer_test.rb
@@ -1,24 +1,11 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require_relative 'email_template_mock_helper'
 
 class EvaluatorMailerTest < ActionMailer::TestCase
-  # Helper to create mock templates that respond to render method
-  def mock_template(subject_format, body_format)
-    template_instance = mock("email_template_instance_#{subject_format.gsub(/\s+/, '_')}")
+  include EmailTemplateMockHelper
 
-    # Stub the render method to return [rendered_subject, rendered_body]
-    # This simulates what the real EmailTemplate.render method does
-    template_instance.stubs(:render).with(any_parameters).returns([subject_format, body_format])
-
-    # Still stub subject and body for inspection if needed
-    template_instance.stubs(:subject).returns(subject_format)
-    template_instance.stubs(:body).returns(body_format)
-
-    template_instance.stubs(:enabled?).returns(true)
-
-    template_instance
-  end
 
   setup do
     # Per project strategy, HTML emails are not used. Only stub for :text format.

--- a/test/mailers/message_stream_test.rb
+++ b/test/mailers/message_stream_test.rb
@@ -9,6 +9,7 @@ class MessageStreamTest < ActionMailer::TestCase
     @account_created_template = mock('EmailTemplate')
     @account_created_template.stubs(:render).returns(['Welcome to the System', 'Account creation email body'])
     EmailTemplate.stubs(:find_by!).with(name: 'application_notifications_account_created', format: :text).returns(@account_created_template)
+    @account_created_template.stubs(:enabled?).returns(true)
 
     # Create mock template for user_mailer_password_reset
     @password_reset_template = mock('EmailTemplate')

--- a/test/mailers/message_stream_test.rb
+++ b/test/mailers/message_stream_test.rb
@@ -13,6 +13,7 @@ class MessageStreamTest < ActionMailer::TestCase
 
     # Create mock template for user_mailer_password_reset
     @password_reset_template = mock('EmailTemplate')
+    @password_reset_template.stubs(:enabled?).returns(true)
     @password_reset_template.stubs(:render).returns(['Reset Your Password', 'Password reset email body'])
     EmailTemplate.stubs(:find_by!).with(name: 'user_mailer_password_reset', format: :text).returns(@password_reset_template)
   end

--- a/test/mailers/url_helpers_in_mailers_test.rb
+++ b/test/mailers/url_helpers_in_mailers_test.rb
@@ -50,6 +50,7 @@ class UrlHelpersInMailersTest < ActionMailer::TestCase
     subject = 'Your Proof Was Rejected'
     body = 'http://test.example.com/dashboard'
     mock_template.stubs(:render).returns([subject, body])
+    mock_template.stubs(:enabled?).returns(true)
     EmailTemplate.stubs(:find_by!).returns(mock_template)
 
     email = ApplicationNotificationsMailer.proof_rejected(@application, @proof_review)
@@ -65,6 +66,7 @@ class UrlHelpersInMailersTest < ActionMailer::TestCase
     subject = 'New Evaluation Assigned'
     body = 'You can view and update the evaluation here: http://test.example.com/evaluations/123'
     mock_template.stubs(:render).returns([subject, body])
+    mock_template.stubs(:enabled?).returns(true)
     EmailTemplate.stubs(:find_by!).returns(mock_template)
 
     # Override status_box_text method to provide the missing value

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -15,6 +15,7 @@ class UserMailerTest < ActionMailer::TestCase
     # Still stub subject and body for inspection if needed
     template_instance.stubs(:subject).returns(subject_format)
     template_instance.stubs(:body).returns(body_format)
+    template_instance.stubs(:enabled?).returns(true)
 
     template_instance
   end

--- a/test/unit/registrations_mailer_test.rb
+++ b/test/unit/registrations_mailer_test.rb
@@ -25,6 +25,7 @@ class RegistrationsMailerTest < ActiveSupport::TestCase
     subject = 'Welcome to the Maryland Accessible Telecommunications Program'
     body = "Dear Test,\n\nWelcome to the program.\n\nThank you,\nThe MAT Team"
     mock_template.stubs(:render).returns([subject, body])
+    mock_template.stubs(:enabled?).returns(true)
     EmailTemplate.stubs(:find_by!).returns(mock_template)
 
     # Clear any emails from previous tests


### PR DESCRIPTION
This allows an admin to disable templated emails one by one or in bulk in the Manage Emails view. It refactors mailer methods to use the same send_email method that only allows enabled emails to be sent.

Note that application_submitted does not seem to be triggering an email but this was an existing error. I will continue to examine it.

Leaving in draft while I resolve the test failures introduced by the send_email refactor..