### PR TITLE
Improve paper application service audit logging and income verification UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Vulcan is a Ruby on Rails application that facilitates Maryland Accessible Telec
 1. **Applications (Portal + Paper)**
    - Self-service portal flow with autosave and inline validation
    - Admin-only paper path guarded by `Current.paper_context`; approvals require attachments, rejections may proceed without a file
-   - Status tracking: draft → in_progress → approved/rejected/needs_information
+   - Status tracking: draft → in_progress → awaiting_proof/reminder_sent/awaiting_dcf → approved/rejected/archived
    - Guardian/dependent application support with managing guardian tracking
 
 2. **Guardian & Dependent Management**
@@ -22,7 +22,7 @@ Vulcan is a Ruby on Rails application that facilitates Maryland Accessible Telec
    - Income and residency proof uploads with status tracking
    - Unified `ProofAttachmentService` for web, paper, and email submissions
    - Resubmission and rate-limit policies; robust error handling
-   - Centralized approval/rejection via `ProofReviewService` with audit logging
+   - Centralized approval/rejection via `ProofReviewService` + `ProofReview` callbacks with audit logging
 
 4. **Medical Certification**
    - Request and track provider responses
@@ -161,7 +161,7 @@ Vulcan is a Ruby on Rails application that facilitates Maryland Accessible Telec
 - [Pain Point Tracking](docs/features/application_pain_point_tracking.md) - Draft drop-off analysis
 
 ### Infrastructure
-- [Email System Guide](docs/infrastructure/EMAIL_SYSTEM.md) - Inbound and outbound email, templates
+- [Email System Guide](docs/infrastructure/email_system.md) - Inbound and outbound email, templates
 - [Active Storage S3 Setup](docs/infrastructure/active_storage_s3_setup.md) - File storage configuration
 
 ### Security

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -54,7 +54,7 @@ module Admin
         scope.where(income_proof_status: 0)
              .or(scope.where(residency_proof_status: 0))
       when 'awaiting_medical_response'
-        scope.where(status: :awaiting_documents)
+        scope.where(status: :awaiting_dcf)
       when 'training_requests'
         # Filter applications with training request notifications
         application_ids = Notification.where(action: 'training_requested')

--- a/app/controllers/webhooks/medical_certifications_controller.rb
+++ b/app/controllers/webhooks/medical_certifications_controller.rb
@@ -5,7 +5,7 @@ module Webhooks
     def create
       application = Application.find_by!(
         medical_provider_email: provider_email,
-        status: :awaiting_documents
+        status: :awaiting_dcf
       )
 
       certification = create_certification(application)

--- a/app/helpers/badge_helper.rb
+++ b/app/helpers/badge_helper.rb
@@ -21,9 +21,9 @@ module BadgeHelper
       in_progress: 'bg-purple-100 text-purple-800',
       approved: 'bg-green-100 text-green-800',
       rejected: 'bg-red-100 text-red-800',
-      needs_information: 'bg-blue-100 text-blue-800',
+      awaiting_proof: 'bg-blue-100 text-blue-800',
       reminder_sent: 'bg-purple-100 text-purple-800',
