### PR TITLE
Fix how the app sends medical cert rejections

### DIFF
--- a/app/mailers/medical_provider_mailer.rb
+++ b/app/mailers/medical_provider_mailer.rb
@@ -32,7 +32,7 @@ class MedicalProviderMailer < ApplicationMailer
     # Map to certification_rejected method
     self.class.with(
       application: notifiable,
-      rejection_reason: notification.metadata['rejection_reason'] || 'Not specified',
+      rejection_reason: notification.metadata['reason'] || 'Not specified',
       admin: notification.actor
     ).certification_rejected
   end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -146,18 +146,22 @@ class NotificationService
   end
 
   MAILER_MAP = {
-    'proof_rejected' => [ApplicationNotificationsMailer, :proof_rejected],
-    'proof_approved' => [ApplicationNotificationsMailer, :proof_approved],
-    'income_proof_rejected' => [ApplicationNotificationsMailer, :proof_rejected],
-    'residency_proof_rejected' => [ApplicationNotificationsMailer, :proof_rejected],
-    'account_created' => [ApplicationNotificationsMailer, :account_created],
-    'income_proof_attached' => [ApplicationNotificationsMailer, :proof_received],
-    'residency_proof_attached' => [ApplicationNotificationsMailer, :proof_received],
-    'w9_approved' => [VendorNotificationsMailer, :w9_approved],
-    'w9_rejected' => [VendorNotificationsMailer, :w9_rejected],
-    'training_requested' => [TrainingSessionNotificationsMailer, :trainer_assigned],
-    'trainer_assigned' => [TrainingSessionNotificationsMailer, :trainer_assigned],
-    'security_key_recovery_approved' => [ApplicationNotificationsMailer, :account_created]
+    'proof_rejected'                    => [ApplicationNotificationsMailer,           :proof_rejected],
+    'proof_approved'                    => [ApplicationNotificationsMailer,           :proof_approved],
+    'income_proof_rejected'             => [ApplicationNotificationsMailer,           :proof_rejected],
+    'residency_proof_rejected'          => [ApplicationNotificationsMailer,           :proof_rejected],
+    'account_created'                   => [ApplicationNotificationsMailer,           :account_created],
+    'income_proof_attached'             => [ApplicationNotificationsMailer,           :proof_received],
+    'residency_proof_attached'          => [ApplicationNotificationsMailer,           :proof_received],
+    'w9_approved'                       => [VendorNotificationsMailer,                :w9_approved],
+    'w9_rejected'                       => [VendorNotificationsMailer,                :w9_rejected],
+    'training_requested'                => [TrainingSessionNotificationsMailer,       :trainer_assigned],
+    'trainer_assigned'                  => [TrainingSessionNotificationsMailer,       :trainer_assigned],
+    'security_key_recovery_approved'    => [ApplicationNotificationsMailer,           :account_created],
+    'medical_certification_rejected'    => [MedicalProviderMailer,                    :rejected],
+    'medical_certification_approved'    => [MedicalProviderMailer,                    :approved]
+    # medical_certification_received: no email — constituent sees status in dashboard
+    # medical_certification_requested: sent directly via MedicalProviderMailer.request_certification, not through NotificationService
   }.freeze
 
   # ---- Creation + validation -------------------------------------------------
@@ -430,8 +434,6 @@ class NotificationService
   def resolve_mailer(notification)
     if (entry = MAILER_MAP[notification.action])
       [entry.first, entry.last]
-    elsif notification.action.start_with?('medical_certification_')
-      [MedicalProviderMailer, notification.action.delete_prefix('medical_certification_').to_sym]
     else
       Rails.logger.warn "NotificationService: No mailer configured for action: #{notification.action} for Notification ##{notification.id}."
       [nil, nil]


### PR DESCRIPTION
- Rejection reason now shows up correctly in provider emails (was always blank before)
- Medical provider email routing is now listed explicitly alongside all other email types