### PR TITLE
Fix auto-approval to work regardless of proof approval order; changed…

### DIFF
--- a/test/jobs/proof_attachment_metrics_job_test.rb
+++ b/test/jobs/proof_attachment_metrics_job_test.rb
@@ -10,6 +10,7 @@ class ProofAttachmentMetricsJobTest < ActiveJob::TestCase
 
     # Clear dependent records first to avoid foreign key violations
     ProofReview.delete_all
+    ApplicationStatusChange.delete_all
     Application.delete_all
     GuardianRelationship.delete_all
     WebauthnCredential.delete_all


### PR DESCRIPTION
Changed callback guard to check current state instead of field changes so that auto-approval fires whenever all requirements are met, regardless of order in which they are met.