-      awaiting_documents: 'bg-orange-100 text-orange-800',
+      awaiting_dcf: 'bg-orange-100 text-orange-800',
       default: 'bg-gray-100 text-gray-800'
     },
     evaluation: {

--- a/app/javascript/controllers/users/document_proof_handler_controller.js
+++ b/app/javascript/controllers/users/document_proof_handler_controller.js
@@ -11,6 +11,7 @@ class DocumentProofHandlerController extends Controller {
   static targets = [
     "acceptRadio",
     "rejectRadio",
+    "noneRadio",
     "uploadSection",
     "rejectionSection",
     "fileInput",
@@ -43,6 +44,28 @@ class DocumentProofHandlerController extends Controller {
   toggleProofAction(event) {
     // Update UI based on selection
     this.updateVisibility();
+  }
+
+  /**
+   * Handle "None Provided" radio button selection
+   * UX shortcut that automatically selects reject + none_provided reason
+   * @param {Event} event The change event from the none radio button
+   */
+  handleNoneProvided(event) {
+    if (!this.hasRejectRadioTarget || !this.hasRejectionReasonSelectTarget) {
+      return;
+    }
+
+    // Programmatically select the reject radio button
+    this.rejectRadioTarget.checked = true;
+
+    // Auto-select "none_provided" from rejection reason dropdown
+    this.rejectionReasonSelectTarget.value = 'none_provided';
+
+    // Update visibility and populate notes
+    this.updateVisibility();
+    this.previewRejectionReason();
+    this.populateRejectionNotes();
   }
 
   /**

--- a/app/javascript/controllers/users/document_proof_handler_controller.js
+++ b/app/javascript/controllers/users/document_proof_handler_controller.js
@@ -11,7 +11,7 @@ class DocumentProofHandlerController extends Controller {
   static targets = [
     "acceptRadio",
     "rejectRadio",
-    "noneRadio",
+    "noneButton",
     "uploadSection",
     "rejectionSection",
     "fileInput",
@@ -47,9 +47,9 @@ class DocumentProofHandlerController extends Controller {
   }
 
   /**
-   * Handle "None Provided" radio button selection
+   * Handle "None Provided" button click
    * UX shortcut that automatically selects reject + none_provided reason
-   * @param {Event} event The change event from the none radio button
+   * @param {Event} event The click event from the none button
    */
   handleNoneProvided(event) {
     if (!this.hasRejectRadioTarget || !this.hasRejectionReasonSelectTarget) {

--- a/app/javascript/controllers/users/document_proof_handler_controller.js
+++ b/app/javascript/controllers/users/document_proof_handler_controller.js
@@ -11,7 +11,6 @@ class DocumentProofHandlerController extends Controller {
   static targets = [
     "acceptRadio",
     "rejectRadio",
-    "noneRadio",
     "uploadSection",
     "rejectionSection",
     "fileInput",
@@ -21,7 +20,7 @@ class DocumentProofHandlerController extends Controller {
   ]
 
   static values = {
-    proofType: String // "income_proof" or "residency_proof"
+    type: String // "income" or "residency"
   }
 
   connect() {
@@ -56,7 +55,6 @@ class DocumentProofHandlerController extends Controller {
     }
 
     const isAccepted = this.acceptRadioTarget.checked;
-    const noneProvided = this.noneRadioTarget.checked;
     const isRejected = this.rejectRadioTarget.checked;
   
     // Toggle visibility of sections using utility
@@ -80,7 +78,7 @@ class DocumentProofHandlerController extends Controller {
     // Toggle required attributes on fields
     if (this.hasRejectionReasonSelectTarget) {
       const target = this.rejectionReasonSelectTarget;
-      if (isAccepted || noneProvided ) {
+      if (isAccepted) {
         target.removeAttribute('required');
       } else {
         target.setAttribute('required', 'required');
@@ -124,6 +122,7 @@ class DocumentProofHandlerController extends Controller {
   formatRejectionReason(reasonCode) {
     // This would typically come from Rails I18n
     const reasonMessages = {
+      'none_provided': this.getNoneProvidedMessage(),
       'address_mismatch': 'The address on the document does not match the application address.',
       'expired': 'The document has expired or is not within the required date range.',
       'missing_name': 'The document does not clearly show the applicant\'s name.',
@@ -135,6 +134,18 @@ class DocumentProofHandlerController extends Controller {
     };
     
     return reasonMessages[reasonCode] || 'This document was rejected. Please provide a valid document.';
+  }
+
+  /**
+   * Get the appropriate "none provided" message based on proof type
+   * @returns {string} The none provided message
+   */
+  getNoneProvidedMessage() {
+    if (this.typeValue === 'income') {
+      return 'No income proof was provided with the application.';
+    } else {
+      return 'No residency proof was provided with the application.';
+    }
   }
 
   /**
@@ -162,6 +173,7 @@ class DocumentProofHandlerController extends Controller {
    */
   getInstructionalText(reasonCode) {
     const instructions = {
+      'none_provided': this.getNoneProvidedInstructions(),
       'address_mismatch': 'Please provide a document that shows your current address.',
       'expired': 'Please provide a current document that is not expired.',
       'missing_name': 'Please provide a document that clearly shows your name.',
@@ -173,6 +185,24 @@ class DocumentProofHandlerController extends Controller {
     };
     
     return instructions[reasonCode] || 'Please provide the required documentation.';
+  }
+
+  /**
+   * Get the appropriate instructions for "none provided" based on proof type
+   * @returns {string} The instructional text
+   */
+  getNoneProvidedInstructions() {
+    if (this.typeValue === 'income') {
+      return `Please provide ONE of the following to complete your application:
+
+• If you receive Social Security (SSA), SSI, or SSDI: Send your most recent Social Security Award Letter.
+
+• If you receive Veterans (VA) benefits, TDAP, TANF, or pharmacy/medical/housing assistance: Send your most recent benefit paperwork.
+
+• If you live on a limited or fixed income: Send your 2 most recent pay stubs, unemployment stubs, or last year's tax return.`;
+    } else {
+      return 'Please provide proof of Maryland residency to complete your application. Acceptable documents include: utility bill, mortgage statement, lease agreement, bank statement, or government ID. IMPORTANT: The address shown on your proof document must match the address you provided in your application.';
+    }
   }
 }
 

--- a/app/mailboxes/proof_submission_mailbox.rb
+++ b/app/mailboxes/proof_submission_mailbox.rb
@@ -173,9 +173,9 @@ class ProofSubmissionMailbox < ApplicationMailbox
 
   def ensure_active_application
     # An application is considered active for proof submission if its status
-    # is one of: in_progress, needs_information, reminder_sent, or awaiting_documents.
+    # is one of: in_progress, awaiting_proof, reminder_sent, or awaiting_dcf.
     # This aligns with the :active scope defined in ApplicationStatusManagement.
-    active_statuses = %i[in_progress needs_information reminder_sent awaiting_documents]
+    active_statuses = %i[in_progress awaiting_proof reminder_sent awaiting_dcf]
     return if application && active_statuses.include?(application.status&.to_sym)
 
     bounce_with_notification(

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -54,9 +54,9 @@ class Application < ApplicationRecord
     in_progress: 1,         # Submitted by constituent, being processed
     approved: 2,            # Application approved
     rejected: 3,            # Application rejected
-    needs_information: 4,   # Additional info needed from constituent
+    awaiting_proof: 4,      # Waiting for income/residency proofs
     reminder_sent: 5,       # Reminder sent to constituent
-    awaiting_documents: 6,  # Waiting for specific documents
+    awaiting_dcf: 6,        # Waiting for disability certification form (DCF)
     archived: 7             # Historical record
   }, prefix: true, validate: true
 
@@ -263,9 +263,9 @@ class Application < ApplicationRecord
 
   # Instance Methods
   # Determines if medical provider validation should be skipped
-  # Skip validation if: status is draft, needs_information
+  # Skip validation if: status is draft, awaiting_proof
   def skip_medical_provider_validation?
-    status_draft? || status_needs_information?
+    status_draft? || status_awaiting_proof?
   end
 
   # Status methods- Delegate approval logic to the Applications::Approver service object

--- a/app/models/application_status_change.rb
+++ b/app/models/application_status_change.rb
@@ -16,6 +16,32 @@ class ApplicationStatusChange < ApplicationRecord
 
   before_validation :set_changed_at
 
+  # Normalize legacy status names for backward compatibility
+  def normalized_from_status
+    case from_status
+    when 'awaiting_documents' then 'awaiting_dcf'
+    when 'needs_information' then 'awaiting_proof'
+    else from_status
+    end
+  end
+
+  def normalized_to_status
+    case to_status
+    when 'awaiting_documents' then 'awaiting_dcf'
+    when 'needs_information' then 'awaiting_proof'
+    else to_status
+    end
+  end
+
+  # Use this in views/helpers instead of direct status access
+  def display_from_status
+    normalized_from_status.humanize
+  end
+
+  def display_to_status
+    normalized_to_status.humanize
+  end
+
   private
 
   def set_changed_at

--- a/app/services/application_status.rb
+++ b/app/services/application_status.rb
@@ -6,14 +6,14 @@ class ApplicationStatus
   end
 
   def send_back!(actor: nil)
-    @application.update(status: :needs_information)
+    @application.update(status: :awaiting_proof)
 
     # Log the audit event
     AuditEventService.log(
       action: 'application_sent_back',
       actor: actor,
       auditable: @application,
-      metadata: { reason: 'Additional information required.' }
+      metadata: { reason: 'Additional proof documentation required.' }
     )
 
     # Send the notification
@@ -22,7 +22,7 @@ class ApplicationStatus
       recipient: @application.user,
       actor: actor,
       notifiable: @application,
-      metadata: { reason: 'Additional information required.' },
+      metadata: { reason: 'Additional proof documentation required.' },
       channel: :email
     )
   end

--- a/app/services/applications/document_requester.rb
+++ b/app/services/applications/document_requester.rb
@@ -18,7 +18,7 @@ module Applications
     # @return [Boolean] True if successful, false otherwise
     def call
       ApplicationRecord.transaction do
-        application.update!(status: :awaiting_documents)
+        application.update!(status: :awaiting_dcf)
 
         # Log the audit event
         AuditEventService.log(

--- a/app/services/applications/filter_service.rb
+++ b/app/services/applications/filter_service.rb
@@ -70,7 +70,7 @@ module Applications
         # Use Rails enum mapping to get the correct integer values
         scope.where(income_proof_status: :not_reviewed).or(scope.where(residency_proof_status: :not_reviewed))
       when 'awaiting_medical_response'
-        scope.where(status: :awaiting_documents)
+        scope.where(status: :awaiting_dcf)
       when 'medical_certs_to_review'
         # Only include applications that are in progress and have received certs
         scope.where(status: :in_progress, medical_certification_status: :received)

--- a/app/services/applications/paper_application_service.rb
+++ b/app/services/applications/paper_application_service.rb
@@ -392,16 +392,13 @@ module Applications
     def process_proof(type)
       action = params["#{type}_proof_action"] || params[:"#{type}_proof_action"]
 
-      return true unless %w[accept reject none].include?(action)
+      return true unless %w[accept reject].include?(action)
 
       case action
       when 'accept'
         process_accept_proof(type)
       when 'reject'
         process_reject_proof(type)
-      when 'none'
-        # UX shortcut that maps to reject with 'none_provided' reason
-        process_none_provided_proof(type)
       end
     end
 
@@ -464,30 +461,6 @@ module Applications
 
       unless result[:success]
         add_error("Error rejecting #{type} proof: #{result[:error]&.message}")
-        return false
-      end
-
-      true
-    end
-
-    def process_none_provided_proof(type)
-      # When "None Provided" is selected, automatically use the rejection workflow
-      # with 'none_provided' as the reason. Use params if explicitly provided (from JavaScript),
-      # otherwise default to 'none_provided'
-      reason = params["#{type}_proof_rejection_reason"].presence || 'none_provided'
-
-      result = ProofAttachmentService.reject_proof_without_attachment(
-        application: @application,
-        proof_type: type,
-        admin: @admin,
-        reason: reason,
-        notes: params["#{type}_proof_rejection_notes"],
-        submission_method: :paper,
-        metadata: {}
-      )
-
-      unless result[:success]
-        add_error("Error processing none provided for #{type} proof: #{result[:error]&.message}")
         return false
       end
 

--- a/app/services/applications/paper_application_service.rb
+++ b/app/services/applications/paper_application_service.rb
@@ -392,13 +392,16 @@ module Applications
     def process_proof(type)
       action = params["#{type}_proof_action"] || params[:"#{type}_proof_action"]
 
-      return true unless %w[accept reject].include?(action)
+      return true unless %w[accept reject none].include?(action)
 
       case action
       when 'accept'
         process_accept_proof(type)
       when 'reject'
         process_reject_proof(type)
+      when 'none'
+        # UX shortcut that maps to reject with 'none_provided' reason
+        process_none_provided_proof(type)
       end
     end
 
@@ -461,6 +464,30 @@ module Applications
 
       unless result[:success]
         add_error("Error rejecting #{type} proof: #{result[:error]&.message}")
+        return false
+      end
+
+      true
+    end
+
+    def process_none_provided_proof(type)
+      # When "None Provided" is selected, automatically use the rejection workflow
+      # with 'none_provided' as the reason. Use params if explicitly provided (from JavaScript),
+      # otherwise default to 'none_provided'
+      reason = params["#{type}_proof_rejection_reason"].presence || 'none_provided'
+
+      result = ProofAttachmentService.reject_proof_without_attachment(
+        application: @application,
+        proof_type: type,
+        admin: @admin,
+        reason: reason,
+        notes: params["#{type}_proof_rejection_notes"],
+        submission_method: :paper,
+        metadata: {}
+      )
+
+      unless result[:success]
+        add_error("Error processing none provided for #{type} proof: #{result[:error]&.message}")
         return false
       end
 

--- a/app/services/applications/reporting_service.rb
+++ b/app/services/applications/reporting_service.rb
@@ -152,11 +152,11 @@ module Applications
       data[:previous_fy_draft_applications] =
         Application.where(status: :draft, created_at: previous_range).count
 
-      # Combined draft and needs_information applications (for production use)
+      # Combined draft and awaiting_proof applications (for production use)
       data[:current_fy_draft_and_needs_info_applications] =
-        Application.where(status: %i[draft needs_information], created_at: current_range).count
+        Application.where(status: %i[draft awaiting_proof], created_at: current_range).count
       data[:previous_fy_draft_and_needs_info_applications] =
-        Application.where(status: %i[draft needs_information], created_at: previous_range).count
+        Application.where(status: %i[draft awaiting_proof], created_at: previous_range).count
     end
 
     def add_voucher_metrics(data)
@@ -342,7 +342,7 @@ module Applications
 
     def add_application_pipeline_data(data, status_counts)
       draft_count = status_count_helper(status_counts, :draft)
-      needs_info_count = status_count_helper(status_counts, :needs_information)
+      needs_info_count = status_count_helper(status_counts, :awaiting_proof)
       draft_and_needs_info_count = draft_count + needs_info_count
       submitted_count = status_count_helper(status_counts, :submitted)
       in_review_count = status_count_helper(status_counts, :in_review)
@@ -369,7 +369,7 @@ module Applications
 
     def add_status_breakdown_data(data, status_counts)
       draft_count = status_count_helper(status_counts, :draft)
-      needs_info_count = status_count_helper(status_counts, :needs_information)
+      needs_info_count = status_count_helper(status_counts, :awaiting_proof)
       draft_and_needs_info_count = draft_count + needs_info_count
       submitted_count = status_count_helper(status_counts, :submitted)
       in_review_count = status_count_helper(status_counts, :in_review)
@@ -395,7 +395,7 @@ module Applications
 
     def add_individual_status_counts(data, status_counts)
       draft_count = status_count_helper(status_counts, :draft)
-      needs_info_count = status_count_helper(status_counts, :needs_information)
+      needs_info_count = status_count_helper(status_counts, :awaiting_proof)
       draft_and_needs_info_count = draft_count + needs_info_count
       submitted_count = status_count_helper(status_counts, :submitted)
       in_review_count = status_count_helper(status_counts, :in_review)

--- a/app/views/admin/applications/_medical_certification_section.html.erb
+++ b/app/views/admin/applications/_medical_certification_section.html.erb
@@ -3,7 +3,14 @@
      updated via Turbo Stream for a smooth UX without full page reload.
 %>
 <div class="flex justify-between items-start">
-  <h2 id="certification-title" class="text-xl font-semibold text-gray-900">Medical Certification</h2>
+  <div class="flex items-center gap-3">
+    <h2 id="certification-title" class="text-xl font-semibold text-gray-900">Medical Certification</h2>
+    <% if @application.medical_certification_status == 'not_requested' %>
+      <span class="inline-flex items-center px-2.5 py-0.5 rounded-md text-sm font-medium bg-gray-100 text-gray-700">
+        Not Requested
+      </span>
+    <% end %>
+  </div>
   <div class="flex items-center space-x-2">
     <%= medical_certification_status_badge(@application) %>
     <%= document_signing_status_badge(@application) %>
@@ -11,7 +18,7 @@
 </div>
 
 <div class="mt-6 space-y-4">
-  <!-- Fax Upload Form and History -->
+  <!-- Medical Certification Upload Form (Visible unless approved) -->
   <%= render "medical_certification_upload" %>
 
   <!-- Provider Information -->

--- a/app/views/admin/applications/_medical_certification_upload.html.erb
+++ b/app/views/admin/applications/_medical_certification_upload.html.erb
@@ -1,14 +1,12 @@
 <%
-  # Only show the form when:
-  # 1. The certification has been requested but not yet received, AND
-  # 2. There's no attachment OR the status is not "approved"
-  show_upload_form = @application.medical_certification_status == "requested" && 
-                    (!@application.medical_certification.attached? ||
-                     @application.medical_certification_status != "approved")
+  # Show the upload form unless the certification is already approved
+  # Sometimes certifications arrive unexpectedly (mail, fax, email) without being formally requested
+  show_upload_form = @application.medical_certification_status != "approved"
 %>
 
 <% if show_upload_form %>
   <div class="mb-4 p-4 bg-blue-50 border-l-4 border-blue-500 rounded-md" 
+       id="medical-certification-upload-form"
        data-testid="medical-certification-upload-form">
     <h3 class="text-sm font-medium text-blue-700 mb-2">Upload Medical Certification</h3>
     <p class="text-sm text-blue-600 mb-2">

--- a/app/views/admin/paper_applications/new.html.erb
+++ b/app/views/admin/paper_applications/new.html.erb
@@ -726,16 +726,14 @@
                            data-document-proof-handler-target="rejectRadio">
                     <span class="ml-2 text-sm font-medium text-red-800">Reject</span>
                   </label>
-                  <label class="flex items-center p-3 bg-gray-50 border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-100 has-[:checked]:ring-2 has-[:checked]:ring-gray-500">
-                    <input type="radio" 
-                           id="no_income_proof_provided" 
-                           name="income_proof_action" 
-                           value="none" 
-                           class="h-4 w-4 text-gray-600 focus:ring-gray-500 border-gray-300" 
-                           data-action="change->document-proof-handler#handleNoneProvided" 
-                           data-document-proof-handler-target="noneRadio">
+                  <button type="button"
+                          id="no_income_proof_provided"
+                          class="flex items-center p-3 bg-gray-50 border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-0"
+                          data-action="click->document-proof-handler#handleNoneProvided"
+                          data-document-proof-handler-target="noneButton">
+                    <span class="text-lg">📂</span>
                     <span class="ml-2 text-sm font-medium text-gray-800">None Provided</span>
-                  </label>
+                  </button>
                 </div>
               </fieldset>
               
@@ -843,16 +841,14 @@
                            data-document-proof-handler-target="rejectRadio">
                     <span class="ml-2 text-sm font-medium text-red-800">Reject</span>
                   </label>
-                  <label class="flex items-center p-3 bg-gray-50 border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-100 has-[:checked]:ring-2 has-[:checked]:ring-gray-500">
-                    <input type="radio" 
-                           id="no_residency_proof_provided" 
-                           name="residency_proof_action" 
-                           value="none" 
-                           class="h-4 w-4 text-gray-600 focus:ring-gray-500 border-gray-300" 
-                           data-action="change->document-proof-handler#handleNoneProvided" 
-                           data-document-proof-handler-target="noneRadio">
+                  <button type="button"
+                          id="no_residency_proof_provided"
+                          class="flex items-center p-3 bg-gray-50 border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-0"
+                          data-action="click->document-proof-handler#handleNoneProvided"
+                          data-document-proof-handler-target="noneButton">
+                    <span class="text-lg">📂</span>
                     <span class="ml-2 text-sm font-medium text-gray-800">None Provided</span>
-                  </label>
+                  </button>
                 </div>
               </fieldset>
               

--- a/app/views/admin/paper_applications/new.html.erb
+++ b/app/views/admin/paper_applications/new.html.erb
@@ -657,21 +657,10 @@
                 <svg class="w-5 h-5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                 </svg>
-                Income Verification
+                Verification of Income and/or Benefits
               </h3>
               
               <%# Income Information Fields %>
-              <div class="flex items-center gap-3 mb-6 pb-4">
-                <%= check_box_tag :no_income_information, 
-                    nil, 
-                    false, 
-                    class: "mt-1 rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500", 
-                    data: { 
-                      "income-validation-target": "noIncomeProvided", 
-                      "action": "change->income-validation#toggleIncome" 
-                    } %>
-                <%= label_tag :no_income_information, "No income information provided" %>
-              </div>
               <%= fields_for :application do |a| %>
                 <div class="mb-4 p-4 bg-gray-50 border-2 border-gray-200 rounded-lg transition-colors duration-200" 
                      data-income-validation-target="incomeFieldsContainer">
@@ -715,6 +704,7 @@
               <%# Proof Action Selection %>
               <fieldset class="mb-4">
                 <legend class="text-sm font-medium text-gray-700 mb-2">Income Proof Action</legend>
+                <p class="text-sm text-gray-600 mb-3">If no income proof was provided with the paper application, select <strong>Reject</strong> and choose "None Provided" from the rejection reasons.</p>
                 <div role="radiogroup" aria-label="Income proof action" class="flex flex-wrap gap-4">
                   <label class="flex items-center p-3 bg-green-50 border border-green-200 rounded-lg cursor-pointer hover:bg-green-100 has-[:checked]:ring-2 has-[:checked]:ring-green-500">
                     <input type="radio" 
@@ -736,16 +726,6 @@
                            data-action="change->document-proof-handler#toggleProofAction" 
                            data-document-proof-handler-target="rejectRadio">
                     <span class="ml-2 text-sm font-medium text-red-800">Reject</span>
-                  </label>
-                  <label class="flex items-center p-3 bg-grey-50 border border-grey-200 rounded-lg cursor-pointer hover:bg-grey-100 has-[:checked]:ring-2 has-[:checked]:ring-grey-500">
-                    <input type="radio" 
-                           id="no_income_proof_provided" 
-                           name="income_proof_action" 
-                           value="none"
-                           class="h-4 w-4 text-red-600 focus:ring-red-500 border-gray-300" 
-                           data-action="change->document-proof-handler#toggleProofAction"
-                           data-document-proof-handler-target="noneRadio">
-                    <span class="ml-2 text-sm font-medium text-red-800">None Provided</span>
                   </label>
                 </div>
               </fieldset>
@@ -777,6 +757,7 @@
                             class="block w-full rounded-md border-gray-300 bg-white shadow-sm ring-1 ring-inset ring-gray-300 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500 sm:text-sm" 
                             data-document-proof-handler-target="rejectionReasonSelect">
                       <option value="">Select a reason</option>
+                      <option value="none_provided">None Provided</option>
                       <option value="address_mismatch">Address Mismatch</option>
                       <option value="expired">Expired Documentation</option>
                       <option value="missing_name">Missing Name</option>
@@ -831,6 +812,7 @@
               <%# Proof Action Selection %>
               <fieldset class="mb-4">
                 <legend class="text-sm font-medium text-gray-700 mb-2">Residency Proof Action</legend>
+                <p class="text-sm text-gray-600 mb-3">If no residency proof was provided with the paper application, select <strong>Reject</strong> and choose "None Provided" from the rejection reasons.</p>
                 <div role="radiogroup" aria-label="Residency proof action" class="flex flex-wrap gap-4">
                   <label class="flex items-center p-3 bg-green-50 border border-green-200 rounded-lg cursor-pointer hover:bg-green-100 has-[:checked]:ring-2 has-[:checked]:ring-green-500">
                     <input type="radio" 
@@ -852,16 +834,6 @@
                            data-action="change->document-proof-handler#toggleProofAction" 
                            data-document-proof-handler-target="rejectRadio">
                     <span class="ml-2 text-sm font-medium text-red-800">Reject</span>
-                  </label>
-                  <label class="flex items-center p-3 bg-grey-50 border border-grey-200 rounded-lg cursor-pointer hover:bg-grey-100 has-[:checked]:ring-2 has-[:checked]:ring-grey-500">
-                    <input type="radio" 
-                           id="no_residency_proof_provided" 
-                           name="residency_proof_action" 
-                           value="none"
-                           class="h-4 w-4 text-red-600 focus:ring-red-500 border-gray-300" 
-                           data-action="change->document-proof-handler#toggleProofAction"
-                           data-document-proof-handler-target="noneRadio">
-                    <span class="ml-2 text-sm font-medium text-red-800">None Provided</span>
                   </label>
                 </div>
               </fieldset>
@@ -893,6 +865,7 @@
                             class="block w-full rounded-md border-gray-300 bg-white shadow-sm ring-1 ring-inset ring-gray-300 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500 sm:text-sm" 
                             data-document-proof-handler-target="rejectionReasonSelect">
                       <option value="">Select a reason</option>
+                      <option value="none_provided">None Provided</option>
                       <option value="address_mismatch">Address Mismatch</option>
                       <option value="expired">Expired Documentation</option>
                       <option value="missing_name">Missing Name</option>

--- a/app/views/admin/paper_applications/new.html.erb
+++ b/app/views/admin/paper_applications/new.html.erb
@@ -661,6 +661,17 @@
               </h3>
               
               <%# Income Information Fields %>
+              <div class="flex items-center gap-3 mb-6 pb-4">
+                <%= check_box_tag :no_income_information, 
+                    nil, 
+                    false, 
+                    class: "mt-1 rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500", 
+                    data: { 
+                      "income-validation-target": "noIncomeProvided", 
+                      "action": "change->income-validation#toggleIncome" 
+                    } %>
+                <%= label_tag :no_income_information, "Benefits information was provided that satisfies the income requirement; no household size or income information needed", class: "text-sm font-medium text-gray-700 cursor-pointer" %>
+              </div>
               <%= fields_for :application do |a| %>
                 <div class="mb-4 p-4 bg-gray-50 border-2 border-gray-200 rounded-lg transition-colors duration-200" 
                      data-income-validation-target="incomeFieldsContainer">

--- a/app/views/admin/paper_applications/new.html.erb
+++ b/app/views/admin/paper_applications/new.html.erb
@@ -704,7 +704,6 @@
               <%# Proof Action Selection %>
               <fieldset class="mb-4">
                 <legend class="text-sm font-medium text-gray-700 mb-2">Income Proof Action</legend>
-                <p class="text-sm text-gray-600 mb-3">If no income proof was provided with the paper application, select <strong>Reject</strong> and choose "None Provided" from the rejection reasons.</p>
                 <div role="radiogroup" aria-label="Income proof action" class="flex flex-wrap gap-4">
                   <label class="flex items-center p-3 bg-green-50 border border-green-200 rounded-lg cursor-pointer hover:bg-green-100 has-[:checked]:ring-2 has-[:checked]:ring-green-500">
                     <input type="radio" 
@@ -726,6 +725,16 @@
                            data-action="change->document-proof-handler#toggleProofAction" 
                            data-document-proof-handler-target="rejectRadio">
                     <span class="ml-2 text-sm font-medium text-red-800">Reject</span>
+                  </label>
+                  <label class="flex items-center p-3 bg-gray-50 border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-100 has-[:checked]:ring-2 has-[:checked]:ring-gray-500">
+                    <input type="radio" 
+                           id="no_income_proof_provided" 
+                           name="income_proof_action" 
+                           value="none" 
+                           class="h-4 w-4 text-gray-600 focus:ring-gray-500 border-gray-300" 
+                           data-action="change->document-proof-handler#handleNoneProvided" 
+                           data-document-proof-handler-target="noneRadio">
+                    <span class="ml-2 text-sm font-medium text-gray-800">None Provided</span>
                   </label>
                 </div>
               </fieldset>
@@ -812,7 +821,6 @@
               <%# Proof Action Selection %>
               <fieldset class="mb-4">
                 <legend class="text-sm font-medium text-gray-700 mb-2">Residency Proof Action</legend>
-                <p class="text-sm text-gray-600 mb-3">If no residency proof was provided with the paper application, select <strong>Reject</strong> and choose "None Provided" from the rejection reasons.</p>
                 <div role="radiogroup" aria-label="Residency proof action" class="flex flex-wrap gap-4">
                   <label class="flex items-center p-3 bg-green-50 border border-green-200 rounded-lg cursor-pointer hover:bg-green-100 has-[:checked]:ring-2 has-[:checked]:ring-green-500">
                     <input type="radio" 
@@ -834,6 +842,16 @@
                            data-action="change->document-proof-handler#toggleProofAction" 
                            data-document-proof-handler-target="rejectRadio">
                     <span class="ml-2 text-sm font-medium text-red-800">Reject</span>
+                  </label>
+                  <label class="flex items-center p-3 bg-gray-50 border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-100 has-[:checked]:ring-2 has-[:checked]:ring-gray-500">
+                    <input type="radio" 
+                           id="no_residency_proof_provided" 
+                           name="residency_proof_action" 
+                           value="none" 
+                           class="h-4 w-4 text-gray-600 focus:ring-gray-500 border-gray-300" 
+                           data-action="change->document-proof-handler#handleNoneProvided" 
+                           data-document-proof-handler-target="noneRadio">
+                    <span class="ml-2 text-sm font-medium text-gray-800">None Provided</span>
                   </label>
                 </div>
               </fieldset>

--- a/docs/current_application_features.md
+++ b/docs/current_application_features.md
@@ -10,8 +10,8 @@ An at-a-glance yet detailed map of MAT Vulcan's major feature sets as of Decembe
 |--------|-------------|------------|
 | `draft` | Constituent working on application | Submit for review |
 | `in_progress` | Submitted, being processed | Proof review, medical cert |
-| `needs_information` | Additional info needed | Constituent provides info |
-| `awaiting_documents` | Waiting for specific docs | Document upload |
+| `awaiting_proof` | Waiting for income/residency proofs | Constituent uploads proofs |
+| `awaiting_dcf` | Waiting for disability certification form | Medical provider submits DCF |
 | `approved` | Application approved | Voucher assignment |
 | `rejected` | Application denied | Constituent may reapply |
 | `archived` | Historical record | — |

--- a/docs/features/application_workflow_guide.md
+++ b/docs/features/application_workflow_guide.md
@@ -137,9 +137,9 @@ Approvals require an attachment; only rejections may proceed without a file. The
 ```
 draft ─▶ in_progress ─▶ approved ─▶ (voucher auto-assigned via VoucherManagement concern)
       └▶ rejected
-      └▶ needs_information
+      └▶ awaiting_proof
       └▶ reminder_sent
-      └▶ awaiting_documents
+      └▶ awaiting_dcf
       └▶ archived
 ```
 

--- a/lib/tasks/status_cleanup.rake
+++ b/lib/tasks/status_cleanup.rake
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+namespace :data do
+  desc 'Update legacy status names to new terminology in ApplicationStatusChange records'
+  task update_status_names: :environment do
+    puts 'Updating legacy status names in ApplicationStatusChange records...'
+
+    # Update awaiting_documents → awaiting_dcf
+    awaiting_docs_from = ApplicationStatusChange.where(from_status: 'awaiting_documents')
+                                                .update_all(from_status: 'awaiting_dcf') # rubocop:disable Rails/SkipsModelValidations
+    awaiting_docs_to = ApplicationStatusChange.where(to_status: 'awaiting_documents')
+                                              .update_all(to_status: 'awaiting_dcf') # rubocop:disable Rails/SkipsModelValidations
+
+    # Update needs_information → awaiting_proof
+    needs_info_from = ApplicationStatusChange.where(from_status: 'needs_information')
+                                             .update_all(from_status: 'awaiting_proof') # rubocop:disable Rails/SkipsModelValidations
+    needs_info_to = ApplicationStatusChange.where(to_status: 'needs_information')
+                                           .update_all(to_status: 'awaiting_proof') # rubocop:disable Rails/SkipsModelValidations
+
+    total_count = awaiting_docs_from + awaiting_docs_to + needs_info_from + needs_info_to
+
+    puts "✓ Updated #{total_count} status change records:"
+    puts "  - awaiting_documents → awaiting_dcf: #{awaiting_docs_from + awaiting_docs_to}"
+    puts "  - needs_information → awaiting_proof: #{needs_info_from + needs_info_to}"
+    puts 'All legacy status references have been updated to new terminology'
+  end
+end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -242,21 +242,21 @@ module SeedLookupHelpers
         raise(ArgumentError, 'No applications found in seeds (expected in_progress)')
     when :submitted_application
       # Try multiple possible statuses that indicate a submitted application
-      scope.where(status: %w[in_progress awaiting_documents]).first ||
+      scope.where(status: %w[in_progress awaiting_dcf]).first ||
         scope.first ||
-        raise(ArgumentError, 'No applications found in seeds (expected in_progress or awaiting_documents)')
+        raise(ArgumentError, 'No applications found in seeds (expected in_progress or awaiting_dcf)')
     when :approved_application
       scope.find_by(status: 'approved') ||
         scope.first ||
         raise(ArgumentError, 'No applications found in seeds (expected approved)')
     when :pending_application
-      scope.where(status: %w[needs_information awaiting_documents]).first ||
+      scope.where(status: %w[awaiting_proof awaiting_dcf]).first ||
         scope.first ||
-        raise(ArgumentError, 'No applications found in seeds (expected needs_information or awaiting_documents)')
+        raise(ArgumentError, 'No applications found in seeds (expected awaiting_proof or awaiting_dcf)')
     when :pending_with_proofs
       # Find a pending application that has both income and residency proofs attached
       scope.joins(:income_proof_attachment, :residency_proof_attachment)
-           .where(status: %w[needs_information awaiting_documents]).first ||
+           .where(status: %w[awaiting_proof awaiting_dcf]).first ||
         scope.first ||
         raise(ArgumentError, 'No applications found in seeds (expected pending with proofs)')
     when :waiting_period

--- a/test/controllers/constituent_portal/dashboards_controller_test.rb
+++ b/test/controllers/constituent_portal/dashboards_controller_test.rb
@@ -33,7 +33,7 @@ module ConstituentPortal
       get constituent_portal_dashboard_path
       assert_response :success
       # Assert for the status badge text and the view details link
-      assert_select 'div.flex.items-center span.rounded-full', text: 'Needs information'
+      assert_select 'div.flex.items-center span.rounded-full', text: 'Awaiting proof'
       assert_select 'a', text: 'View Application Details'
     end
 

--- a/test/controllers/constituent_portal/dashboards_controller_test.rb
+++ b/test/controllers/constituent_portal/dashboards_controller_test.rb
@@ -27,8 +27,8 @@ module ConstituentPortal
     end
 
     test 'dashboard shows different content based on application status' do
-      # Test for a status that might require user action, e.g., needs_information
-      create(:application, user: @user, status: :needs_information)
+      # Test for a status that might require user action, e.g., awaiting_proof
+      create(:application, user: @user, status: :awaiting_proof)
 
       get constituent_portal_dashboard_path
       assert_response :success

--- a/test/factories/applications.rb
+++ b/test/factories/applications.rb
@@ -89,7 +89,7 @@ FactoryBot.define do
     end
 
     trait :with_rejected_proofs do
-      status { :needs_information }
+      status { :awaiting_proof }
       income_proof_status { :rejected }
       residency_proof_status { :rejected }
       needs_review_since { Time.current }
@@ -113,7 +113,7 @@ FactoryBot.define do
     end
 
     trait :paper_rejected_proofs do
-      status { :needs_information }
+      status { :awaiting_proof }
 
       # This trait represents the paper application scenario where
       # admin rejected proofs without uploading them (paper workflow)

--- a/test/fixtures/application_status_changes.yml
+++ b/test/fixtures/application_status_changes.yml
@@ -16,7 +16,7 @@ in_progress_to_approved:
 
 needs_info_to_in_progress:
   application: in_review
-  from_status: needs_information
+  from_status: awaiting_proof
   to_status: in_progress
   user: admin_david
   changed_at: <%= 2.days.ago %>

--- a/test/fixtures/applications.yml
+++ b/test/fixtures/applications.yml
@@ -80,7 +80,7 @@ complete:
 one:
   user: constituent_john
   application_date: <%= Time.current %>
-  status: needs_information
+  status: awaiting_proof
   income_proof_status: rejected
   residency_proof_status: rejected
   maryland_resident: true
@@ -180,7 +180,7 @@ submitted_proofs_pending_application:
 awaiting_medical_response_application:
   user: constituent_jane
   application_date: <%= Time.zone.parse("2025-02-15 15:30:00").strftime("%F %T") %>
-  status: awaiting_documents
+  status: awaiting_dcf
   maryland_resident: true
   annual_income: "90000"
   household_size: 2
@@ -188,7 +188,9 @@ awaiting_medical_response_application:
   medical_provider_name: "City Health Partners"
   medical_provider_phone: "555-111-2222"
   medical_provider_email: "appointments@cityhealth.com"
-  medical_certification_status: not_requested
+  income_proof_status: approved
+  residency_proof_status: approved
+  medical_certification_status: requested
   submission_method: paper
 
 new_user_application:
@@ -271,25 +273,25 @@ submitted_status_application:
   medical_certification_status: approved
   submission_method: web
 
-awaiting_documents_application:
+awaiting_dcf_application:
   user: confirmed_user2
-  status: awaiting_documents
+  status: awaiting_dcf
   application_date: <%= Time.current - 10.days %>
   household_size: 3
   annual_income: 45000
-  income_proof_status: not_reviewed
-  residency_proof_status: not_reviewed
+  income_proof_status: approved
+  residency_proof_status: approved
   maryland_resident: true
   self_certify_disability: true
   medical_provider_name: "Awaiting Provider"
   medical_provider_phone: "555-999-0000"
   medical_provider_email: "awaiting.provider@example.com"
-  medical_certification_status: not_requested
+  medical_certification_status: requested
   submission_method: paper
 
 needs_information_application:
   user: unconfirmed_user
-  status: needs_information
+  status: awaiting_proof
   application_date: <%= Time.current - 1.month %>
   household_size: 2
   annual_income: 28000

--- a/test/mailboxes/proof_submission_mailbox_test.rb
+++ b/test/mailboxes/proof_submission_mailbox_test.rb
@@ -238,7 +238,7 @@ class ProofSubmissionMailboxTest < ActionMailbox::TestCase
     puts "CONSTITUENT FOUND: #{constituent.present?} (#{email_params[:from]})"
     if constituent
       # Check for active applications - helps identify bounce reasons
-      app = constituent.applications.where(status: %i[in_progress needs_information reminder_sent awaiting_documents]).first
+      app = constituent.applications.where(status: %i[in_progress awaiting_proof reminder_sent awaiting_dcf]).first
       puts "ACTIVE APPLICATION: #{app.present?} (ID: #{app&.id})"
     end
 

--- a/test/models/application_status_change_test.rb
+++ b/test/models/application_status_change_test.rb
@@ -93,19 +93,19 @@ class ApplicationStatusChangeTest < ActiveSupport::TestCase
     application.update!(status: :in_progress)
     assert_equal initial_count + 1, ApplicationStatusChange.count
 
-    # Change 2: in_progress -> needs_information
-    application.update!(status: :needs_information)
+    # Change 2: in_progress -> awaiting_proof
+    application.update!(status: :awaiting_proof)
     assert_equal initial_count + 2, ApplicationStatusChange.count
 
-    # Change 3: needs_information -> in_progress
+    # Change 3: awaiting_proof -> in_progress
     application.update!(status: :in_progress)
     assert_equal initial_count + 3, ApplicationStatusChange.count
 
     # Verify all changes are distinct
     changes = ApplicationStatusChange.where(application: application).order(created_at: :asc)
     assert_equal 3, changes.count
-    assert_equal %w[draft in_progress needs_information], changes.map(&:from_status)
-    assert_equal %w[in_progress needs_information in_progress], changes.map(&:to_status)
+    assert_equal %w[draft in_progress awaiting_proof], changes.map(&:from_status)
+    assert_equal %w[in_progress awaiting_proof in_progress], changes.map(&:to_status)
   end
 
   test 'status change without Current.user falls back to application user' do

--- a/test/services/applications/paper_application_service_test.rb
+++ b/test/services/applications/paper_application_service_test.rb
@@ -155,7 +155,8 @@ module Applications
 
       # Rather than directly inspecting the model, check that the service completed
       # and the application was created with appropriate parameters
-      assert_equal 'in_progress', application.status, 'Status should be in_progress'
+      # Status should be awaiting_proof when any proof is rejected
+      assert_equal 'awaiting_proof', application.status, 'Status should be awaiting_proof when proof is rejected'
 
       # Since we've mocked the service, we just need to verify that the application was created
       # and our mocked rejection service was called
@@ -250,7 +251,8 @@ module Applications
       assert_not_nil application, 'Application should be created'
 
       # Verify the application was created
-      assert_equal 'in_progress', application.status, 'Status should be in_progress'
+      # Status should be awaiting_proof when any proof is rejected
+      assert_equal 'awaiting_proof', application.status, 'Status should be awaiting_proof when proof is rejected'
     end
   end
 end

--- a/test/services/applications/reporting_service_test.rb
+++ b/test/services/applications/reporting_service_test.rb
@@ -372,10 +372,10 @@ module Applications
                               status: :in_progress)
 
       # 1 Needs information application (which maps to in_review_count in the service)
-      needs_info_app = create(:application,
+      needs_info_app =       create(:application,
                               user: create(:constituent, email: "unique_index_needsinfo_#{Time.now.to_i}@example.com"),
                               created_at: current_fy_start + 3.months + 15.days, # Use 3 months + 15 days instead of 3.5 months
-                              status: :needs_information)
+                              status: :awaiting_proof)
 
       # 3 Approved applications (2 current FY, 1 previous FY)
       approved_app1 = create(:application,
@@ -431,8 +431,8 @@ module Applications
         in_progress_count_after = new_status_counts.fetch(in_progress_key, 0) + new_status_counts.fetch(in_progress_key_int, 0)
         _added_in_progress = in_progress_count_after - in_progress_count_before
 
-        needs_info_key = Application.statuses[:needs_information].to_s
-        needs_info_key_int = Application.statuses[:needs_information]
+        needs_info_key = Application.statuses[:awaiting_proof].to_s
+        needs_info_key_int = Application.statuses[:awaiting_proof]
         needs_info_count_before = initial_status_counts.fetch(needs_info_key, 0) + initial_status_counts.fetch(needs_info_key_int, 0)
         needs_info_count_after = new_status_counts.fetch(needs_info_key, 0) + new_status_counts.fetch(needs_info_key_int, 0)
         _added_needs_info = needs_info_count_after - needs_info_count_before

--- a/test/support/proof_test_helper.rb
+++ b/test/support/proof_test_helper.rb
@@ -38,7 +38,7 @@ module ProofTestHelper
     app.update_columns(
       income_proof_status: Application.income_proof_statuses[:rejected],
       residency_proof_status: Application.residency_proof_statuses[:rejected],
-      status: Application.statuses[:needs_information],
+      status: Application.statuses[:awaiting_proof],
       needs_review_since: nil
     )
 

--- a/test/system/admin/proof_email_submission_test.rb
+++ b/test/system/admin/proof_email_submission_test.rb
@@ -19,7 +19,7 @@ module Admin
 
       # Set the application to a status that allows for proof submission.
       # The ProofSubmissionMailbox bounces emails for applications that are not in an active state (e.g. 'draft').
-      @application.update!(status: :needs_information)
+      @application.update!(status: :awaiting_proof)
 
       # Set up ApplicationMailbox routing for testing
       ApplicationMailbox.instance_eval do
@@ -67,7 +67,7 @@ module Admin
       unique_email = "constituent_#{Time.now.to_i}_#{SecureRandom.hex(4)}@example.com"
       constituent = create(:constituent, email: unique_email)
       app = create(:application, :old_enough_for_new_application, user: constituent)
-      app.update!(status: :needs_information)
+      app.update!(status: :awaiting_proof)
       file_path = Rails.root.join('tmp/income_proof.pdf')
       File.write(file_path, 'This is a test PDF file that is larger than one kilobyte to ensure it passes all attachment validations in the mailbox. ' * 20)
 
@@ -102,7 +102,7 @@ module Admin
       unique_email = "constituent_truncation_#{Time.now.to_i}_#{rand(10_000)}@example.com"
       constituent = create(:constituent, email: unique_email)
       app = create(:application, :old_enough_for_new_application, user: constituent)
-      app.update!(status: :needs_information)
+      app.update!(status: :awaiting_proof)
 
       income_file_path = Rails.root.join('tmp/income_proof.pdf')
       residency_file_path = Rails.root.join('tmp/residency_proof.pdf')

--- a/test/system/admin/proof_rejection_reasons_test.rb
+++ b/test/system/admin/proof_rejection_reasons_test.rb
@@ -13,7 +13,7 @@ module Admin
       @admin = create(:admin)
       @user = create(:constituent, hearing_disability: true)
       @application = create(:application, :old_enough_for_new_application, user: @user)
-      @application.update!(status: 'needs_information')
+      @application.update!(status: 'awaiting_proof')
 
       # Attach proofs using the lightweight helper and verify they're attached
       attach_lightweight_proof(@application, :income_proof)

--- a/test/system/constituent_portal/proof_uploads_test.rb
+++ b/test/system/constituent_portal/proof_uploads_test.rb
@@ -14,7 +14,7 @@ class ProofUploadsTest < ApplicationSystemTestCase
       :application,
       :in_progress_with_rejected_proofs,
       user: @user,
-      status: :needs_information
+      status: :awaiting_proof
     )
 
     # Verify prerequisites


### PR DESCRIPTION
This commit includes two related improvements to the paper application workflow:

**Audit Logging**
- Fixed PaperApplicationService to log correct audit events for updates vs creates
- Added log_application_update method with 'application_updated' action
- Modified handle_successful_application to accept operation parameter (:create or :update)
- Includes updated_attributes and proof_actions in update metadata for better audit trail
- Prevents corruption of audit logs where updates were incorrectly logged as creations

**Income Verification vs Income and Benefits Verification clarification in view**
- Changed section heading from "Income Verification" to "Verification of Income and/or Benefits"
- Removed redundant "No Income Verification Provided" checkbox
- Removed "None Provided" radio buttons for both income and residency proofs
- Added "None Provided" option to rejection reason dropdowns
- Added staff instructions clarifying the rejection workflow for missing proofs
- Enhanced rejection messages with context-specific acceptable documentation lists
- Updated JavaScript controller to generate tailored messages for income vs residency proof
- Added address-matching requirement clarification for residency proof rejections