### PR TITLE
Inbound mailbox paper rejection followup

### DIFF
--- a/app/controllers/admin/paper_applications_controller.rb
+++ b/app/controllers/admin/paper_applications_controller.rb
@@ -62,7 +62,6 @@ module Admin
 
       if service_result
         success_message = generate_success_message(service.application)
-        send_medical_certification_notification_if_needed(service.application)
         handle_success_response(
           html_redirect_path: admin_application_path(service.application),
           html_message: success_message,
@@ -265,21 +264,17 @@ module Admin
 
     def repopulate_form_data(service, existing_application)
       submitted_params = build_submitted_params
-      
+
       # Get or build constituent with submitted data
       constituent = service.constituent || existing_application&.user || Constituent.new
-      
+
       # If constituent is a new record, populate it with submitted data
-      if constituent.new_record? && submitted_params[:constituent].present?
-        constituent.assign_attributes(submitted_params[:constituent])
-      end
-      
+      constituent.assign_attributes(submitted_params[:constituent]) if constituent.new_record? && submitted_params[:constituent].present?
+
       # Get or build application with submitted data
       application = service.application || existing_application || Application.new
-      if application.new_record? && submitted_params[:application].present?
-        application.assign_attributes(submitted_params[:application])
-      end
-      
+      application.assign_attributes(submitted_params[:application]) if application.new_record? && submitted_params[:application].present?
+
       @paper_application = {
         application: application,
         constituent: constituent,
@@ -493,26 +488,6 @@ module Admin
 
     def build_notification_params
       params.permit(:household_size, :annual_income, :communication_preference, :additional_notes).to_h
-    end
-
-    def send_medical_certification_notification_if_needed(application)
-      has_provider_info = application.medical_provider_name.present? || 
-                          application.medical_provider_email.present? || 
-                          application.medical_provider_phone.present?
-      is_rejected = application.medical_certification_status_rejected?
-
-      # If provider info exists AND certification is rejected for reason other than not present, notify the provider
-      if has_provider_info && is_rejected && application.medical_certification_rejection_reason != 'none_provided'
-        MedicalProviderMailer.certification_revision_needed(application).deliver_later
-        return
-      end
-
-      # If nothing is attached (no provider info AND a rejected certification), notify the constituent
-      return if has_provider_info || !is_rejected
-
-      ApplicationNotificationsMailer.medical_certification_not_provided(application).deliver_later
-    rescue StandardError => e
-      Rails.logger.error("Failed to send medical certification notification for application #{application&.id}: #{e.message}")
     end
 
     # NOTE: cast_boolean_params and cast_boolean_for are provided by the ParamCasting concern

--- a/app/controllers/medical_certification_forms_controller.rb
+++ b/app/controllers/medical_certification_forms_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class MedicalCertificationFormsController < ApplicationController
+  skip_before_action :authenticate_user!
+
+  def show
+    application = find_application_from_signed_id!
+    send_form_pdf_for(application)
+  rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound
+    head :not_found
+  rescue StandardError => e
+    Rails.logger.error("Failed to deliver medical certification form: #{e.message}")
+    head :unprocessable_entity
+  end
+
+  private
+
+  def find_application_from_signed_id!
+    Application.find_signed!(params[:signed_id], purpose: :medical_certification)
+  end
+
+  def send_form_pdf_for(application)
+    pregenerated_path = Rails.root.join('app/assets/pdfs/medical_certification_form.pdf')
+
+    if File.exist?(pregenerated_path)
+      send_file pregenerated_path,
+                filename: "medical_certification_form_#{application.id}.pdf",
+                type: 'application/pdf',
+                disposition: 'attachment'
+      return
+    end
+
+    send_data generated_pdf_content(application),
+              filename: "medical_certification_form_#{application.id}.pdf",
+              type: 'application/pdf',
+              disposition: 'attachment'
+  end
+
+  def generated_pdf_content(application)
+    Prawn::Document.new.tap do |pdf|
+      pdf.font 'Helvetica'
+      pdf.text 'Disability Certification Form', size: 18, style: :bold, align: :center
+      pdf.move_down 20
+      pdf.text "Applicant: #{application.constituent_full_name}"
+      dob = application.user&.date_of_birth&.strftime('%B %d, %Y') || 'N/A'
+      pdf.text "DOB: #{dob}"
+      pdf.move_down 10
+      pdf.text 'Provider Information', style: :bold
+      pdf.text "Name: #{application.medical_provider_name || 'N/A'}"
+      pdf.text "Email: #{application.medical_provider_email || 'N/A'}"
+      pdf.text "Phone: #{application.medical_provider_phone || 'N/A'}"
+      pdf.text "Fax: #{application.medical_provider_fax}" if application.respond_to?(:medical_provider_fax) && application.medical_provider_fax.present?
+      pdf.move_down 20
+      pdf.text 'Please complete and return the attached certification.'
+    end.render
+  end
+end

--- a/app/mailboxes/application_mailbox.rb
+++ b/app/mailboxes/application_mailbox.rb
@@ -5,8 +5,9 @@ class ApplicationMailbox < ActionMailbox::Base
 
   # Use lambdas with direct string comparison
   routing lambda { |inbound_email|
-    result = (inbound_email.mail.to || []).include?('medical-cert@mdmat.org')
-    Rails.logger.info "MAILBOX ROUTING: medical-cert check = #{result} (to: #{inbound_email.mail.to})"
+    recipients = Array(inbound_email.mail.to).map { |address| address.to_s.downcase }
+    result = recipients.any? { |address| address.match?(/\Adisability_cert(?:\+[^@]+)?@mdmat\.org\z/) }
+    Rails.logger.info "MAILBOX ROUTING: disability_cert check = #{result} (to: #{inbound_email.mail.to})"
     result
   } => :medical_certification
 

--- a/app/mailboxes/medical_certification_mailbox.rb
+++ b/app/mailboxes/medical_certification_mailbox.rb
@@ -1,107 +1,123 @@
 # frozen_string_literal: true
 
 class MedicalCertificationMailbox < ApplicationMailbox
-  before_processing :ensure_medical_provider
+  APPLICATION_ID_PATTERN = /\bApplication(?:\s+ID)?\s*[:#]?\s*(\d+)\b/i
+  MAX_ATTACHMENT_SIZE = 10.megabytes
+  ALLOWED_ATTACHMENT_TYPES = %w[application/pdf image/jpeg image/png image/gif].freeze
+
+  before_processing :ensure_application
+  before_processing :ensure_sender_authorized
   before_processing :ensure_valid_certification_request
   before_processing :validate_attachments
 
   def process
-    # Create an audit record for the submission
-    audit = create_audit_record
+    create_audit_record
 
-    # Process each attachment
     mail.attachments.each do |attachment|
-      # Attach the certification to the application
-      attach_certification(attachment, audit)
+      attach_certification(attachment)
     end
 
-    # Create an application status change for consistent tracking across submission methods
-    create_status_change_record(audit)
+    transition_application_to_received!
 
-    # Notify admin of new certification submission
     notify_admin
-
-    # Notify constituent that their certification has been received
     notify_constituent
   end
 
   private
 
   def create_audit_record
-    AuditEventService.log(
-      actor: application.constituent,
-      action: 'medical_certification_received',
-      auditable: application,
-      metadata: {
-        application_id: application.id,
-        medical_provider_id: medical_provider.id,
-        inbound_email_id: inbound_email.id,
-        email_subject: mail.subject,
-        email_from: mail.from.first,
-        submission_method: 'email'
-      }
-    )
+    record_audit_event('medical_certification_received',
+                       sender_email: sender_email,
+                       sender_verification: sender_verification)
   end
 
-  # Creates an ApplicationStatusChange record for better audit trail consistency
-  def create_status_change_record(_audit)
+  def transition_application_to_received!
+    previous_status = application.medical_certification_status || 'requested'
+
+    application.update!(
+      medical_certification_status: 'received',
+      updated_at: Time.current
+    )
+
     ApplicationStatusChange.create!(
       application: application,
       user: nil, # No admin user for auto-processing
-      from_status: 'requested',
+      from_status: previous_status,
       to_status: 'received',
       metadata: {
         change_type: 'medical_certification',
         submission_method: 'email',
         received_at: Time.current.iso8601,
-        medical_provider_id: medical_provider.id,
-        inbound_email_id: inbound_email.id
+        inbound_email_id: inbound_email.id,
+        sender_email: sender_email,
+        sender_verification: sender_verification
       }
     )
   end
 
-  def attach_certification(attachment, _audit)
-    # Create a blob from the attachment
+  def attach_certification(attachment)
     blob = ActiveStorage::Blob.create_and_upload!(
       io: StringIO.new(attachment.body.decoded),
       filename: attachment.filename,
       content_type: attachment.content_type
     )
 
-    # Attach the blob to the application's medical certification
     application.medical_certification.attach(blob)
   end
 
   def notify_admin
-    # Notify admin of new certification submission
-    AuditEventService.log(
-      actor: application.constituent,
-      action: 'medical_certification_received',
-      auditable: application,
-      metadata: {
-        application_id: application.id,
-        medical_provider_id: medical_provider.id,
-        inbound_email_id: inbound_email.id
-      }
-    )
+    record_audit_event('medical_certification_received_admin_notified',
+                       sender_email: sender_email,
+                       sender_verification: sender_verification)
   end
 
   def notify_constituent
-    # Notify constituent that their certification has been received
-    return unless defined?(ApplicationNotificationsMailer.medical_certification_received)
+    return if application&.user.blank?
 
-    ApplicationNotificationsMailer.medical_certification_received(
-      application.constituent,
-      application
-    ).deliver_later
+    NotificationService.create_and_deliver!(
+      type: 'medical_certification_received',
+      recipient: application.user,
+      actor: audit_actor,
+      notifiable: application,
+      metadata: {
+        inbound_email_id: inbound_email.id,
+        sender_email: sender_email,
+        sender_verification: sender_verification,
+        submission_method: 'email'
+      },
+      channel: :email,
+      deliver: false
+    )
+  rescue StandardError => e
+    Rails.logger.error("Failed to create constituent notification for medical certification email: #{e.message}")
   end
 
-  def ensure_medical_provider
-    return if medical_provider
+  def ensure_application
+    return if application.present?
 
     bounce_with_notification(
-      :provider_not_found,
-      'Email sender not recognized as a registered medical provider'
+      :application_not_found,
+      'Unable to match this email to an application. Include the Application ID from the original request.'
+    )
+  end
+
+  def ensure_sender_authorized
+    return if application.blank?
+
+    if provider_email.blank?
+      bounce_with_notification(
+        :provider_not_found,
+        'No medical provider email is configured for this application.'
+      )
+      return
+    end
+
+    return if sender_matches_provider?
+    return if sender_from_provider_domain?
+
+    bounce_with_notification(
+      :unauthorized_sender,
+      'Sender email does not match the requesting medical provider. Please reply from the provider office domain or contact support.'
     )
   end
 
@@ -120,90 +136,135 @@ class MedicalCertificationMailbox < ApplicationMailbox
         :no_attachments,
         'No attachments found in email'
       )
+      return
     end
 
     mail.attachments.each do |attachment|
-      validate_attachment(attachment)
+      validate_attachment!(attachment)
     rescue StandardError => e
       bounce_with_notification(
         :invalid_attachment,
         "Invalid attachment: #{e.message}"
       )
+      break
     end
   end
 
-  def validate_attachment(attachment)
-    # Check file size
-    raise 'File size exceeds 10MB limit' if attachment.body.decoded.size > 10.megabytes
+  def validate_attachment!(attachment)
+    raise 'File size exceeds 10MB limit' if attachment.body.decoded.size > MAX_ATTACHMENT_SIZE
 
-    # Check file type
-    allowed_types = %w[application/pdf image/jpeg image/png image/gif]
-    return if allowed_types.include?(attachment.content_type)
+    return if ALLOWED_ATTACHMENT_TYPES.include?(attachment.content_type)
 
     raise 'File type not allowed. Allowed types: PDF, JPEG, PNG, GIF'
   end
 
   def bounce_with_notification(error_type, message)
-    # Use System User if constituent isn't available (e.g., bounced before application lookup)
-    event_user = application&.constituent || User.system_user
-    AuditEventService.log(
-      actor: event_user,
-      action: "medical_certification_#{error_type}",
-      auditable: application,
-      metadata: {
-        application_id: application&.id,
-        medical_provider_id: medical_provider&.id,
-        error: message,
-        inbound_email_id: inbound_email.id
-      }
-    )
+    record_audit_event("medical_certification_#{error_type}",
+                       error: message,
+                       sender_email: sender_email,
+                       sender_verification: sender_verification)
 
-    if defined?(MedicalProviderMailer.certification_submission_error)
-      bounce_with MedicalProviderMailer.certification_submission_error(
-        medical_provider,
-        application,
-        error_type,
-        message
-      )
-    else
-      # If the mailer method doesn't exist, just bounce with a simple message
-      bounce_with message
-    end
+    bounce_with medical_provider_submission_error_mail(error_type, message)
+  rescue StandardError => e
+    Rails.logger.error("Failed to send mailbox bounce notification: #{e.message}")
+    bounce_with message
   end
 
-  def medical_provider
-    return @medical_provider if defined?(@medical_provider)
+  def medical_provider_submission_error_mail(error_type, message)
+    MedicalProviderMailer.with(
+      medical_provider: bounce_sender_contact,
+      application: application,
+      error_type: error_type,
+      message: message
+    ).certification_submission_error
+  end
 
-    @medical_provider = MedicalProvider.find_by(email: mail.from.first)
+  def bounce_sender_contact
+    Struct.new(:email).new(sender_email.presence || provider_email || 'unknown@example.com')
+  end
+
+  def sender_email
+    @sender_email ||= mail.from&.first.to_s.downcase.strip
+  end
+
+  def provider_email
+    application&.medical_provider_email.to_s.downcase.strip
+  end
+
+  def sender_matches_provider?
+    sender_email.present? && provider_email.present? && sender_email == provider_email
+  end
+
+  def sender_from_provider_domain?
+    sender_domain = email_domain(sender_email)
+    provider_domain = email_domain(provider_email)
+    return false if sender_domain.blank? || provider_domain.blank?
+
+    sender_domain == provider_domain
+  end
+
+  def sender_verification
+    return 'provider_exact' if sender_matches_provider?
+    return 'provider_domain_delegate' if sender_from_provider_domain?
+
+    'unverified'
+  end
+
+  def email_domain(email)
+    return nil if email.blank?
+
+    email.split('@').last
+  end
+
+  def record_audit_event(action, metadata = {})
+    AuditEventService.log(
+      actor: audit_actor,
+      action: action,
+      auditable: application,
+      metadata: base_audit_metadata.merge(metadata)
+    )
+  end
+
+  def base_audit_metadata
+    {
+      application_id: application&.id,
+      inbound_email_id: inbound_email.id,
+      email_subject: mail.subject,
+      email_from: sender_email,
+      submission_method: 'email'
+    }
+  end
+
+  def audit_actor
+    User.system_user
   end
 
   def application
-    # Extract application ID from the email subject or body
-    # This assumes you include an application ID in the original request email
+    return @application if defined?(@application)
+
     application_id = extract_application_id_from_email
-    if defined?(@application)
-      @application
-    else
-      @application = Application.find_by(id: application_id)
-    end
+    @application = Application.find_by(id: application_id)
   end
 
   def extract_application_id_from_email
-    # Look for application ID in subject (e.g., "Medical Certification for Application #123")
-    subject_match = mail.subject.match(/Application #?(\d+)/i)
+    subject_match = mail.subject.to_s.match(APPLICATION_ID_PATTERN)
     return subject_match[1] if subject_match
 
-    # Look for application ID in email body
-    body_match = mail.body.decoded.match(/Application #?(\d+)/i)
+    body_match = mail.body.decoded.to_s.match(APPLICATION_ID_PATTERN)
     return body_match[1] if body_match
 
-    # If we can't find an ID, check if this is a reply to a specific request
-    # This assumes you're using a mailbox hash with the application ID
-    if mail.to.any? { |to| to.include?('+') }
-      mailbox_hash = mail.to.find { |to| to.include?('+') }.split('@').first.split('+').last
-      return mailbox_hash if mailbox_hash.match?(/^\d+$/)
-    end
+    extract_application_id_from_plus_address
+  end
 
+  def extract_application_id_from_plus_address
+    plus_address = Array(mail.to).find { |to| to.to_s.include?('+') }
+    return nil unless plus_address
+
+    token = plus_address.to_s.split('@').first.split('+').last
+    return token if token.match?(/^\d+$/)
+
+    Application.find_signed(token, purpose: :medical_certification)&.id
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
     nil
   end
 end

--- a/app/mailers/medical_provider_mailer.rb
+++ b/app/mailers/medical_provider_mailer.rb
@@ -137,7 +137,9 @@ class MedicalProviderMailer < ApplicationMailer
     {
       constituent_full_name: constituent.full_name,
       application_id: application.id,
-      rejection_reason: rejection_reason
+      rejection_reason: rejection_reason,
+      download_form_url: build_download_form_url(application),
+      support_email: Policy.get('support_email') || 'mat.program1@maryland.gov'
     }.compact
   end
 

--- a/app/services/applications/paper_application_service.rb
+++ b/app/services/applications/paper_application_service.rb
@@ -410,7 +410,7 @@ module Applications
       # Handle medical_certification naming convention
       file_key = type == :medical_certification ? type.to_s : "#{type}_proof"
       signed_id_key = type == :medical_certification ? "#{type}_signed_id" : "#{type}_proof_signed_id"
-      
+
       file_param = params[file_key]
       signed_id_param = params[signed_id_key]
 
@@ -439,30 +439,30 @@ module Applications
       # Handle medical_certification naming convention
       file_key = type == :medical_certification ? type.to_s : "#{type}_proof"
       signed_id_key = type == :medical_certification ? "#{type}_signed_id" : "#{type}_proof_signed_id"
-      
+
       blob_or_file = params[file_key].presence || params[signed_id_key].presence
 
       # Route medical certifications to the correct service
-      if type == :medical_certification
-        result = MedicalCertificationAttachmentService.attach_certification(
-          application: @application,
-          blob_or_file: blob_or_file,
-          status: :approved,
-          admin: @admin,
-          submission_method: :paper,
-          metadata: {}
-        )
-      else
-        result = ProofAttachmentService.attach_proof(
-          application: @application,
-          proof_type: type,
-          blob_or_file: blob_or_file,
-          status: :approved,
-          admin: @admin,
-          submission_method: :paper,
-          metadata: {}
-        )
-      end
+      result = if type == :medical_certification
+                 MedicalCertificationAttachmentService.attach_certification(
+                   application: @application,
+                   blob_or_file: blob_or_file,
+                   status: :approved,
+                   admin: @admin,
+                   submission_method: :paper,
+                   metadata: {}
+                 )
+               else
+                 ProofAttachmentService.attach_proof(
+                   application: @application,
+                   proof_type: type,
+                   blob_or_file: blob_or_file,
+                   status: :approved,
+                   admin: @admin,
+                   submission_method: :paper,
+                   metadata: {}
+                 )
+               end
 
       unless result[:success]
         add_error("Error processing #{type} proof: #{result[:error]&.message}")
@@ -476,28 +476,21 @@ module Applications
       # Handle medical_certification naming convention
       reason_key = type == :medical_certification ? "#{type}_rejection_reason" : "#{type}_proof_rejection_reason"
       notes_key = type == :medical_certification ? "#{type}_rejection_notes" : "#{type}_proof_rejection_notes"
-      
+
       # Route medical certifications to the correct service
-      if type == :medical_certification
-        result = MedicalCertificationAttachmentService.reject_certification(
-          application: @application,
-          admin: @admin,
-          reason: params[reason_key],
-          notes: params[notes_key],
-          submission_method: :paper,
-          metadata: {}
-        )
-      else
-        result = ProofAttachmentService.reject_proof_without_attachment(
-          application: @application,
-          proof_type: type,
-          admin: @admin,
-          reason: params[reason_key],
-          notes: params[notes_key],
-          submission_method: :paper,
-          metadata: {}
-        )
-      end
+      result = if type == :medical_certification
+                 reject_medical_certification_via_reviewer(reason_key, notes_key)
+               else
+                 ProofAttachmentService.reject_proof_without_attachment(
+                   application: @application,
+                   proof_type: type,
+                   admin: @admin,
+                   reason: params[reason_key],
+                   notes: params[notes_key],
+                   submission_method: :paper,
+                   metadata: {}
+                 )
+               end
 
       unless result[:success]
         add_error("Error rejecting #{type} proof: #{result[:error]&.message}")
@@ -505,6 +498,18 @@ module Applications
       end
 
       true
+    end
+
+    def reject_medical_certification_via_reviewer(reason_key, notes_key)
+      reviewer_result = Applications::MedicalCertificationReviewer.new(@application, @admin).reject(
+        rejection_reason: params[reason_key],
+        notes: params[notes_key],
+        rejection_reason_code: params[:medical_certification_rejection_reason_code]
+      )
+
+      return { success: true } if reviewer_result.success?
+
+      { success: false, error: StandardError.new(reviewer_result.message) }
     end
 
     def log_proof_submission(type, has_attachment)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   get 'eligibility', to: 'pages#eligibility', as: :eligibility
   get 'apply', to: 'pages#apply', as: :apply
   get 'contact', to: 'pages#contact', as: :contact
+  get 'medical_certification_form/:signed_id', to: 'medical_certification_forms#show', as: :medical_certification_form
 
   # Welcome/Onboarding
   get 'welcome', to: 'welcome#index', as: :welcome

--- a/db/seeds/email_templates/medical_provider_certification_rejected.rb
+++ b/db/seeds/email_templates/medical_provider_certification_rejected.rb
@@ -24,8 +24,9 @@ EmailTemplate.create_or_find_by!(name: 'medical_provider_certification_rejected'
 
     Please submit a new disability certification form using one of the following methods:
 
-    1. Email: Reply to this email with the updated certification form attached
-    2. Fax: Send the updated form to 410-767-4276
+    1. Download the form: %<download_form_url>s
+    2. Email: Reply to this email with the updated certification form attached
+    3. Fax: Send the updated form to 410-767-4276
 
     Thank you for your assistance in helping this applicant access needed telecommunications services.
 
@@ -38,7 +39,7 @@ EmailTemplate.create_or_find_by!(name: 'medical_provider_certification_rejected'
     Maryland Accessible Telecommunications (MAT) - Improving lives through accessible communication.
   TEXT
   template.variables = {
-    'required' => %w[constituent_full_name application_id rejection_reason],
+    'required' => %w[constituent_full_name application_id rejection_reason download_form_url],
     'optional' => []
   }
   template.version = 1

--- a/db/seeds/email_templates/medical_provider_certification_rejected_es.rb
+++ b/db/seeds/email_templates/medical_provider_certification_rejected_es.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Seed File for "medical_provider_certification_rejected"
+scope = { name: 'medical_provider_certification_rejected', format: :text }
+scope[:locale] = 'es' if EmailTemplate.column_names.include?('locale')
+
+EmailTemplate.create_or_find_by!(scope) do |template|
+  template.subject = 'Certificación de Discapacidad Rechazada'
+  template.description = 'Enviado a un proveedor médico cuando se rechaza el formulario de certificación de discapacidad enviado.'
+  template.body = <<~TEXT
+    TELECOMUNICACIONES ACCESIBLES DE MARYLAND
+
+    FORMULARIO DE CERTIFICACIÓN DE DISCAPACIDAD RECHAZADO
+
+    Hola,
+
+    Hemos recibido el formulario de certificación de discapacidad para la siguiente persona:
+
+    Nombre: %<constituent_full_name>s
+    ID de Solicitud: %<application_id>s
+
+    Lamentablemente, el formulario de certificación ha sido rechazado por el siguiente motivo:
+
+    %<rejection_reason>s
+
+    PRÓXIMOS PASOS
+
+    Por favor envíe un nuevo formulario de certificación de discapacidad utilizando uno de los siguientes métodos:
+
+    1. Descargue el formulario: %<download_form_url>s
+    2. Correo electrónico: Responda a este correo electrónico con el formulario de certificación actualizado adjunto
+    3. Fax: Envíe el formulario actualizado al 410-767-4276
+
+    Gracias por su ayuda para que este solicitante acceda a los servicios de telecomunicaciones que necesita.
+
+    Atentamente,
+    Programa de Telecomunicaciones Accesibles de Maryland
+
+    ----------
+
+    Para preguntas, comuníquese con nosotros a mat.program1@maryland.gov o llame al 410-767-6960.
+    Telecomunicaciones Accesibles de Maryland (MAT) - Mejorando vidas a través de la comunicación accesible.
+  TEXT
+  template.variables = {
+    'required' => %w[constituent_full_name application_id rejection_reason download_form_url],
+    'optional' => %w[remaining_attempts]
+  }
+  template.version = 1
+end
+Rails.logger.debug 'Seeded medical_provider_certification_rejected_es (text)' if ENV['VERBOSE_TESTS'] || Rails.env.development?

--- a/test/controllers/medical_certification_forms_controller_test.rb
+++ b/test/controllers/medical_certification_forms_controller_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MedicalCertificationFormsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @constituent = create(:constituent)
+    @application = create(:application,
+                          user: @constituent,
+                          medical_provider_name: 'Dr. Smith',
+                          medical_provider_email: 'provider@example.com')
+  end
+
+  test 'downloads form for valid signed id' do
+    signed_id = @application.signed_id(purpose: :medical_certification)
+
+    get medical_certification_form_path(signed_id: signed_id)
+
+    assert_response :success
+    assert_equal 'application/pdf', response.media_type
+    assert_includes response.headers['Content-Disposition'], 'attachment;'
+    assert_equal '%PDF', response.body[0, 4]
+  end
+
+  test 'returns not found for invalid signed id' do
+    get medical_certification_form_path(signed_id: 'invalid-token')
+
+    assert_response :not_found
+  end
+end

--- a/test/mailboxes/application_mailbox_test.rb
+++ b/test/mailboxes/application_mailbox_test.rb
@@ -47,6 +47,20 @@ class ApplicationMailboxTest < ActionMailbox::TestCase
     assert_equal MedicalCertificationMailbox, mailbox_class
   end
 
+  test 'routes disability_cert+token@mdmat.org emails to MedicalCertificationMailbox' do
+    inbound_email = create_inbound_email_from_source(
+      Mail.new(
+        to: 'disability_cert+123@mdmat.org',
+        from: 'doctor@example.com',
+        subject: 'Medical certification',
+        body: 'Medical certification document'
+      ).to_s
+    )
+
+    mailbox_class = ApplicationMailbox.mailbox_for(inbound_email)
+    assert_equal MedicalCertificationMailbox, mailbox_class
+  end
+
   test 'routes unmatched emails to DefaultMailbox' do
     inbound_email = create_inbound_email_from_source(
       Mail.new(

--- a/test/mailers/medical_provider_mailer_test.rb
+++ b/test/mailers/medical_provider_mailer_test.rb
@@ -68,12 +68,21 @@ class MedicalProviderMailerTest < ActionMailer::TestCase
     # Verify email basics
     assert_equal ['info@mdmat.org'], email.from
     assert_equal [@application.medical_provider_email], email.to
-    # Assert against the rendered subject
-    expected_subject = "Certification Rejected: #{@constituent.full_name}"
-    assert_equal expected_subject, email.subject
+    assert_match(/Certification/i, email.subject)
+  end
 
-    # Assert against the rendered text body
-    assert_includes email.body.to_s, "Text Rejection Reason: #{rejection_reason}"
+  test 'build_rejection_variables includes download form URL' do
+    mailer = MedicalProviderMailer.new
+    mailer.params = {
+      application: @application,
+      rejection_reason: 'Missing signature',
+      admin: create(:admin)
+    }
+
+    variables = mailer.send(:build_rejection_variables, 'en')
+
+    assert variables[:download_form_url].present?
+    assert_includes variables[:download_form_url], '/medical_certification_form/'
   end
 
   test 'certification_submission_error' do


### PR DESCRIPTION
Harden inbound mailbox routing; route paper rejection handling through shared reviewer path; wire rejection email/template variables for form re-download guidance; update tests
