### PR TITLE
Add lifecycle characterization tests; fix log_status_change ivar leak

### DIFF
--- a/app/controllers/webhooks/medical_certifications_controller.rb
+++ b/app/controllers/webhooks/medical_certifications_controller.rb
@@ -9,7 +9,6 @@ module Webhooks
       )
 
       certification = create_certification(application)
-      notify_admins(certification)
 
       head :ok
     rescue ActiveRecord::RecordNotFound
@@ -25,40 +24,34 @@ module Webhooks
     end
 
     def create_certification(application)
-      ApplicationRecord.transaction do
-        # Attach the certification document
-        document = URI.open(params[:document_url])
-        application.medical_certification.attach(
-          io: document,
-          filename: "certification-#{application.id}.pdf"
+      document = URI.open(params[:document_url])
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: document,
+        filename: params[:original_filename].presence || "certification-#{application.id}.pdf",
+        content_type: 'application/pdf'
+      )
+
+      MedicalCertificationAttachmentService.attach_certification(
+        application: application,
+        blob_or_file: blob,
+        status: :received,
+        admin: User.system_user,
+        submission_method: :webhook,
+        metadata: certification_metadata
+      )
+
+      AuditEventService.log(
+        actor: User.system_user,
+        action: 'medical_certification_received',
+        auditable: application,
+        metadata: certification_metadata.merge(
+          application_id: application.id,
+          submission_method: 'webhook'
         )
+      )
 
-        # Update application status
-        application.update!(
-          medical_certification_status: :received,
-          last_activity_at: Time.current
-        )
-
-        # Create an audit trail
-        CertificationSubmissionAudit.create!(
-          application: application,
-          provider_email: provider_email,
-          provider_name: params[:provider_name],
-          submission_method: 'webhook',
-          metadata: certification_metadata
-        )
-
-        # Return the updated application
-        application
-      end
-    end
-
-    def notify_admins(certification)
-      AdminNotifier.new(
-        subject: 'New Disability Certification Received',
-        message: "Disability certification received for Application ##{certification.id}",
-        level: :info
-      ).notify_all
+      application.update!(last_activity_at: Time.current)
+      application
     end
 
     def provider_email

--- a/app/mailboxes/medical_certification_mailbox.rb
+++ b/app/mailboxes/medical_certification_mailbox.rb
@@ -11,20 +11,28 @@ class MedicalCertificationMailbox < ApplicationMailbox
   before_processing :validate_attachments
 
   def process
-    create_audit_record
+    # Application has a single medical_certification attachment, so we treat the
+    # first valid attachment as the canonical submission for this email.
+    attachment = mail.attachments.first
 
-    mail.attachments.each do |attachment|
-      attach_certification(attachment)
-    end
+    MedicalCertificationAttachmentService.attach_certification(
+      application: application,
+      blob_or_file: build_blob_from_attachment(attachment),
+      status: :received,
+      admin: User.system_user,
+      submission_method: :email,
+      metadata: certification_metadata
+    )
 
-    transition_application_to_received!
-
-    notify_admin
-    notify_constituent
+    AuditEventService.log(
+      actor: User.system_user,
+      action: 'medical_certification_received',
+      auditable: application,
+      metadata: certification_metadata
+    )
   end
 
   private
-
   def create_audit_record
     record_audit_event('medical_certification_received',
                        sender_email: sender_email,
@@ -222,6 +230,10 @@ class MedicalCertificationMailbox < ApplicationMailbox
     User.system_user
   end
 
+  def medical_provider
+    @medical_provider = MedicalProvider.find_by_email(mail.from.first)
+  end
+
   def application
     return @application if defined?(@application)
 
@@ -249,5 +261,24 @@ class MedicalCertificationMailbox < ApplicationMailbox
     Application.find_signed(token, purpose: :medical_certification)&.id
   rescue ActiveSupport::MessageVerifier::InvalidSignature
     nil
+  end
+
+  def build_blob_from_attachment(attachment)
+    ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new(attachment.body.decoded),
+      filename: attachment.filename,
+      content_type: attachment.content_type
+    )
+  end
+
+  def certification_metadata
+    {
+      application_id: application.id,
+      medical_provider_id: medical_provider.id,
+      inbound_email_id: inbound_email.id,
+      email_subject: mail.subject,
+      email_from: mail.from.first,
+      submission_method: 'email'
+    }
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -415,19 +415,20 @@ class Application < ApplicationRecord
   private
 
   def log_status_change
-    # Guard clause to prevent infinite recursion
     return if @logging_status_change
 
-    # Use pending user/notes from deprecated update_status, or fall back to Current.user
     acting_user = @pending_status_change_user || Current.user || user
     status_notes = @pending_status_change_notes
 
-    return if acting_user.blank?
+    if acting_user.blank?
+      @pending_status_change_user = nil
+      @pending_status_change_notes = nil
+      return
+    end
 
     @logging_status_change = true
 
     begin
-      # Create ApplicationStatusChange record for audit logs
       status_changes.create!(
         from_status: status_before_last_save,
         to_status: status,
@@ -435,7 +436,6 @@ class Application < ApplicationRecord
         notes: status_notes
       )
 
