### PR TITLE
Move print queue link back to dashboard

### DIFF
--- a/app/views/admin/dashboards/index.html.erb
+++ b/app/views/admin/dashboards/index.html.erb
@@ -9,9 +9,26 @@
       <!-- Hidden semantic landmark for test compatibility -->
       <h1 class="sr-only">Dashboard</h1>
       
-      <h1 class="text-3xl font-bold mb-4" id="page-title">
-        Admin Dashboard
-      </h1>
+      <div class="flex items-start justify-between gap-4 mb-4">
+        <h1 class="text-3xl font-bold" id="page-title">
+          Admin Dashboard
+        </h1>
+        
+        <%= link_to admin_print_queue_index_path,
+            class: "group relative overflow-hidden rounded-lg border border-gray-300 bg-white px-6 py-4 text-gray-900 transition-all hover:border-indigo-300 hover:bg-indigo-50 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 flex items-center gap-3 whitespace-nowrap",
+            aria: { label: "View print queue" } do %>
+          <svg class="h-5 w-5 flex-shrink-0 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
+          </svg>
+          <div class="text-left">
+            <div class="font-semibold text-sm">Print Queue
+              <% if @metrics[:print_queue_pending_count].to_i > 0 %>
+                (<%= @metrics[:print_queue_pending_count] %>)
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
       
       <%# 
         Administrative Action Buttons

--- a/app/views/admin/print_queue/index.html.erb
+++ b/app/views/admin/print_queue/index.html.erb
@@ -2,7 +2,7 @@
   <div class="flex justify-between items-center mb-6">
     <h1 class="text-2xl font-bold">Print Queue</h1>
     <div>
-      <a href="<%= admin_applications_path %>" 
+      <a href="<%= admin_dashboard_path %>" 
          class="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
          data-turbo-frame="_top"
          aria-label="Return to applications dashboard">


### PR DESCRIPTION
The print queue link accidentally got dropped in the new dashboard redesign. Moved it back to upper right corner of screen so it's obvious when letters are awaiting printing.

<img width="1263" height="546" alt="Screenshot 2026-02-27 at 11 22 28 AM" src="https://github.com/user-attachments/assets/689bb6ad-6e07-4fc5-b667-b63dc2529d7a" />
