### PR TITLE
Fix Turbo Frame navigation: ensure links break out to full page

### DIFF
--- a/app/views/admin/applications/_applications_table.html.erb
+++ b/app/views/admin/applications/_applications_table.html.erb
@@ -128,7 +128,6 @@
           <td class="px-2 py-2 text-sm font-medium overflow-hidden">
             <%= link_to "View",
                 admin_application_path(id: application.id),
-                data: { turbo_frame: "_top" },
                 class: "text-indigo-600 hover:text-indigo-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 whitespace-nowrap",
                 aria: { label: "View details for #{application.user&.full_name || 'Unknown User'}" },
                 data: { turbo_frame: "_top" } %>

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -38,7 +38,7 @@
           <dt class="text-sm font-medium text-gray-500">Applicant</dt>
           <dd class="mt-1 text-sm text-gray-900">
             <% if @application.user.present? %>
-              <%= link_to @application.user.full_name, admin_user_path(@application.user), class: "text-indigo-600 hover:text-indigo-500" %>
+              <%= link_to @application.user.full_name, admin_user_path(@application.user), class: "text-indigo-600 hover:text-indigo-500", data: { turbo_frame: "_top" } %>
               <span class="text-gray-500">(ID: <%= @application.user.id %>)</span>
             <% else %>
               Unknown Applicant
@@ -49,7 +49,7 @@
           <div>
             <dt class="text-sm font-medium text-gray-500">Managed By</dt>
             <dd class="mt-1 text-sm text-gray-900">
-              <%= link_to @application.managing_guardian.full_name, admin_user_path(@application.managing_guardian), class: "text-indigo-600 hover:text-indigo-500" %>
+              <%= link_to @application.managing_guardian.full_name, admin_user_path(@application.managing_guardian), class: "text-indigo-600 hover:text-indigo-500", data: { turbo_frame: "_top" } %>
               <span class="text-gray-500">(ID: <%= @application.managing_guardian.id %>)</span>
               <% guardian_relationship = GuardianRelationship.find_by(guardian_id: @application.managing_guardian.id, dependent_id: @application.user.id) %>
               <% if guardian_relationship %>

--- a/app/views/admin/users/_users_table.html.erb
+++ b/app/views/admin/users/_users_table.html.erb
@@ -43,7 +43,7 @@
                       <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
                     </svg>
                   <% end %>
-                  <%= link_to user.full_name, admin_user_path(user), class: "hover:text-indigo-600" %>
+                  <%= link_to user.full_name, admin_user_path(user), class: "hover:text-indigo-600", data: { turbo_frame: "_top" } %>
                   <% if is_guardian && user.dependents_count > 0 %>
                     <span class="ml-1 text-xs text-gray-500">(<%= pluralize(user.dependents_count, "dependent") %>)</span>
                   <% end %>
@@ -72,7 +72,7 @@
                   <% user.guardian_relationships_as_guardian.each do |gr| %>
                     <% relation = gr.relationship_type %>
                     <li>
-                      <%= link_to gr.dependent_user.full_name, admin_user_path(gr.dependent_user), class: "hover:text-indigo-600" %>
+                      <%= link_to gr.dependent_user.full_name, admin_user_path(gr.dependent_user), class: "hover:text-indigo-600", data: { turbo_frame: "_top" } %>
                       <span class="text-xs text-gray-500">(<%= inverse_relationship_label(relation) %>)</span>
                     </li>
                   <% end %>
@@ -83,7 +83,7 @@
                     <% relation = gr.relationship_type.to_s.downcase %>
                     <% label = relation.presence || 'guardian' %>
                     <li>
-                      <%= link_to gr.guardian_user.full_name, admin_user_path(gr.guardian_user), class: "hover:text-indigo-600" %>
+                      <%= link_to gr.guardian_user.full_name, admin_user_path(gr.guardian_user), class: "hover:text-indigo-600", data: { turbo_frame: "_top" } %>
                       <span class="text-xs text-gray-500">(<%= label %>)</span>
                     </li>
                   <% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -95,7 +95,8 @@
                     <div class="flex-1">
                       <p class="text-md font-semibold text-gray-900">
                         <%= link_to dependent.full_name, admin_user_path(dependent), 
-                            class: "text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded" %>
+                            class: "text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded",
+                            data: { turbo_frame: "_top" } %>
                       </p>
                       <p class="text-sm text-gray-700">Relationship: <span class="font-medium text-gray-900"><%= gr.relationship_type %></span></p>
                       <p class="text-sm text-gray-700">Established: <%= gr.created_at.strftime("%B %d, %Y") %></p>
@@ -125,7 +126,8 @@
                         <span class="text-xs text-gray-700"><%= active_app.application_date.strftime('%b %d, %Y') %></span>
                         <%= link_to admin_application_path(active_app), 
                             class: "inline-flex items-center px-2.5 py-1.5 border border-indigo-200 text-sm font-medium rounded-md text-indigo-700 bg-indigo-50 hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500", 
-                            "aria-label": "View application for #{dependent.full_name}" do %>
+                            "aria-label": "View application for #{dependent.full_name}",
+                            data: { turbo_frame: "_top" } do %>
                           View
                         <% end %>
                       </div>
@@ -144,7 +146,8 @@
                         <span class="text-xs text-gray-700"><%= last_app.application_date.strftime('%b %d, %Y') %></span>
                         <%= link_to admin_application_path(last_app), 
                             class: "inline-flex items-center px-2.5 py-1.5 border border-indigo-200 text-sm font-medium rounded-md text-indigo-700 bg-indigo-50 hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500", 
-                            "aria-label": "View application for #{dependent.full_name}" do %>
+                            "aria-label": "View application for #{dependent.full_name}",
+                            data: { turbo_frame: "_top" } do %>
                           View
                         <% end %>
                       </div>
@@ -202,7 +205,8 @@
                   <div class="flex-1">
                     <p class="text-md font-semibold text-gray-900">
                       <%= link_to guardian.full_name, admin_user_path(guardian), 
-                          class: "text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded" %>
+                          class: "text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded",
+                          data: { turbo_frame: "_top" } %>
                     </p>
                     <p class="text-sm text-gray-700">Relationship: <span class="font-medium text-gray-900"><%= gr.relationship_type %></span></p>
                     <p class="text-sm text-gray-700">Established: <%= gr.created_at.strftime("%B %d, %Y") %></p>


### PR DESCRIPTION
- Remove duplicate turbo_frame attribute in applications table View link
- Add turbo_frame: '_top' to user/application links in admin views

Fixes bug where links would try to load content in wrong frame