-      # Also create Event record for other audit purposes
       AuditEventService.log(
         action: 'application_status_changed',
         actor: acting_user,
@@ -452,7 +452,6 @@ class Application < ApplicationRecord
       Rails.logger.error "Failed to log status change for application #{id}: #{e.message}"
     ensure
       @logging_status_change = false
-      # Clear pending attributes after use
       @pending_status_change_user = nil
       @pending_status_change_notes = nil
     end

--- a/test/controllers/admin/dashboard_controller_test.rb
+++ b/test/controllers/admin/dashboard_controller_test.rb
@@ -8,6 +8,7 @@ module Admin
       # Use factory and standard helper for authentication
       @admin = create(:admin)
       sign_in_as(@admin)
+      Rails.cache.clear
 
       # Create applications with different statuses for testing
       @draft_app = create(:application, :draft, user: create(:constituent, email: "draft#{@admin.email}"))
@@ -124,7 +125,56 @@ module Admin
                       "Application #{application_id} should be included in the filtered results"
     end
 
+    def test_dashboard_training_requests_count_falls_back_to_sessions_when_notifications_absent
+      clear_training_request_sources
+
+      trainer = create(:trainer)
+      session_app = create(:application, :approved, user: create(:constituent, email: "session_only#{@admin.email}"))
+      TrainingSession.create!(
+        application: session_app,
+        trainer: trainer,
+        scheduled_for: 1.day.from_now,
+        status: :requested
+      )
+
+      get admin_dashboard_path
+      assert_response :success
+
+      assert_equal 1, assigns(:metrics)[:training_requests_count],
+                   'Dashboard should fall back to pending training sessions when no notifications exist'
+    end
+
+    def test_dashboard_training_requests_count_prefers_notifications_over_sessions
+      clear_training_request_sources
+
+      notification_app = create(:application, :approved, user: create(:constituent, email: "notification_only#{@admin.email}"))
+      session_app = create(:application, :approved, user: create(:constituent, email: "session_ignored#{@admin.email}"))
+      trainer = create(:trainer)
+
+      Notification.create!(
+        action: 'training_requested',
+        notifiable: notification_app,
+        recipient: @admin,
+        actor: notification_app.user,
+        metadata: { application_id: notification_app.id }
+      )
+
+      TrainingSession.create!(
+        application: session_app,
+        trainer: trainer,
+        scheduled_for: 1.day.from_now,
+        status: :requested
+      )
+
+      get admin_dashboard_path
+      assert_response :success
+
+      assert_equal 1, assigns(:metrics)[:training_requests_count],
+                   'Dashboard should count notification-backed requests and ignore session-only apps when notifications exist'
+    end
+
     def teardown
+      Rails.cache.clear
       Current.reset if defined?(Current) && Current.respond_to?(:reset)
     end
 
@@ -159,6 +209,7 @@ module Admin
     def setup_training_requests
       # Clear any existing training request notifications to start fresh.
       Notification.where(action: 'training_requested').delete_all
+      Rails.cache.clear
 
       # Create exactly 4 training request notifications with unique applications.
       4.times do |i|
@@ -183,6 +234,12 @@ module Admin
                    'Database should have 4 distinct applications with training requests'
       assert_equal 4, assigns(:metrics)[:training_requests_count],
                    'Controller should assign 4 training requests'
+    end
+
+    def clear_training_request_sources
+      Notification.where(action: 'training_requested').delete_all
+      TrainingSession.where(status: %i[requested scheduled confirmed]).delete_all
+      Rails.cache.clear
     end
   end
 end

--- a/test/controllers/admin/scanned_proofs_controller_test.rb
+++ b/test/controllers/admin/scanned_proofs_controller_test.rb
@@ -27,18 +27,29 @@ module Admin
     def test_creates_proof_with_valid_parameters
       # Clear events before the test to ensure we only count events from this test
       Event.delete_all
+      clear_enqueued_jobs
 
-      assert_difference 'Event.count', 1 do # Expect one event from ProofAttachmentService
-        post admin_application_scanned_proofs_path(@application),
-             params: {
-               proof_type: 'income',
-               file: @file
-             },
-             headers: default_headers
+      assert_no_difference -> { Notification.where(notifiable: @application, action: 'income_proof_attached').count } do
+        assert_no_difference -> { Notification.where(notifiable: @application, action: 'proof_submitted').count } do
+          assert_enqueued_jobs 1, only: ActionMailer::MailDeliveryJob do
+            assert_difference 'Event.count', 1 do # Controller creates one proof_submitted event; service audit event is skipped
+              post admin_application_scanned_proofs_path(@application),
+                   params: {
+                     proof_type: 'income',
+                     file: @file
+                   },
+                   headers: default_headers
+            end
+          end
+        end
       end
 
+      @application.reload
+
       # Verify the application has the proof attached first
-      assert @application.reload.income_proof.attached?, 'Proof was not attached to the application'
+      assert @application.income_proof.attached?, 'Proof was not attached to the application'
+      assert_equal 'approved', @application.income_proof_status
+      assert_nil @application.needs_review_since, 'Approved scanned proofs should not set needs_review_since'
 
       # Verify the redirect
       assert_redirected_to admin_application_path(@application)

--- a/test/integration/application_ingress_characterization_test.rb
+++ b/test/integration/application_ingress_characterization_test.rb
@@ -1,0 +1,389 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'open-uri'
+require 'support/action_mailbox_test_helper'
+
+class ApplicationIngressCharacterizationTest < ActionDispatch::IntegrationTest
+  include ActionDispatch::TestProcess::FixtureFile
+  include ActionMailboxTestHelper
+  include MailboxTestHelper
+
+  setup do
+    @admin = create(:admin)
+    @system_user = create(:admin, email: generate(:email))
+    @webhook_secret = 'test_webhook_secret'
+
+    User.stubs(:system_user).returns(@system_user)
+    Rails.application.credentials.stubs(:webhook_secret).returns(@webhook_secret)
+    ApplicationController.any_instance.stubs(:authenticate_user!).returns(true)
+    ProofAttachmentValidator.stubs(:validate!).returns(true)
+
+    proof_rate_limit_policy.value = 5
+    proof_rate_limit_policy.updated_by = @admin
+    proof_rate_limit_policy.save!
+
+    proof_period_policy.value = 1
+    proof_period_policy.updated_by = @admin
+    proof_period_policy.save!
+
+    max_rejections_policy.value = 10
+    max_rejections_policy.updated_by = @admin
+    max_rejections_policy.save!
+
+    proof_email_rate_limit_policy.value = 100
+    proof_email_rate_limit_policy.updated_by = @admin
+    proof_email_rate_limit_policy.save!
+
+    setup_fpl_policies
+  end
+
+  test 'portal proof upload produces the expected proof state' do
+    constituent = create(:constituent)
+    application = create(:application, :paper_rejected_proofs, user: constituent)
+
+    sign_in_for_integration_test(constituent)
+
+    post "/constituent_portal/applications/#{application.id}/proofs/resubmit",
+         params: {
+           proof_type: 'income',
+           income_proof_upload: fixture_file_upload(Rails.root.join('test/fixtures/files/test_income_proof.pdf'), 'application/pdf')
+         }
+
+    assert_redirected_to constituent_portal_application_path(application)
+
+    assert_proof_contract(
+      application,
+      proof_type: 'income',
+      expected_status: 'not_reviewed',
+      expected_submission_method: 'web',
+      expected_actor: constituent,
+      expected_event_action: 'income_proof_attached'
+    )
+
+    # CHARACTERIZATION: needs_review_since is set by ProofAttachmentService.update_application_status
+    # via update_columns when status is :not_reviewed. The concern's set_needs_review_timestamp
+    # callback does NOT fire (guarded by Current.proof_attachment_service_context).
+    application.reload
+    refute_nil application.needs_review_since, 'needs_review_since should be set for not_reviewed proof'
+  end
+
+  test 'scanned proof upload produces the expected proof state' do
+    application = create(:application, user: create(:constituent))
+
+    sign_in_for_integration_test(@admin)
+
+    post admin_application_scanned_proofs_path(application),
+         params: {
+           proof_type: 'income',
+           file: fixture_file_upload(Rails.root.join('test/fixtures/files/test_proof.pdf'), 'application/pdf')
+         }
+
+    assert_redirected_to admin_application_path(application)
+
+    assert_proof_contract(
+      application,
+      proof_type: 'income',
+      expected_status: 'approved',
+      expected_submission_method: 'paper',
+      expected_actor: @admin,
+      expected_event_action: 'proof_submitted'
+    )
+
+    # CHARACTERIZATION: needs_review_since is NOT set for scanned proofs because
+    # ProofAttachmentService only sets it when status is :not_reviewed, and the
+    # scanned controller passes status: :approved.
+    application.reload
+    assert_nil application.needs_review_since, 'needs_review_since should not be set for approved scanned proof'
+  end
+
+  # CHARACTERIZATION: ProofAttachmentService skips constituent notification when
+  # Current.paper_context is true (paper/scanned paths set this). The scanned proof
+  # controller sends its own ApplicationNotificationsMailer.proof_received instead.
+  # The concern's notify_admins_of_new_proofs callback does NOT fire from any
+  # ProofAttachmentService path because update_columns bypasses after_save.
+  test 'scanned proof upload does not send constituent notification via NotificationService' do
+    constituent = create(:constituent)
+    application = create(:application, user: constituent)
+
+    sign_in_for_integration_test(@admin)
+
+    assert_no_difference -> { Notification.where(notifiable: application, action: 'income_proof_attached').count } do
+      post admin_application_scanned_proofs_path(application),
+           params: {
+             proof_type: 'income',
+             file: fixture_file_upload(Rails.root.join('test/fixtures/files/test_proof.pdf'), 'application/pdf')
+           }
+    end
+  end
+
+  test 'paper application creation produces approved paper proof state' do
+    constituent = create(:constituent)
+
+    service = Applications::PaperApplicationService.new(
+      params: {
+        existing_constituent_id: constituent.id,
+        contact_info_verified: '1',
+        application: {
+          household_size: 1,
+          annual_income: 12_000,
+          maryland_resident: '1',
+          self_certify_disability: '1',
+          medical_provider_name: 'Dr. Paper',
+          medical_provider_phone: '555-111-2222',
+          medical_provider_email: 'paper-doctor@example.com'
+        },
+        income_proof_action: 'accept',
+        income_proof: fixture_file_upload(Rails.root.join('test/fixtures/files/test_income_proof.pdf'), 'application/pdf'),
+        residency_proof_action: 'accept',
+        residency_proof: fixture_file_upload(Rails.root.join('test/fixtures/files/test_residency_proof.pdf'), 'application/pdf'),
+        medical_certification_action: 'approved',
+        medical_certification: fixture_file_upload(Rails.root.join('test/fixtures/files/test_document.pdf'), 'application/pdf')
+      },
+      admin: @admin
+    )
+
+    assert service.create, "Expected paper application creation to succeed, got: #{service.errors.inspect}"
+
+    application = service.application
+    refute_nil application
+    assert_equal 'paper', application.submission_method
+    assert_equal 'approved', application.income_proof_status
+    assert_equal 'approved', application.residency_proof_status
+    assert_equal 'approved', application.medical_certification_status
+    assert application.income_proof.attached?
+    assert application.residency_proof.attached?
+    assert application.medical_certification.attached?
+    assert Event.where(auditable: application, action: 'application_created').exists?
+  end
+
+  test 'proof mailbox produces the expected proof state' do
+    constituent = create(:constituent)
+    application = create(:application, user: constituent, status: :in_progress)
+
+    inbound_email = receive_inbound_email_from_mail(
+      to: 'proof@mdmat.org',
+      from: constituent.email,
+      subject: 'Income Proof Submission',
+      body: 'Attached income proof.'
+    ) do |mail|
+      mail.attachments['income-proof.pdf'] = 'Income proof attachment ' * 80
+    end
+
+    assert_equal ProofSubmissionMailbox, ApplicationMailbox.mailbox_for(inbound_email)
+
+    assert_proof_contract(
+      application,
+      proof_type: 'income',
+      expected_status: 'not_reviewed',
+      expected_submission_method: 'email',
+      expected_actor: constituent,
+      expected_event_action: 'income_proof_submitted'
+    )
+  end
+
+  test 'admin certification review produces the expected certification state' do
+    application = create(:application, medical_certification_status: :requested)
+
+    sign_in_for_integration_test(@admin)
+
+    patch upload_medical_certification_admin_application_path(application),
+          params: {
+            medical_certification: fixture_file_upload(Rails.root.join('test/fixtures/files/test_document.pdf'), 'application/pdf'),
+            medical_certification_status: 'approved'
+          }
+
+    assert_redirected_to admin_application_path(application)
+
+    assert_medical_certification_contract(
+      application,
+      expected_status: 'approved',
+      expected_from_status: 'requested',
+      expected_event_action: 'medical_certification_status_changed',
+      expected_submission_method: 'admin_upload',
+      expected_actor: @admin
+    )
+  end
+
+  test 'docuseal completion produces the expected certification state' do
+    application = create(
+      :application,
+      document_signing_service: 'docuseal',
+      document_signing_submission_id: 'sub_123456',
+      document_signing_status: :sent,
+      medical_certification_status: :requested
+    )
+
+    response = mock('docuseal_response')
+    status = mock('docuseal_status')
+    status.stubs(:success?).returns(true)
+    response.stubs(:status).returns(status)
+    response.stubs(:body).returns('signed pdf')
+    HTTP.stubs(:timeout).with(30).returns(HTTP)
+    HTTP.stubs(:get).with('https://example.com/signed_doc.pdf').returns(response)
+
+    payload = {
+      event_type: 'form.completed',
+      data: {
+        'submission_id' => 'sub_123456',
+        'email' => 'doctor@example.com',
+        'documents' => [{ 'url' => 'https://example.com/signed_doc.pdf' }],
+        'audit_log_url' => 'https://example.com/audit_log'
+      }
+    }
+
+    post webhooks_docuseal_medical_certification_path,
+         params: payload,
+         headers: webhook_headers(payload),
+         as: :json
+
+    assert_response :ok
+
+    application.reload
+    assert application.medical_certification.attached?
+    assert_equal 'received', application.medical_certification_status
+    assert_equal 'signed', application.document_signing_status
+    assert_equal 'https://example.com/audit_log', application.document_signing_audit_url
+    assert Event.where(auditable: application, action: 'document_signing_completed').exists?
+  end
+
+  test 'certification mailbox produces the expected certification state' do
+    medical_provider = create(:medical_provider)
+    application = create(
+      :application,
+      status: :awaiting_dcf,
+      medical_provider_name: medical_provider.full_name,
+      medical_provider_email: medical_provider.email,
+      medical_provider_phone: medical_provider.phone,
+      medical_certification_status: :requested
+    )
+
+    inbound_email = receive_inbound_email_from_mail(
+      to: 'disability_cert@mdmat.org',
+      from: medical_provider.email,
+      subject: "Medical Certification for Application ##{application.id}",
+      body: "Attached certification for Application ##{application.id}",
+      attachments: [
+        {
+          filename: 'medical-certification.pdf',
+          content: 'certification pdf ' * 80,
+          content_type: 'application/pdf'
+        }
+      ]
+    )
+
+    assert_equal MedicalCertificationMailbox, ApplicationMailbox.mailbox_for(inbound_email)
+    assert_includes %w[processed delivered], inbound_email.reload.status
+
+    assert_medical_certification_contract(
+      application,
+      expected_status: 'received',
+      expected_from_status: 'requested',
+      expected_event_action: 'medical_certification_received',
+      expected_submission_method: 'email',
+      expected_actor: @system_user
+    )
+  end
+
+  test 'direct certification webhook produces the expected certification state' do
+    application = create(
+      :application,
+      status: :awaiting_dcf,
+      medical_provider_email: 'doctor@example.com',
+      medical_certification_status: :requested
+    )
+
+    # URI.open is private in Ruby 3.4+; stub the controller's download at the Kernel level
+    # since open-uri patches Kernel#open
+    OpenURI.stubs(:open_uri).returns(StringIO.new('certification pdf'))
+
+    payload = {
+      provider_email: 'doctor@example.com',
+      provider_name: 'Dr. Example',
+      constituent_name: application.user.full_name,
+      document_url: 'https://example.com/certification.pdf',
+      original_filename: 'certification.pdf',
+      webhook_id: SecureRandom.uuid
+    }
+
+    post webhooks_medical_certifications_path,
+         params: payload,
+         headers: webhook_headers(payload),
+         as: :json
+
+    assert_response :ok
+
+    assert_medical_certification_contract(
+      application,
+      expected_status: 'received',
+      expected_from_status: 'requested',
+      expected_event_action: 'medical_certification_received',
+      expected_submission_method: 'webhook',
+      expected_actor: @system_user
+    )
+  end
+
+  private
+
+  def proof_rate_limit_policy
+    @proof_rate_limit_policy ||= Policy.find_or_initialize_by(key: 'proof_submission_rate_limit_web')
+  end
+
+  def proof_period_policy
+    @proof_period_policy ||= Policy.find_or_initialize_by(key: 'proof_submission_rate_period')
+  end
+
+  def max_rejections_policy
+    @max_rejections_policy ||= Policy.find_or_initialize_by(key: 'max_proof_rejections')
+  end
+
+  def proof_email_rate_limit_policy
+    @proof_email_rate_limit_policy ||= Policy.find_or_initialize_by(key: 'proof_submission_rate_limit_email')
+  end
+
+  def assert_proof_contract(application, proof_type:, expected_status:, expected_submission_method:, expected_actor:,
+                            expected_event_action:)
+    application.reload
+
+    assert application.public_send("#{proof_type}_proof").attached?
+    assert_equal expected_status, application.public_send("#{proof_type}_proof_status")
+
+    event = Event.where(auditable: application, action: expected_event_action)
+                 .order(:created_at)
+                 .last
+
+    refute_nil event
+    assert_equal expected_actor, event.user
+    assert_equal proof_type.to_s, event.metadata['proof_type']
+    assert_equal expected_submission_method, event.metadata['submission_method']
+  end
+
+  def assert_medical_certification_contract(application, expected_status:, expected_from_status:, expected_event_action:,
+                                            expected_submission_method:, expected_actor:)
+    application.reload
+
+    assert application.medical_certification.attached?
+    assert_equal expected_status, application.medical_certification_status
+
+    status_change = ApplicationStatusChange.where(application: application, change_type: :medical_certification)
+                                           .order(:created_at)
+                                           .last
+    refute_nil status_change
+    assert_equal expected_from_status, status_change.from_status
+    assert_equal expected_status, status_change.to_status
+    assert_equal 'medical_certification', status_change.metadata['change_type']
+    assert_equal expected_submission_method, status_change.metadata['submission_method']
+
+    event = Event.where(auditable: application, action: expected_event_action).order(:created_at).last
+    refute_nil event
+    assert_equal expected_actor, event.user
+    assert_equal expected_submission_method, event.metadata['submission_method'] if event.metadata.key?('submission_method')
+  end
+
+  def webhook_headers(payload)
+    {
+      'Content-Type' => 'application/json',
+      'X-Webhook-Signature' => OpenSSL::HMAC.hexdigest('sha256', @webhook_secret, payload.to_json)
+    }
+  end
+end

--- a/test/integration/application_ingress_characterization_test.rb
+++ b/test/integration/application_ingress_characterization_test.rb
@@ -248,41 +248,47 @@ class ApplicationIngressCharacterizationTest < ActionDispatch::IntegrationTest
   end
 
   test 'certification mailbox produces the expected certification state' do
-    medical_provider = create(:medical_provider)
-    application = create(
-      :application,
-      status: :awaiting_dcf,
-      medical_provider_name: medical_provider.full_name,
-      medical_provider_email: medical_provider.email,
-      medical_provider_phone: medical_provider.phone,
-      medical_certification_status: :requested
-    )
+    with_committed_records do
+      medical_provider = create(:medical_provider)
+      application = create(
+        :application,
+        status: :awaiting_dcf,
+        medical_provider_name: medical_provider.full_name,
+        medical_provider_email: medical_provider.email,
+        medical_provider_phone: medical_provider.phone,
+        medical_certification_status: :requested
+      )
 
-    inbound_email = receive_inbound_email_from_mail(
-      to: 'disability_cert@mdmat.org',
-      from: medical_provider.email,
-      subject: "Medical Certification for Application ##{application.id}",
-      body: "Attached certification for Application ##{application.id}",
-      attachments: [
-        {
+      mail = Mail.new do
+        to 'disability_cert@mdmat.org'
+        from medical_provider.email
+        subject "Medical Certification for Application ##{application.id}"
+
+        text_part do
+          body "Attached certification for Application ##{application.id}"
+        end
+
+        add_file(
           filename: 'medical-certification.pdf',
           content: 'certification pdf ' * 80,
           content_type: 'application/pdf'
-        }
-      ]
-    )
+        )
+      end
 
-    assert_equal MedicalCertificationMailbox, ApplicationMailbox.mailbox_for(inbound_email)
-    assert_includes %w[processed delivered], inbound_email.reload.status
+      inbound_email = ActionMailbox::InboundEmail.create_and_extract_message_id!(mail.to_s)
+      inbound_email.route
 
-    assert_medical_certification_contract(
-      application,
-      expected_status: 'received',
-      expected_from_status: 'requested',
-      expected_event_action: 'medical_certification_received',
-      expected_submission_method: 'email',
-      expected_actor: @system_user
-    )
+      assert_equal MedicalCertificationMailbox, ApplicationMailbox.mailbox_for(inbound_email)
+
+      assert_medical_certification_contract(
+        application,
+        expected_status: 'received',
+        expected_from_status: 'requested',
+        expected_event_action: 'medical_certification_received',
+        expected_submission_method: 'email',
+        expected_actor: @system_user
+      )
+    end
   end
 
   test 'direct certification webhook produces the expected certification state' do
@@ -385,5 +391,17 @@ class ApplicationIngressCharacterizationTest < ActionDispatch::IntegrationTest
       'Content-Type' => 'application/json',
       'X-Webhook-Signature' => OpenSSL::HMAC.hexdigest('sha256', @webhook_secret, payload.to_json)
     }
