### PR TITLE
Change how ReportingService returns notifications so that presentation is handled in view layer

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -67,7 +67,6 @@ module Admin
                               .where('created_at > ?', 7.days.ago)
                               .order(created_at: :desc)
                               .limit(5)
-                              .map { |n| NotificationDecorator.new(n) }
     end
 
     def show

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,9 +14,12 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:email])
 
-    handle_invalid_credentials and return unless user&.authenticate(params[:password])
+    if !user&.authenticate(params[:password])
+      @errors = { email: ["Invalid email or password"] }
+      return render_form_errors
+    end
 
-    return sign_in(user) unless user.second_factor_enabled?
+    return sign_in(user) if !user.second_factor_enabled?
 
     setup_two_factor_session(user)
     redirect_to_two_factor_verification(user)
@@ -43,6 +46,17 @@ class SessionsController < ApplicationController
   end
 
   private
+
+  def render_form_errors
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace('sign_in_form', partial: 'sessions/form')
+      end
+      format.html do
+        redirect_to sign_in_path(email_hint: params[:email]), alert: 'Invalid email or password'
+      end
+    end
+  end
 
   def handle_invalid_credentials
     # Add user feedback for failed login attempts if User model supports it

--- a/app/services/applications/reporting_service.rb
+++ b/app/services/applications/reporting_service.rb
@@ -304,7 +304,7 @@ module Applications
       ).order(created_at: :desc)
                                   .limit(5)
 
-      data[:recent_notifications] = notifications.map { |n| NotificationDecorator.new(n) }
+      data[:recent_notifications] = notifications
     end
 
     def fetch_application_status_counts

--- a/app/views/admin/applications/index.html.erb
+++ b/app/views/admin/applications/index.html.erb
@@ -353,7 +353,7 @@
         <ul class="divide-y divide-gray-200">
           <% @recent_notifications.each do |notification| %>
             <!-- Use render instead of inline partial to avoid implicit loading of notifiable association -->
-            <%= render "notifications/notification", notification: notification %>
+            <%= render "notifications/notification", notification: NotificationDecorator.new(notification) %>
           <% end %>
         </ul>
       <% else %>


### PR DESCRIPTION
- Reporting Service returned notifications as a NoticeDecorator class and this was causing an error in DashboardLoadingMetrics. Based on separation of concerns, the decorating would make more sense in the view layer so I've moved it out of the service.