### PR TITLE
Remove user status from trainer, evaluator

### DIFF
--- a/app/models/concerns/status_management.rb
+++ b/app/models/concerns/status_management.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module StatusManagement
+  extend ActiveSupport::Concern
+
+  included do
+    enum :status, {
+      requested: 0,
+      scheduled: 1,
+      confirmed: 2,
+      completed: 3,
+      cancelled: 4,
+      rescheduled: 5,
+      no_show: 6
+    }, prefix: true, validate: true
+
+    scope :active, -> { where(status: %i[scheduled confirmed]) }
+    scope :pending, -> { where(status: %i[scheduled confirmed]) }
+    scope :completed_sessions, -> { where(status: :completed) }
+    scope :needing_followup, -> { where(status: %i[no_show cancelled]) }
+    scope :requested_items, -> { where(status: :requested) }
+  end
+
+  def active?
+    status_scheduled? || status_confirmed?
+  end
+
+  def complete?
+    status_completed?
+  end
+
+  def needs_followup?
+    status_no_show? || status_cancelled?
+  end
+
+  def can_reschedule?
+    status_cancelled? || status_no_show?
+  end
+
+  def can_cancel?
+    status_scheduled? || status_confirmed?
+  end
+
+  def can_complete?
+    status_scheduled? || status_confirmed?
+  end
+
+  def rescheduling?
+    return false unless persisted?
+
+    # Get the date field name for this model
+    date_field = self.class.status_management_date_field
+    return false unless date_field
+
+    # Only consider it rescheduling if:
+    # 1. The date is changing AND
+    # 2. We're staying in a scheduled state (not completing or cancelling)
+    return true if send("#{date_field}_changed?") && status_scheduled? && !status_changed?
+
+    # Or if we're explicitly changing TO rescheduled status
+    return true if status_changed? && status_rescheduled?
+
+    false
+  end
+
+  class_methods do
+    def status_management_date_field(field_name = nil)
+      if field_name
+        @status_management_date_field = field_name
+      else
+        @status_management_date_field
+      end
+    end
+  end
+end

--- a/app/models/users/evaluator.rb
+++ b/app/models/users/evaluator.rb
@@ -7,8 +7,13 @@ module Users
              through: :evaluations,
              source: :constituent
 
-    enum :status, { inactive: 0, active: 1, suspended: 2 }, default: :inactive, prefix: true
-
-    scope :available, -> { where(status: :active) }
+    scope :available, -> {
+      left_outer_joins(:role_capabilities)
+        .where(
+          "users.type IN (?) OR role_capabilities.capability = ?",
+          ['Users::Evaluator', 'Users::Administrator'],
+          'can_evaluate'
+        )
+    }
   end
 end

--- a/app/models/users/trainer.rb
+++ b/app/models/users/trainer.rb
@@ -7,8 +7,13 @@ module Users
              through: :training_sessions,
              source: :constituent
 
-    enum :status, { inactive: 0, active: 1, suspended: 2 }, default: :inactive, prefix: true
-
-    scope :available, -> { where(status: :active) }
+    scope :available, -> {
+      left_outer_joins(:role_capabilities)
+        .where(
+          "users.type IN (?) OR role_capabilities.capability = ?",
+          ['Users::Trainer', 'Users::Administrator'],
+          'can_train'
+        )
+    }
   end
 end


### PR DESCRIPTION
Removes reference to user status from Trainer and Evaluator Models, and includes role capabilities.