+  end
+
+  def with_committed_records
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.clean
+    Current.reset
+    @system_user = create(:admin, email: generate(:email))
+    User.stubs(:system_user).returns(@system_user)
+    yield
+  ensure
+    Current.reset
+    DatabaseCleaner.strategy = :transaction
   end
 end

--- a/test/integration/application_lifecycle_flow_test.rb
+++ b/test/integration/application_lifecycle_flow_test.rb
@@ -1,0 +1,538 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApplicationLifecycleFlowTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    clear_enqueued_jobs
+    clear_performed_jobs
+    Current.reset
+  end
+
+  teardown do
+    clear_enqueued_jobs
+    clear_performed_jobs
+    Current.reset
+    FeatureFlag.disable!(:vouchers_enabled)
+  end
+
+  test 'explicit certification resend is allowed when certification is already requested' do
+    with_after_commit_callbacks do
+      admin = create(:admin)
+      application = create_application_with_documents
+      set_application_state(
+        application,
+        status: :awaiting_dcf,
+        income_proof_status: :approved,
+        residency_proof_status: :approved,
+        medical_certification_status: :requested
+      )
+      application.update_columns(
+        medical_certification_requested_at: 2.days.ago,
+        medical_certification_request_count: 1,
+        updated_at: Time.current
+      )
+
+      service = Applications::MedicalCertificationService.new(
+        application: application,
+        actor: admin
+      )
+
+      assert_difference -> { application.reload.medical_certification_request_count }, 1 do
+        assert_difference -> { Notification.where(notifiable: application, action: 'medical_certification_requested').count }, 1 do
+          assert_difference -> { Event.where(auditable: application, action: 'medical_certification_requested').count }, 1 do
+            assert_difference -> { ApplicationStatusChange.where(application: application).count }, 1 do
+              assert_enqueued_with(job: MedicalCertificationEmailJob) do
+                result = service.request_certification
+                assert result.success?, result.message
+              end
+            end
+          end
+        end
+      end
+
+      application.reload
+
+      assert_equal 'requested', application.medical_certification_status
+      assert_equal 'awaiting_dcf', application.status
+
+      latest_notification = Notification.where(notifiable: application, action: 'medical_certification_requested').order(:created_at).last
+      assert_equal 2, latest_notification.metadata['request_count']
+
+      latest_status_change = ApplicationStatusChange.where(application: application).order(:created_at).last
+      assert_equal 'requested', latest_status_change.to_status
+      assert_equal 'medical_certification', latest_status_change.metadata['change_type']
+    end
+  end
+
+  test 'final proof approval moves application to awaiting_dcf and requests certification once' do
+    with_after_commit_callbacks do
+      admin = create(:admin)
+      application = create_application_with_documents
+      set_application_state(
+        application,
+        status: :in_progress,
+        income_proof_status: :approved,
+        residency_proof_status: :not_reviewed,
+        medical_certification_status: :not_requested
+      )
+
+      request_mail = mock('request_mail')
+      request_mail.expects(:deliver_later).once
+      MedicalProviderMailer.expects(:request_certification).with do |app|
+        app.id == application.id
+      end.returns(request_mail).once
+
+      reviewer = Applications::ProofReviewer.new(application, admin)
+
+      assert_difference -> { application.proof_reviews.where(proof_type: :residency, status: :approved).count }, 1 do
+        reviewer.review(proof_type: :residency, status: :approved)
+      end
+
+      application.reload
+
+      assert_equal 'approved', application.residency_proof_status
+      assert_equal 'awaiting_dcf', application.status
+      assert_equal 'requested', application.medical_certification_status
+
+      dcf_status_changes = ApplicationStatusChange.where(application: application, to_status: 'awaiting_dcf')
+      assert_equal 1, dcf_status_changes.count
+    end
+  end
+
+  # CHARACTERIZATION: ProofReviewer uses update_column for both proof status and
+  # application status, so log_status_change (after_update) never fires. This means
+  # no ApplicationStatusChange and no application_status_changed event are created.
+  # Only the manually-logged application_auto_approved event exists.
+  # This gap is documented in the lifecycle refactor plan (Problem #2) and will be
+  # fixed when ProofReviewer is migrated through the WorkflowReconciler (PR 4).
+  test 'proof reviewer auto-approval creates application_auto_approved but no status change record' do
+    with_after_commit_callbacks do
+      admin = create(:admin)
+      application = create_application_with_documents(
+        attach_medical_certification: true
+      )
+      set_application_state(
+        application,
+        status: :in_progress,
+        income_proof_status: :approved,
+        residency_proof_status: :not_reviewed,
+        medical_certification_status: :approved
+      )
+
+      reviewer = Applications::ProofReviewer.new(application, admin)
+
+      assert_difference -> { application.proof_reviews.where(proof_type: :residency, status: :approved).count }, 1 do
+        assert_difference -> { Event.where(auditable: application, action: 'application_auto_approved').count }, 1 do
+          reviewer.review(proof_type: :residency, status: :approved)
+        end
+      end
+
+      application.reload
+
+      assert_equal 'approved', application.status
+
+      # update_column bypasses after_update :log_status_change, so no ApplicationStatusChange
+      assert_equal 0, ApplicationStatusChange.where(application: application, to_status: 'approved').count
+
+      # No application_status_changed event either (same bypass)
+      approved_status_events = Event.where(auditable: application, action: 'application_status_changed').select do |event|
+        event.metadata['new_status'] == 'approved'
+      end
+      assert_equal 0, approved_status_events.count
+
+      # The only audit artifact is the manually-created event from ProofReviewer
+      auto_approval_event = Event.where(auditable: application, action: 'application_auto_approved').order(:created_at).last
+      refute_nil auto_approval_event
+      assert_equal admin, auto_approval_event.user
+    end
+  end
+
+  # TARGET: After PR 4 migrates ProofReviewer through WorkflowReconciler, auto-approval
+  # via proof review should produce the full audit trail. Unskip this test and delete the
+  # characterization test above when that migration lands.
+  test 'PR4 target: proof reviewer auto-approval creates full audit artifacts' do
+    skip 'Requires PR 4: migrate ProofReviewer auto-approval through WorkflowReconciler'
+
+    with_after_commit_callbacks do
+      admin = create(:admin)
+      application = create_application_with_documents(
+        attach_medical_certification: true
+      )
+      set_application_state(
+        application,
+        status: :in_progress,
+        income_proof_status: :approved,
+        residency_proof_status: :not_reviewed,
+        medical_certification_status: :approved
+      )
+
+      reviewer = Applications::ProofReviewer.new(application, admin)
+
+      assert_difference -> { application.proof_reviews.where(proof_type: :residency, status: :approved).count }, 1 do
+        assert_difference -> { Event.where(auditable: application, action: 'application_auto_approved').count }, 1 do
+          reviewer.review(proof_type: :residency, status: :approved)
+        end
+      end
+
+      application.reload
+
+      assert_equal 'approved', application.status
+      assert_equal 1, ApplicationStatusChange.where(application: application, to_status: 'approved').count
+
+      approved_status_events = Event.where(auditable: application, action: 'application_status_changed').select do |event|
+        event.metadata['new_status'] == 'approved'
+      end
+      assert_equal 1, approved_status_events.count
+      assert_equal admin, approved_status_events.first.user
+
+      auto_approval_event = Event.where(auditable: application, action: 'application_auto_approved').order(:created_at).last
+      refute_nil auto_approval_event
+      assert_equal admin, auto_approval_event.user
+    end
+  end
+
+  test 'explicit document request keeps documents_requested behavior and requests certification' do
+    with_after_commit_callbacks do
+      admin = create(:admin)
+      application = create_application_with_documents
+      set_application_state(
+        application,
+        status: :in_progress,
+        income_proof_status: :approved,
+        residency_proof_status: :approved,
+        medical_certification_status: :not_requested
+      )
+
+      request_mail = mock('request_mail')
+      request_mail.expects(:deliver_later).once
+      MedicalProviderMailer.expects(:request_certification).with do |app|
+        app.id == application.id
+      end.returns(request_mail).once
+
+      service = Applications::DocumentRequester.new(application, by: admin)
+
+      assert_difference -> { Event.where(auditable: application, action: 'documents_requested').count }, 1 do
+        assert_difference -> { Notification.where(notifiable: application, action: 'documents_requested').count }, 1 do
+          assert service.call
+        end
+      end
+
+      application.reload
+
+      assert_equal 'awaiting_dcf', application.status
+      assert_equal 'requested', application.medical_certification_status
+      assert_equal 1, ApplicationStatusChange.where(application: application, to_status: 'awaiting_dcf').count
+    end
+  end
+
+  test 'explicit document request does not duplicate certification request when already requested' do
+    with_after_commit_callbacks do
+      admin = create(:admin)
+      application = create_application_with_documents
+      set_application_state(
+        application,
+        status: :in_progress,
+        income_proof_status: :approved,
+        residency_proof_status: :approved,
+        medical_certification_status: :requested
+      )
+
+      MedicalProviderMailer.expects(:request_certification).never
+
+      service = Applications::DocumentRequester.new(application, by: admin)
+
+      assert_difference -> { Event.where(auditable: application, action: 'documents_requested').count }, 1 do
+        assert_difference -> { Notification.where(notifiable: application, action: 'documents_requested').count }, 1 do
+          assert_no_difference -> { ApplicationStatusChange.where(application: application, change_type: 'medical_certification').count } do
+            assert service.call
+          end
+        end
+      end
+
+      application.reload
+
+      assert_equal 'awaiting_dcf', application.status
+      assert_equal 'requested', application.medical_certification_status
+      assert_equal 1, ApplicationStatusChange.where(application: application, to_status: 'awaiting_dcf').count
+    end
+  end
+
+  # CHARACTERIZATION: MedicalCertificationAttachmentService uses update_columns for
+  # cert status, which bypasses all after_save callbacks including auto_approve_if_eligible.
+  # The application remains in_progress even though all three requirements are now met.
+  # This gap is documented in the lifecycle refactor plan (Problem #2, writer list) and
+  # will be fixed when cert approval paths call the WorkflowReconciler (PR 4).
+  test 'certification approval does not auto-approve because update_columns bypasses callbacks' do
+    with_after_commit_callbacks do
+      admin = create(:admin)
+      application = create_application_with_documents(
+        attach_medical_certification: true
+      )
+      set_application_state(
+        application,
+        status: :in_progress,
+        income_proof_status: :approved,
+        residency_proof_status: :approved,
+        medical_certification_status: :requested
+      )
+
+      result = MedicalCertificationAttachmentService.update_certification_status(
+        application: application,
+        status: :approved,
+        admin: admin,
+        submission_method: :admin_review
+      )
+
+      assert result[:success], 'Certification approval should succeed'
+
+      application.reload
+
+      assert_equal 'approved', application.medical_certification_status
+
+      # Application status does NOT change — update_columns bypasses auto_approve_if_eligible
+      assert_equal 'in_progress', application.status
+
+      # No auto-approval artifacts because the callback path never fires
+      assert_equal 0, Event.where(auditable: application, action: 'application_auto_approved').count
+      assert_equal 0, ApplicationStatusChange.where(
+        application: application, to_status: 'approved'
+      ).where.not(change_type: 'medical_certification').count
+
+      # The service DOES create its own medical_certification status change record
+      cert_change = ApplicationStatusChange.where(
+        application: application,
+        change_type: 'medical_certification',
+        to_status: 'approved'
+      ).last
+      refute_nil cert_change
+      assert_equal 'requested', cert_change.from_status
+
+      # And the service creates its own audit event
+      cert_event = Event.where(auditable: application, action: 'medical_certification_status_changed').last
+      refute_nil cert_event
+      assert_equal admin, cert_event.user
+    end
+  end
+
+  # TARGET: After PR 4 migrates cert approval paths to call WorkflowReconciler,
+  # approving the final requirement should auto-approve the application. Unskip this
+  # test and delete the characterization test above when that migration lands.
+  test 'PR4 target: certification approval auto-approves the application' do
+    skip 'Requires PR 4: migrate cert approval through WorkflowReconciler'
+
+    with_after_commit_callbacks do
+      admin = create(:admin)
+      application = create_application_with_documents(
+        attach_medical_certification: true
+      )
+      set_application_state(
+        application,
+        status: :in_progress,
+        income_proof_status: :approved,
+        residency_proof_status: :approved,
+        medical_certification_status: :requested
+      )
+
+      result = MedicalCertificationAttachmentService.update_certification_status(
+        application: application,
+        status: :approved,
+        admin: admin,
+        submission_method: :admin_review
+      )
+
+      assert result[:success], 'Certification approval should succeed'
+
+      application.reload
+
+      assert_equal 'approved', application.medical_certification_status
+      assert_equal 'approved', application.status
+      assert_equal 1, ApplicationStatusChange.where(application: application, to_status: 'approved').count
+      assert_equal 1, Event.where(auditable: application, action: 'application_auto_approved').count
+
+      approved_status_events = Event.where(auditable: application, action: 'application_status_changed').select do |event|
+        event.metadata['new_status'] == 'approved'
+      end
+      assert_equal 1, approved_status_events.count
+      assert_equal admin, approved_status_events.first.user
+
+      auto_approval_event = Event.where(auditable: application, action: 'application_auto_approved').order(:created_at).last
+      refute_nil auto_approval_event
+      assert_equal admin, auto_approval_event.user
+    end
+  end
+
+  test 'explicit admin approval creates exact audit artifacts and initial voucher' do
+    with_after_commit_callbacks do
+      admin = create(:admin)
+      Current.user = admin
+      FeatureFlag.enable!(:vouchers_enabled)
+
+      application = create_application_with_documents(
+        attach_medical_certification: true
+      )
+      set_application_state(
+        application,
+        status: :in_progress,
+        income_proof_status: :approved,
+        residency_proof_status: :approved,
+        medical_certification_status: :approved
+      )
+
+      service = Applications::Approver.new(application, by: admin)
+
+      assert_difference -> { Voucher.where(application: application).count }, 1 do
+        assert_difference -> { Event.where(auditable: application, action: 'application_approved').count }, 1 do
+          assert_difference -> { Event.where(action: 'voucher_assigned', auditable_type: 'Voucher').count }, 1 do
+          assert service.call
+          end
+        end
+      end
+
+      application.reload
+
+      assert_equal 'approved', application.status
+      assert_equal 1, ApplicationStatusChange.where(application: application, to_status: 'approved').count
+
+      approved_status_events = Event.where(auditable: application, action: 'application_status_changed').select do |event|
+        event.metadata['new_status'] == 'approved'
+      end
+      assert_equal 1, approved_status_events.count
+      assert_equal admin, approved_status_events.first.user
+
+      approval_event = Event.where(auditable: application, action: 'application_approved').order(:created_at).last
+      refute_nil approval_event
+      assert_equal admin, approval_event.user
+
+      voucher = Voucher.find_by!(application: application)
+      assert voucher.persisted?
+      voucher_assignment_event = Event.find_by!(auditable: voucher, action: 'voucher_assigned')
+      assert_equal admin, voucher_assignment_event.user
+    end
+  end
+
+  # CHARACTERIZATION: When status changes via update! (e.g. Approver, DocumentRequester),
+  # the after_update :log_status_change callback fires and creates both an
+  # ApplicationStatusChange and an application_status_changed event. This is the
+  # callback-driven path — contrast with the update_column path tested above.
+  test 'update! status change creates ApplicationStatusChange and event via callback' do
+    with_after_commit_callbacks do
+      admin = create(:admin)
+      Current.user = admin
+
+      application = create_application_with_documents
+      set_application_state(
+        application,
+        status: :in_progress,
+        income_proof_status: :approved,
+        residency_proof_status: :approved,
+        medical_certification_status: :not_requested
+      )
+
+      assert_difference -> { ApplicationStatusChange.where(application: application).count }, 1 do
+        assert_difference -> { Event.where(auditable: application, action: 'application_status_changed').count }, 1 do
+          application.update!(status: :awaiting_dcf)
+        end
+      end
+
+      change = ApplicationStatusChange.where(application: application, to_status: 'awaiting_dcf').last
+      refute_nil change
+      assert_equal 'in_progress', change.from_status
+      assert_equal admin, change.user
+
+      event = Event.where(auditable: application, action: 'application_status_changed').last
+      assert_equal admin, event.user
+      assert_equal 'awaiting_dcf', event.metadata['new_status']
+    end
+  end
+
+  # BUG FIX TEST: Previously, if log_status_change was called with acting_user.blank?,
+  # the method returned early before the ensure block, leaving @pending_status_change_user
+  # and @pending_status_change_notes set. A subsequent status change on the same instance
+  # would then use those stale values for actor attribution.
+  test 'log_status_change clears pending ivars even when acting_user is blank' do
+    with_after_commit_callbacks do
+      application = create_application_with_documents
+      set_application_state(
+        application,
+        status: :in_progress,
+        income_proof_status: :not_reviewed,
+        residency_proof_status: :not_reviewed,
+        medical_certification_status: :not_requested
+      )
+
+      # Set up the blank-actor condition:
+      # pending user is nil, Current.user is nil, and stub `user` to return nil
+      application.instance_variable_set(:@pending_status_change_user, nil)
+      application.instance_variable_set(:@pending_status_change_notes, 'stale notes from prior call')
+      Current.user = nil
+      application.stubs(:user).returns(nil)
+
+      # Call the private method directly — acting_user will be blank
+      application.send(:log_status_change)
+
+      # After the early return, pending ivars must be cleared (this is the fix)
+      assert_nil application.instance_variable_get(:@pending_status_change_user)
+      assert_nil application.instance_variable_get(:@pending_status_change_notes)
+    end
+  end
+
+  private
+
+  def with_after_commit_callbacks
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.clean
+    clear_enqueued_jobs
+    clear_performed_jobs
+    Current.reset
+    yield
+  ensure
+    clear_enqueued_jobs
+    clear_performed_jobs
+    Current.reset
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  def create_application_with_documents(
+    attach_income_proof: true,
+    attach_residency_proof: true,
+    attach_medical_certification: false
+  )
+    application = create(
+      :application,
+      skip_proofs: true,
+      status: :in_progress,
+      income_proof_status: :not_reviewed,
+      residency_proof_status: :not_reviewed,
+      medical_certification_status: :not_requested
+    )
+
+    attach_pdf(application.income_proof, 'income.pdf') if attach_income_proof
+    attach_pdf(application.residency_proof, 'residency.pdf') if attach_residency_proof
+    attach_pdf(application.medical_certification, 'medical-certification.pdf') if attach_medical_certification
+
+    application.reload
+  end
+
+  def set_application_state(application, status:, income_proof_status:, residency_proof_status:, medical_certification_status:)
+    application.update_columns(
+      status: Application.statuses.fetch(status.to_s),
+      income_proof_status: Application.income_proof_statuses.fetch(income_proof_status.to_s),
+      residency_proof_status: Application.residency_proof_statuses.fetch(residency_proof_status.to_s),
+      medical_certification_status: Application.medical_certification_statuses.fetch(medical_certification_status.to_s),
+      updated_at: Time.current
+    )
+
+    application.reload
+  end
+
+  def attach_pdf(attachment, filename)
+    attachment.attach(
+      io: StringIO.new("PDF content for #{filename}"),
+      filename: filename,
+      content_type: 'application/pdf'
+    )
+  end
+end

