### PR TITLE
Application transition status api

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -141,7 +141,7 @@ class Application < ApplicationRecord
   before_save :ensure_managing_guardian_set, if: :user_id_changed?
   # Callbacks
   before_create :ensure_managing_guardian_set
-  after_update :log_status_change, if: :saved_change_to_status?
+  after_update :log_status_change, if: :should_log_status_change?
   after_save :log_alternate_contact_changes, if: :saved_change_to_alternate_contact?
 
   # Scopes
@@ -284,6 +284,51 @@ class Application < ApplicationRecord
   # Delegate document request logic to the Applications::DocumentRequester service object
   def request_documents!(user: Current.user)
     Applications::DocumentRequester.new(self, by: user).call
+  end
+
+  # Explicit status transition API for new lifecycle paths.
+  # This writes the status change, status-change record, and audit event atomically.
+  # Audit failures propagate and roll back the status change.
+  def transition_status!(new_status, actor:, notes: nil, metadata: {})
+    raise ArgumentError, 'actor is required' if actor.blank?
+
+    with_lock do
+      old_status = status
+      target_status = new_status.to_s
+
+      return true if old_status == target_status
+
+      # Transitional coexistence guard while the legacy log_status_change callback still exists.
+      # Remove this when callback-owned status logging is deleted.
+      @skip_status_change_logging = true
+      update!(status: target_status)
+
+      status_changes.create!(
+        from_status: old_status,
+        to_status: status,
+        user: actor,
+        notes: notes
+      )
+
+      AuditEventService.log(
+        action: 'application_status_changed',
+        actor: actor,
+        auditable: self,
+        metadata: metadata.reverse_merge(
+          application_id: id,
+          old_status: old_status,
+          new_status: status,
+          submission_method: submission_method,
+          notes: notes
+        )
+      )
+
+      true
+    end
+  ensure
+    # Method-level ensure guarantees cleanup even if locking or auditing raises
+    # before the coexistence guard can be unset inside the locked section.
+    @skip_status_change_logging = false
   end
 
   def constituent_full_name
@@ -456,6 +501,10 @@ class Application < ApplicationRecord
       @pending_status_change_user = nil
       @pending_status_change_notes = nil
     end
+  end
+
+  def should_log_status_change?
+    saved_change_to_status? && !@skip_status_change_logging
   end
 
   def waiting_period_completed

--- a/app/services/applications/approver.rb
+++ b/app/services/applications/approver.rb
@@ -18,7 +18,7 @@ module Applications
     # @return [Boolean] True if successful, false otherwise
     def call
       ApplicationRecord.transaction do
-        application.update!(status: :approved)
+        application.transition_status!(:approved, actor: actor)
 
         # Create event for approval
         AuditEventService.log(

--- a/test/models/application_transition_status_test.rb
+++ b/test/models/application_transition_status_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApplicationTransitionStatusTest < ActiveSupport::TestCase
+  setup do
+    @admin = create(:admin)
+    @other_admin = create(:admin)
+    @constituent = create(:constituent, email: generate(:email))
+    Current.reset
+  end
+
+  teardown do
+    Current.reset
+  end
+
+  test 'transition_status! creates one status change and event with explicit actor, notes, and metadata' do
+    application = create(:application, :in_progress, user: @constituent)
+    Current.user = @other_admin
+
+    assert_difference -> { ApplicationStatusChange.where(application: application).count }, 1 do
+      assert_difference -> { Event.where(auditable: application, action: 'application_status_changed').count }, 1 do
+        assert application.transition_status!(
+          :approved,
+          actor: @admin,
+          notes: 'Manual approval',
+          metadata: { trigger: 'admin_panel' }
+        )
+      end
+    end
+
+    application.reload
+    assert_equal 'approved', application.status
+
+    change = ApplicationStatusChange.where(application: application).order(:created_at).last
+    assert_equal 'in_progress', change.from_status
+    assert_equal 'approved', change.to_status
+    assert_equal @admin, change.user
+    assert_equal 'Manual approval', change.notes
+
+    event = Event.where(auditable: application, action: 'application_status_changed').order(:created_at).last
+    assert_equal @admin, event.user
+    assert_equal 'in_progress', event.metadata['old_status']
+    assert_equal 'approved', event.metadata['new_status']
+    assert_equal 'Manual approval', event.metadata['notes']
+    assert_equal 'admin_panel', event.metadata['trigger']
+  end
+
+  test 'transition_status! is a no-op when the target status matches the current status' do
+    application = create(:application, :approved, user: @constituent)
+
+    assert_no_difference -> { ApplicationStatusChange.where(application: application).count } do
+      assert_no_difference -> { Event.where(auditable: application, action: 'application_status_changed').count } do
+        assert application.transition_status!(:approved, actor: @admin)
+      end
+    end
+
+    application.reload
+    assert_equal 'approved', application.status
+  end
+
+  test 'transition_status! requires an explicit actor' do
+    application = create(:application, :in_progress, user: @constituent)
+
+    error = assert_raises(ArgumentError) do
+      application.transition_status!(:approved, actor: nil)
+    end
+
+    assert_equal 'actor is required', error.message
+  end
+
+  test 'transition_status! rolls back the status change if status audit logging fails' do
+    application = create(:application, :in_progress, user: @constituent)
+
+    AuditEventService.stub :log, ->(**) { raise 'status audit failed' } do
+      error = assert_raises(RuntimeError) do
+        application.transition_status!(:approved, actor: @admin)
+      end
+
+      assert_equal 'status audit failed', error.message
+    end
+
+    application.reload
+    assert_equal 'in_progress', application.status
+    assert_equal 0, ApplicationStatusChange.where(application: application, to_status: 'approved').count
+    assert_equal 0, Event.where(auditable: application, action: 'application_status_changed').count
+  end
+end


### PR DESCRIPTION
Add explicit status transition API for application approvals
Introduce Application#transition_status! as the first explicit status
writer for lifecycle work.

Route Applications::Approver through the new API so approval status
changes create their ApplicationStatusChange and
application_status_changed audit event in one locked, atomic path with
explicit actor attribution.

Keep caller-specific approval side effects in Approver, preserve
coexistence with the legacy callback path for older callers, and add
focused tests proving the transactional contract:

- transition_status! can succeed internally
- a later Approver side effect can still fail
- the surrounding transaction rolls back the status change,
  ApplicationStatusChange, and application_status_changed audit event