### PR TITLE
Fix duplicate notifications in paper application flow with nil recipients

### DIFF
--- a/app/javascript/utils/visibility.js
+++ b/app/javascript/utils/visibility.js
@@ -31,17 +31,18 @@ export function setVisible(element, visible, options = {}) {
 
   const { required, hiddenClass = 'hidden', ariaHidden } = options;
 
-  // Toggle visibility - let CSS handle it to maintain screen reader accessibility
+  // Toggle visibility
   if (visible) {
     element.classList.remove(hiddenClass);
-    // Remove inline display that might override CSS classes
-    if (element.style.display) {
+    // Remove inline display:none that might override CSS classes
+    if (element.style.display === 'none') {
       element.style.display = '';
     }
   } else {
     element.classList.add(hiddenClass);
-    // Don't set inline display:none - let CSS handle it
-    // This ensures screen readers can still access content if needed
+    // Set inline style as fallback in case CSS fails to load
+    // This prevents sensitive sections from being visible if .hidden class doesn't apply
+    element.style.display = 'none';
   }
 
   // Handle required attribute if specified

--- a/app/services/proof_attachment_service.rb
+++ b/app/services/proof_attachment_service.rb
@@ -393,6 +393,9 @@ class ProofAttachmentService
     end
 
     def send_notification(context, event_metadata)
+      # Skip notifications if this is a paper application as paper applications handle their own notifications in PaperApplicationService
+      return if Current.paper_context
+
       NotificationService.create_and_deliver!(
         type: "#{context.proof_type}_proof_attached",
         recipient: context.application.user,
@@ -445,6 +448,10 @@ class ProofAttachmentService
         actor: admin,
         metadata: audit_metadata
       )
+
+      # Skip notifications if this is a paper application context as PaperApplicationService handles notifications
+      return if Current.paper_context
+
       NotificationService.create_and_deliver!(
         type: "#{proof_type}_proof_rejected",
         recipient: application.user,

--- a/app/views/admin/paper_applications/_dependent_form.html.erb
+++ b/app/views/admin/paper_applications/_dependent_form.html.erb
@@ -233,7 +233,7 @@
                 value: dependent&.physical_address_1,
                 autocomplete: "address-line1",
                 class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", 
-                data: { dependent_fields_target: "dependentAddress1" } %>
+                data: { dependent_fields_target: "dependentAddress1", contact_feedback_target: "address1" } %>
           </div>
           <div>
             <%= d.label :physical_address_2, "Apt, suite, unit (optional)", class: "block text-sm font-medium text-gray-700", for: "dependent_constituent_physical_address_2" %>
@@ -242,7 +242,7 @@
                 value: dependent&.physical_address_2,
                 autocomplete: "address-line2",
                 class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", 
-                data: { dependent_fields_target: "dependentAddress2" } %>
+                data: { dependent_fields_target: "dependentAddress2", contact_feedback_target: "address2" } %>
           </div>
           <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
             <div class="col-span-2">
@@ -252,7 +252,7 @@
                   value: dependent&.city,
                   autocomplete: "address-level2",
                   class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", 
-                  data: { dependent_fields_target: "dependentCity" } %>
+                  data: { dependent_fields_target: "dependentCity", contact_feedback_target: "city" } %>
             </div>
             <div>
               <%= d.label :state, "State", class: "block text-sm font-medium text-gray-700", for: "dependent_constituent_state" %>
@@ -261,7 +261,7 @@
                   value: (dependent&.state || "MD"),
                   autocomplete: "address-level1",
                   class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", 
-                  data: { dependent_fields_target: "dependentState" } %>
+                  data: { dependent_fields_target: "dependentState", contact_feedback_target: "state" } %>
             </div>
             <div>
               <%= d.label :zip_code, "ZIP Code", class: "block text-sm font-medium text-gray-700", for: "dependent_constituent_zip_code" %>
@@ -271,7 +271,7 @@
                   autocomplete: "postal-code",
                   pattern: "[0-9]{5}(-[0-9]{4})?",
                   class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", 
-                  data: { dependent_fields_target: "dependentZip" } %>
+                  data: { dependent_fields_target: "dependentZip", contact_feedback_target: "zipCode" } %>
             </div>
           </div>
         </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,6 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
   config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.


### PR DESCRIPTION
- Skip ProofReview notifications when Current.paper_context is true
- Skip ProofAttachmentService notifications in paper context
- Guard ProofReview notifications with association presence checks
- Keep notifiable as Application for query consistency
- Add contact_feedback_target to dependent form address fields
- Restore display:none fallback in setVisible utility