--- a/test/integration/proof_submission_flow_test.rb
+++ b/test/integration/proof_submission_flow_test.rb
@@ -40,27 +40,31 @@ class ProofSubmissionFlowTest < ActionDispatch::IntegrationTest
                    to: 'not_reviewed' do
       # Instead of checking exact change in needs_review_since, just verify it gets set
       before_value = @application.needs_review_since
-      assert_difference 'Event.count', 2 do # ProofAttachmentService creates income_proof_attached, tracking creates proof_submitted
-        # Use the direct path
-        post "/constituent_portal/applications/#{@application.id}/proofs/resubmit",
-             params: { proof_type: 'income', income_proof_upload: @valid_pdf }
+      assert_difference -> { Notification.where(notifiable: @application, action: 'income_proof_attached').count }, 1 do
+        assert_no_difference -> { Notification.where(notifiable: @application, action: 'proof_submitted').count } do
+          assert_difference 'Event.count', 2 do # ProofAttachmentService creates income_proof_attached, tracking creates proof_submitted
+            # Use the direct path
+            post "/constituent_portal/applications/#{@application.id}/proofs/resubmit",
+                 params: { proof_type: 'income', income_proof_upload: @valid_pdf }
 
-        # Verify response and flash
-        assert_response :redirect
-        follow_redirect_with_user!
-        assert_equal 'Proof submitted successfully', flash[:notice]
+            # Verify response and flash
+            assert_response :redirect
+            follow_redirect_with_user!
+            assert_equal 'Proof submitted successfully', flash[:notice]
 
