### PR TITLE
fix: add system user to policy seeding rake task

### DIFF
--- a/lib/tasks/seed_policies.rake
+++ b/lib/tasks/seed_policies.rake
@@ -48,6 +48,7 @@ namespace :db do
       elsif policy.value != value
         old_value = policy.value
         policy.value = value
+        policy.updated_by = User.system_user
         policy.save!
         updated_count += 1
         puts "  ✓ Updated policy: #{key} (#{old_value} → #{value})"


### PR DESCRIPTION
When running `db:seed_policies`, updating an existing policy failed with an error stating that an User must exist. This was because any change to a Policy must be associated with an user

- Update the rake task to asign `User.system_user` to `policy.updated_by`