### PR TITLE
Redirect user to dashboard on sign up

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -115,11 +115,11 @@ class ApplicationController < ActionController::Base
 
   # Determines the appropriate dashboard path based on user type.
   def _dashboard_for(user)
-    case user
-    when Users::Administrator then admin_dashboard_path
-    when Users::Constituent then constituent_portal_dashboard_path
-    when Users::Evaluator then evaluators_dashboard_path
-    when Users::Vendor then vendor_portal_dashboard_path
+    case user.type
+    when 'Users::Administrator' then admin_dashboard_path
+    when 'Users::Constituent' then constituent_portal_dashboard_path
+    when 'Users::Evaluator' then evaluators_dashboard_path
+    when 'Users::Vendor' then vendor_portal_dashboard_path
     else root_path
     end
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -29,7 +29,8 @@ class RegistrationsController < ApplicationController
       track_sign_in
       send_registration_confirmation
 
-      redirect_to welcome_path, notice: 'Account created successfully. Welcome!'
+      @user.reload
+      redirect_to _dashboard_for(@user), notice: 'Account created successfully. Welcome!'
     else
       render :new, status: :unprocessable_content
     end

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -57,7 +57,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
       } }
     end
 
-    assert_redirected_to welcome_path
+    assert_redirected_to constituent_portal_dashboard_path
     assert_equal 'Account created successfully. Welcome!', flash[:notice]
 
     # Verify user was created correctly
@@ -91,7 +91,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     end
 
     # Should succeed and redirect
-    assert_redirected_to welcome_path
+    assert_redirected_to constituent_portal_dashboard_path
     assert_equal 'Account created successfully. Welcome!', flash[:notice]
 
     # Verify user was created correctly without disability flags set
@@ -206,7 +206,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     end
 
     # Should still redirect successfully
-    assert_redirected_to welcome_path
+    assert_redirected_to constituent_portal_dashboard_path
     assert_equal 'Account created successfully. Welcome!', flash[:notice]
 
     # Verify the new user was created AND flagged
@@ -273,7 +273,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, ActionMailer::Base.deliveries.size, 'Email should have been delivered'
 
     # Verify the registration was successful
-    assert_redirected_to welcome_path
+    assert_redirected_to constituent_portal_dashboard_path
     assert_equal 'Account created successfully. Welcome!', flash[:notice]
 
     # Verify user was created with expected attributes


### PR DESCRIPTION
Instead of directing new users to home, sends them directly to the dashboard.

- One note is that we could assume all new users are constitutents, but re-used _dashboard_for in case we ever do sign people up in a role.