-        # Verify needs_review_since was updated
-        @application.reload
-        assert @application.needs_review_since != before_value, 'needs_review_since should be updated'
+            # Verify needs_review_since was updated
+            @application.reload
+            assert @application.needs_review_since != before_value, 'needs_review_since should be updated'
 
-        # Verify application updates
-        assert @application.income_proof.attached?, 'Income proof should be attached'
-        assert_equal 'not_reviewed', @application.income_proof_status
-        assert_not_nil @application.needs_review_since
+            # Verify application updates
+            assert @application.income_proof.attached?, 'Income proof should be attached'
+            assert_equal 'not_reviewed', @application.income_proof_status
+            assert_not_nil @application.needs_review_since
 
-        # Verify audit trail and events
-        assert_audit_and_events
+            # Verify audit trail and events
+            assert_audit_and_events
+          end
+        end
       end
     end
   end
@@ -113,6 +117,7 @@ class ProofSubmissionFlowTest < ActionDispatch::IntegrationTest
     assert_equal @user, attachment_event.user
     assert_equal @application, attachment_event.auditable
     assert_equal 'income', attachment_event.metadata['proof_type']
+    assert_equal 'web', attachment_event.metadata['submission_method']
   end
 
   test 'requires authentication' do

--- a/test/services/applications/filter_service_test.rb
+++ b/test/services/applications/filter_service_test.rb
@@ -320,6 +320,96 @@ module Applications
       end
     end
 
+    # CHARACTERIZATION: The training_requests filter uses notification-derived state.
+    # It queries Notification records with action 'training_requested', not application columns.
+    # If notifications exist, it returns applications referenced by those notifications.
+    # If no notifications exist, it falls back to with_pending_training (training sessions join).
+    test 'filters by training_requests using notification-derived state' do
+      with_mocked_attachments do
+        admin = create(:admin)
+        approved_app = create(:application, :completed, user: create(:constituent, speech_disability: true))
+
+        Notification.create!(
+          action: 'training_requested',
+          notifiable: approved_app,
+          recipient: admin,
+          actor: approved_app.user,
+          metadata: { application_id: approved_app.id }
+        )
+
+        service = FilterService.new(@scope, { filter: 'training_requests' })
+        service_result = service.apply_filters
+
+        assert service_result.success?
+        result_data = service_result.data
+        assert_includes result_data, approved_app
+        assert_not_includes result_data, @active_app
+      end
+    end
+
+    # CHARACTERIZATION: When no training_requested notifications exist, the filter
+    # falls back to with_pending_training scope (joins training_sessions with active status).
+    test 'training_requests filter falls back to training sessions when no notifications exist' do
+      with_mocked_attachments do
+        trainer = create(:trainer)
+
+        # Ensure no training_requested notifications exist
+        Notification.where(action: 'training_requested').delete_all
+
+        TrainingSession.create!(
+          application: @approved_app,
+          trainer: trainer,
+          scheduled_for: 1.day.from_now,
+          status: :requested
+        )
+
+        service = FilterService.new(@scope, { filter: 'training_requests' })
+        service_result = service.apply_filters
+
+        assert service_result.success?
+        result_data = service_result.data
+        assert_includes result_data, @approved_app
+        assert_not_includes result_data, @active_app
+      end
+    end
+
+    # CHARACTERIZATION: Notification-derived and session-derived queries can disagree.
+    # If a training_requested notification exists for app A, and a training session
+    # exists for app B, the filter returns app A (notifications take precedence).
+    test 'training_requests filter prefers notifications over sessions when both exist' do
+      with_mocked_attachments do
+        admin = create(:admin)
+        trainer = create(:trainer)
+
+        other_user = create(:constituent, speech_disability: true)
+        other_app = create(:application, :completed, user: other_user)
+
+        Notification.create!(
+          action: 'training_requested',
+          notifiable: @approved_app,
+          recipient: admin,
+          actor: @approved_app.user,
+          metadata: { application_id: @approved_app.id }
+        )
+
+        TrainingSession.create!(
+          application: other_app,
+          trainer: trainer,
+          scheduled_for: 1.day.from_now,
+          status: :requested
+        )
+
+        service = FilterService.new(@scope, { filter: 'training_requests' })
+        service_result = service.apply_filters
+
+        assert service_result.success?
+        result_data = service_result.data
+        # Notifications win — other_app's session is ignored
+        assert_includes result_data, @approved_app
+        assert_not_includes result_data, other_app
+      end
+    end
+
     test 'handles errors gracefully' do
       Rails.logger.stubs(:error)
       Rails.logger.expects(:error).with(regexp_matches(/Error applying filters: Test error/)).once


### PR DESCRIPTION
Pin current behavior for four lifecycle flows before refactoring:

Flow A (proof attachment):
- needs_review_since is correctly set for not_reviewed proofs and correctly skipped for approved scanned proofs (working as intended)
- scanned path correctly skips constituent NotificationService notifications (working as intended)

Flow B (proof -> awaiting_dcf -> cert request):
- already covered by existing tests, no additions needed

Flow C (auto-approval):
- ProofReviewer uses update_column, which bypasses callbacks. This means auto-approval currently does not create ApplicationStatusChange or application_status_changed records. It should. Skipped target tests define the correct behavior we want after the fix (out of scope for this PR).
- MedicalCertificationAttachmentService uses update_columns, which bypasses callbacks. This means cert approval currently does not trigger auto-approval even when all requirements are met. It should.

Flow D (training request queue):
- FilterService reads training request state from Notification records instead of from an application column. Training request state should live on the application itself (training_requested_at). Tests document the current notification-derived lookup and session fallback so the migration to application-owned state has a baseline to verify against.

Bug fix: log_status_change early return skipped clearing @pending_status_change_user/@pending_status_change_notes, leaking stale actor/notes into subsequent status changes.