### PR TITLE
Alternate contact relationship

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -717,7 +717,8 @@ module Admin
                      medical_provider_email
                      alternate_contact_name
                      alternate_contact_phone
-                     alternate_contact_email]
+                     alternate_contact_email
+                     alternate_contact_relationship_type]
 
       permitted.push(:household_size, :annual_income) if @application.income_proof_required?
 

--- a/app/controllers/admin/paper_applications_controller.rb
+++ b/app/controllers/admin/paper_applications_controller.rb
@@ -31,7 +31,7 @@ module Admin
       medical_provider_name medical_provider_phone medical_provider_fax
       medical_provider_email terms_accepted information_verified
       medical_release_authorized
-      alternate_contact_name alternate_contact_phone alternate_contact_email
+      alternate_contact_name alternate_contact_phone alternate_contact_email alternate_contact_relationship_type
     ].freeze
 
     def new

--- a/app/controllers/constituent_portal/applications_controller.rb
+++ b/app/controllers/constituent_portal/applications_controller.rb
@@ -545,7 +545,7 @@ module ConstituentPortal
           medical_provider_name medical_provider_phone medical_provider_fax medical_provider_email
           physical_address_1 physical_address_2 city state zip_code
           hearing_disability vision_disability speech_disability mobility_disability cognition_disability
-          alternate_contact_name alternate_contact_phone alternate_contact_email
+          alternate_contact_name alternate_contact_phone alternate_contact_email alternate_contact_relationship_type
           medical_provider_attributes
         ]
       )

--- a/app/forms/application_form.rb
+++ b/app/forms/application_form.rb
@@ -45,6 +45,12 @@ class ApplicationForm
   attribute :user_id, :integer # For dependent applications
   attribute :managing_guardian_id, :integer
 
+  # Alternate contact attributes
+  attribute :alternate_contact_name, :string
+  attribute :alternate_contact_phone, :string
+  attribute :alternate_contact_email, :string
+  attribute :alternate_contact_relationship_type, :string
+
   # Form state
   attribute :is_submission, :boolean, default: false
 
@@ -123,6 +129,7 @@ class ApplicationForm
     extract_address_attributes(app_params)
     extract_locale_attribute(params, app_params)
     extract_medical_provider_attributes(params)
+    extract_alternate_contact_attributes(app_params)
 
     self.is_submission = params[:submit_application].present?
   end
@@ -191,6 +198,13 @@ class ApplicationForm
     self.medical_provider_phone = mp_attrs[:phone] if mp_attrs[:phone]
     self.medical_provider_fax = mp_attrs[:fax] if mp_attrs[:fax]
     self.medical_provider_email = mp_attrs[:email] if mp_attrs[:email]
+  end
+
+  def extract_alternate_contact_attributes(app_params)
+    self.alternate_contact_name = app_params[:alternate_contact_name] if app_params.key?(:alternate_contact_name)
+    self.alternate_contact_phone = app_params[:alternate_contact_phone] if app_params.key?(:alternate_contact_phone)
+    self.alternate_contact_email = app_params[:alternate_contact_email] if app_params.key?(:alternate_contact_email)
+    self.alternate_contact_relationship_type = app_params[:alternate_contact_relationship_type] if app_params.key?(:alternate_contact_relationship_type)
   end
 
   def determine_applicant_user

--- a/app/services/applications/application_creator.rb
+++ b/app/services/applications/application_creator.rb
@@ -97,7 +97,11 @@ module Applications
         maryland_resident: @form.maryland_resident,
         self_certify_disability: @form.self_certify_disability,
         submission_method: @form.submission_method,
-        application_date: target_application.application_date || Date.current
+        application_date: target_application.application_date || Date.current,
+        alternate_contact_name: @form.alternate_contact_name,
+        alternate_contact_phone: @form.alternate_contact_phone,
+        alternate_contact_email: @form.alternate_contact_email,
+        alternate_contact_relationship_type: @form.alternate_contact_relationship_type
       }
       # Submission moves draft -> in_progress via transition_status! after save (canonical audit).
       attributes[:status] =

--- a/app/views/admin/applications/edit.html.erb
+++ b/app/views/admin/applications/edit.html.erb
@@ -79,10 +79,26 @@
           <%= form.text_field :alternate_contact_name, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
         </div>
         <div>
+          <%= form.label :alternate_contact_relationship_type, "Relationship", class: "block text-sm font-medium text-gray-700" %>
+          <%= form.select :alternate_contact_relationship_type,
+              options_for_select([
+                ["Select a relationship", ""],
+                ["Parent", "parent"],
+                ["Spouse", "spouse"],
+                ["Child", "child"],
+                ["Sibling", "sibling"],
+                ["Neighbor", "neighbor"],
+                ["Friend", "friend"],
+                ["Other", "other"]
+              ], @application.alternate_contact_relationship_type),
+              { include_blank: false },
+              class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
+        </div>
+        <div>
           <%= form.label :alternate_contact_phone, "Phone", class: "block text-sm font-medium text-gray-700" %>
           <%= form.telephone_field :alternate_contact_phone, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
         </div>
-        <div class="md:col-span-2">
+        <div>
           <%= form.label :alternate_contact_email, "Email", class: "block text-sm font-medium text-gray-700" %>
           <%= form.email_field :alternate_contact_email, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
         </div>

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -178,12 +178,18 @@
     <!-- Alternate Contact Information Section -->
     <section class="bg-white rounded-lg shadow p-6 mb-6" aria-labelledby="alternate-contact-info-title">
       <h2 id="alternate-contact-info-title" class="text-xl font-semibold text-gray-900 mb-4">Alternate Contact Information</h2>
-      <% if @application.alternate_contact_name.present? || @application.alternate_contact_phone.present? || @application.alternate_contact_email.present? %>
+      <% if @application.alternate_contact_name.present? || @application.alternate_contact_phone.present? || @application.alternate_contact_email.present? || @application.alternate_contact_relationship_type.present? %>
         <dl class="grid grid-cols-1 md:grid-cols-2 gap-6">
           <% if @application.alternate_contact_name.present? %>
             <div>
               <dt class="text-sm font-medium text-gray-500">Name</dt>
               <dd class="mt-1 text-sm text-gray-900"><%= @application.alternate_contact_name %></dd>
+            </div>
+          <% end %>
+          <% if @application.alternate_contact_relationship_type.present? %>
+            <div>
+              <dt class="text-sm font-medium text-gray-500">Relationship</dt>
+              <dd class="mt-1 text-sm text-gray-900"><%= @application.alternate_contact_relationship_type.titleize %></dd>
             </div>
           <% end %>
           <% if @application.alternate_contact_phone.present? %>

--- a/app/views/admin/paper_applications/new.html.erb
+++ b/app/views/admin/paper_applications/new.html.erb
@@ -710,11 +710,27 @@
           
           <div class="p-6">
             <%= fields_for :application do |a| %>
-              <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
                 <div>
                   <%= a.label :alternate_contact_name, "Name", class: "block text-sm font-medium text-gray-700" %>
                   <%= a.text_field :alternate_contact_name, 
                       autocomplete: "name",
+                      class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
+                </div>
+                <div>
+                  <%= a.label :alternate_contact_relationship_type, "Relationship", class: "block text-sm font-medium text-gray-700" %>
+                  <%= a.select :alternate_contact_relationship_type,
+                      options_for_select([
+                        ["Select", ""],
+                        ["Parent", "parent"],
+                        ["Spouse", "spouse"],
+                        ["Child", "child"],
+                        ["Sibling", "sibling"],
+                        ["Neighbor", "neighbor"],
+                        ["Friend", "friend"],
+                        ["Other", "other"]
+                      ]),
+                      { include_blank: false },
                       class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
                 </div>
                 <div>

--- a/app/views/constituent_portal/applications/edit.html.erb
+++ b/app/views/constituent_portal/applications/edit.html.erb
@@ -197,6 +197,23 @@
              <%= f.text_field :alternate_contact_name, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
            </div>
            
+           <div>
+             <%= f.label :alternate_contact_relationship_type, "Relationship", class: "block text-sm font-medium text-gray-700" %>
+             <% relationship_options = [
+               [t("applications.alternate_contact_relationship_types.parent"), "parent"],
+               [t("applications.alternate_contact_relationship_types.spouse"), "spouse"],
+               [t("applications.alternate_contact_relationship_types.child"), "child"],
+               [t("applications.alternate_contact_relationship_types.sibling"), "sibling"],
+               [t("applications.alternate_contact_relationship_types.neighbor"), "neighbor"],
+               [t("applications.alternate_contact_relationship_types.friend"), "friend"],
+               [t("applications.alternate_contact_relationship_types.other"), "other"]
+             ] %>
+             <%= f.select :alternate_contact_relationship_type,
+                 options_for_select(relationship_options, @application.alternate_contact_relationship_type),
+                 { prompt: "Select a relationship" },
+                 class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
+           </div>
+           
            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
              <div>
                <%= f.label :alternate_contact_phone, "Phone", class: "block text-sm font-medium text-gray-700" %>

--- a/app/views/constituent_portal/applications/new.html.erb
+++ b/app/views/constituent_portal/applications/new.html.erb
@@ -262,6 +262,23 @@
               <%= form.text_field :alternate_contact_name, autocomplete: "name", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
             </div>
             
+            <div>
+              <%= form.label :alternate_contact_relationship_type, "Relationship", class: "block text-sm font-medium text-gray-700" %>
+              <% relationship_options = [
+                [t("applications.alternate_contact_relationship_types.parent"), "parent"],
+                [t("applications.alternate_contact_relationship_types.spouse"), "spouse"],
+                [t("applications.alternate_contact_relationship_types.child"), "child"],
+                [t("applications.alternate_contact_relationship_types.sibling"), "sibling"],
+                [t("applications.alternate_contact_relationship_types.neighbor"), "neighbor"],
+                [t("applications.alternate_contact_relationship_types.friend"), "friend"],
+                [t("applications.alternate_contact_relationship_types.other"), "other"]
+              ] %>
+              <%= form.select :alternate_contact_relationship_type,
+                  options_for_select(relationship_options, @application.alternate_contact_relationship_type),
+                  { prompt: "Select a relationship" },
+                  class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
+            </div>
+            
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <%= form.label :alternate_contact_phone, "Phone", class: "block text-sm font-medium text-gray-700" %>

--- a/app/views/constituent_portal/applications/show.html.erb
+++ b/app/views/constituent_portal/applications/show.html.erb
@@ -100,12 +100,18 @@
     <%# Alternate Contact Section %>
     <section aria-labelledby="alternate-contact-heading" class="mb-6 p-4 bg-gray-50 rounded">
       <h2 id="alternate-contact-heading" class="text-xl font-semibold mb-4 text-gray-900">Alternate Contact Information</h2>
-      <% if @application.alternate_contact_name.present? || @application.alternate_contact_phone.present? || @application.alternate_contact_email.present? %>
+      <% if @application.alternate_contact_name.present? || @application.alternate_contact_phone.present? || @application.alternate_contact_email.present? || @application.alternate_contact_relationship_type.present? %>
         <dl class="space-y-3">
           <% if @application.alternate_contact_name.present? %>
             <div>
               <dt class="text-sm font-medium text-gray-700">Name</dt>
               <dd class="mt-1 text-sm text-gray-900"><%= @application.alternate_contact_name %></dd>
+            </div>
+          <% end %>
+          <% if @application.alternate_contact_relationship_type.present? %>
+            <div>
+              <dt class="text-sm font-medium text-gray-700">Relationship</dt>
+              <dd class="mt-1 text-sm text-gray-900"><%= @application.alternate_contact_relationship_type.titleize %></dd>
             </div>
           <% end %>
           <% if @application.alternate_contact_phone.present? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,15 @@
 #       enabled: "ON"
 
 en:
+  applications:
+    alternate_contact_relationship_types:
+      parent: "Parent"
+      spouse: "Spouse"
+      child: "Child"
+      sibling: "Sibling"
+      neighbor: "Neighbor"
+      friend: "Friend"
+      other: "Other"
   document_signing:
     medical_certification_request:
       submission_name: "Medical Certification - %{constituent_full_name} (Application %{application_id})"

--- a/db/migrate/20260414000000_add_alternate_contact_relationship_type_to_applications.rb
+++ b/db/migrate/20260414000000_add_alternate_contact_relationship_type_to_applications.rb
@@ -1,0 +1,5 @@
+class AddAlternateContactRelationshipTypeToApplications < ActiveRecord::Migration[8.1]
+  def change
+    add_column :applications, :alternate_contact_relationship_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,43 +10,43 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_14_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "accessories_evaluations", id: false, force: :cascade do |t|
-    t.bigint "evaluation_id", null: false
     t.bigint "accessory_id", null: false
+    t.bigint "evaluation_id", null: false
   end
 
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|
-    t.integer "status", default: 0, null: false
-    t.string "message_id", null: false
-    t.string "message_checksum", null: false
     t.datetime "created_at", null: false
+    t.string "message_checksum", null: false
+    t.string "message_id", null: false
+    t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index ["message_id", "message_checksum"], name: "index_action_mailbox_inbound_emails_uniqueness", unique: true
   end
 
   create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
     t.bigint "byte_size", null: false
     t.string "checksum"
+    t.string "content_type"
     t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -57,14 +57,14 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "application_notes", force: :cascade do |t|
-    t.bigint "application_id", null: false
     t.bigint "admin_id", null: false
-    t.text "content", null: false
-    t.boolean "internal_only", default: true
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.bigint "application_id", null: false
     t.bigint "assigned_to_id"
     t.datetime "completed_at"
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.boolean "internal_only", default: true
+    t.datetime "updated_at", null: false
     t.index ["admin_id"], name: "index_application_notes_on_admin_id"
     t.index ["application_id"], name: "index_application_notes_on_application_id"
     t.index ["assigned_to_id"], name: "index_application_notes_on_assigned_to_id"
@@ -73,73 +73,74 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
 
   create_table "application_status_changes", force: :cascade do |t|
     t.bigint "application_id", null: false
-    t.bigint "user_id"
-    t.string "from_status", null: false
-    t.string "to_status", null: false
-    t.datetime "changed_at", null: false
-    t.text "notes"
-    t.json "metadata"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "change_type"
+    t.datetime "changed_at", null: false
+    t.datetime "created_at", null: false
+    t.string "from_status", null: false
+    t.json "metadata"
+    t.text "notes"
+    t.string "to_status", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["application_id"], name: "index_application_status_changes_on_application_id"
     t.index ["changed_at"], name: "index_application_status_changes_on_changed_at"
     t.index ["user_id"], name: "index_application_status_changes_on_user_id"
   end
 
   create_table "applications", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.integer "status"
-    t.integer "application_type"
-    t.integer "submission_method"
-    t.datetime "application_date"
-    t.integer "household_size"
+    t.string "alternate_contact_email"
+    t.string "alternate_contact_name"
+    t.string "alternate_contact_phone"
+    t.string "alternate_contact_relationship_type"
     t.decimal "annual_income"
+    t.datetime "application_date"
+    t.integer "application_type"
+    t.datetime "created_at", null: false
+    t.string "current_step"
+    t.text "document_signing_audit_url"
+    t.text "document_signing_document_url"
+    t.integer "document_signing_request_count", default: 0, null: false
+    t.datetime "document_signing_requested_at"
+    t.string "document_signing_service"
+    t.datetime "document_signing_signed_at"
+    t.integer "document_signing_status", default: 0, null: false
+    t.string "document_signing_submission_id"
+    t.string "document_signing_submitter_id"
+    t.integer "fulfillment_type", null: false
+    t.integer "household_size"
+    t.text "income_details"
+    t.boolean "income_proof_required", null: false
+    t.integer "income_proof_status", default: 0, null: false
     t.datetime "income_verified_at"
     t.bigint "income_verified_by_id"
-    t.text "income_details"
-    t.text "residency_details"
-    t.string "current_step"
-    t.datetime "received_at"
-    t.datetime "last_activity_at"
-    t.integer "review_count"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "self_certify_disability"
-    t.boolean "maryland_resident"
-    t.boolean "terms_accepted"
     t.boolean "information_verified"
-    t.boolean "medical_release_authorized"
-    t.string "medical_provider_name"
-    t.string "medical_provider_phone"
-    t.string "medical_provider_fax"
-    t.string "medical_provider_email"
-    t.integer "total_rejections", default: 0, null: false
+    t.datetime "last_activity_at"
     t.datetime "last_proof_submitted_at"
-    t.datetime "needs_review_since"
+    t.string "last_visited_step"
+    t.bigint "managing_guardian_id"
+    t.boolean "maryland_resident"
+    t.integer "medical_certification_request_count", default: 0
+    t.datetime "medical_certification_requested_at"
     t.integer "medical_certification_status", default: 0, null: false
     t.datetime "medical_certification_verified_at"
     t.bigint "medical_certification_verified_by_id"
-    t.datetime "medical_certification_requested_at"
-    t.integer "medical_certification_request_count", default: 0
-    t.string "last_visited_step"
-    t.bigint "managing_guardian_id"
-    t.string "alternate_contact_name"
-    t.string "alternate_contact_phone"
-    t.string "alternate_contact_email"
-    t.integer "income_proof_status", default: 0, null: false
+    t.string "medical_provider_email"
+    t.string "medical_provider_fax"
+    t.string "medical_provider_name"
+    t.string "medical_provider_phone"
+    t.boolean "medical_release_authorized"
+    t.datetime "needs_review_since"
+    t.datetime "received_at"
+    t.text "residency_details"
     t.integer "residency_proof_status", default: 0, null: false
-    t.integer "document_signing_status", default: 0, null: false
-    t.string "document_signing_service"
-    t.string "document_signing_submission_id"
-    t.string "document_signing_submitter_id"
-    t.datetime "document_signing_requested_at"
-    t.datetime "document_signing_signed_at"
-    t.integer "document_signing_request_count", default: 0, null: false
-    t.text "document_signing_audit_url"
-    t.text "document_signing_document_url"
-    t.integer "fulfillment_type", null: false
-    t.boolean "income_proof_required", null: false
+    t.integer "review_count"
+    t.boolean "self_certify_disability"
+    t.integer "status"
+    t.integer "submission_method"
+    t.boolean "terms_accepted"
+    t.integer "total_rejections", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["document_signing_service"], name: "index_applications_on_document_signing_service"
     t.index ["document_signing_status"], name: "index_applications_on_document_signing_status"
     t.index ["document_signing_submission_id"], name: "index_applications_on_document_signing_submission_id"
@@ -168,42 +169,42 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "email_templates", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "subject"
     t.text "body"
-    t.jsonb "variables", default: {}
-    t.bigint "updated_by_id"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "format", default: 0
     t.text "description"
-    t.integer "version", default: 1
-    t.string "previous_subject"
-    t.text "previous_body"
     t.boolean "enabled", default: true, null: false
+    t.integer "format", default: 0
     t.string "locale", default: "en", null: false
+    t.string "name", null: false
     t.boolean "needs_sync", default: false, null: false
+    t.text "previous_body"
+    t.string "previous_subject"
+    t.string "subject"
+    t.datetime "updated_at", null: false
+    t.bigint "updated_by_id"
+    t.jsonb "variables", default: {}
+    t.integer "version", default: 1
     t.index ["enabled"], name: "index_email_templates_on_enabled"
     t.index ["name", "format", "locale"], name: "index_email_templates_on_name_format_locale", unique: true
     t.index ["updated_by_id"], name: "index_email_templates_on_updated_by_id"
   end
 
   create_table "evaluations", force: :cascade do |t|
-    t.bigint "evaluator_id", null: false
+    t.bigint "application_id", null: false
+    t.jsonb "attendees", default: []
     t.bigint "constituent_id", null: false
+    t.datetime "created_at", null: false
     t.datetime "evaluation_date"
     t.integer "evaluation_type"
-    t.boolean "report_submitted"
-    t.text "notes"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "status", default: 0
-    t.bigint "application_id", null: false
-    t.text "needs"
+    t.bigint "evaluator_id", null: false
     t.string "location"
-    t.jsonb "attendees", default: []
+    t.text "needs"
+    t.text "notes"
     t.jsonb "products_tried", default: []
+    t.boolean "report_submitted"
     t.text "reschedule_reason"
+    t.integer "status", default: 0
+    t.datetime "updated_at", null: false
     t.index ["application_id"], name: "index_evaluations_on_application_id"
     t.index ["constituent_id"], name: "index_evaluations_on_constituent_id"
     t.index ["evaluator_id"], name: "index_evaluations_on_evaluator_id"
@@ -217,15 +218,15 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "events", force: :cascade do |t|
-    t.bigint "user_id", null: false
     t.string "action", null: false
-    t.string "user_agent"
-    t.string "ip_address"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.jsonb "metadata", default: {}, null: false
-    t.string "auditable_type"
     t.bigint "auditable_id"
+    t.string "auditable_type"
+    t.datetime "created_at", null: false
+    t.string "ip_address"
+    t.jsonb "metadata", default: {}, null: false
+    t.datetime "updated_at", null: false
+    t.string "user_agent"
+    t.bigint "user_id", null: false
     t.index ["action", "auditable_type", "auditable_id"], name: "index_events_on_action_and_auditable"
     t.index ["auditable_type", "auditable_id"], name: "index_events_on_auditable"
     t.index ["metadata"], name: "index_events_on_metadata", using: :gin
@@ -233,18 +234,18 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "feature_flags", force: :cascade do |t|
-    t.string "name", null: false
-    t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
+    t.boolean "enabled", default: false, null: false
+    t.string "name", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_feature_flags_on_name", unique: true
   end
 
   create_table "guardian_relationships", force: :cascade do |t|
-    t.bigint "guardian_id", null: false
-    t.bigint "dependent_id", null: false
-    t.string "relationship_type"
     t.datetime "created_at", null: false
+    t.bigint "dependent_id", null: false
+    t.bigint "guardian_id", null: false
+    t.string "relationship_type"
     t.datetime "updated_at", null: false
     t.index ["dependent_id"], name: "index_guardian_relationships_on_dependent_id"
     t.index ["guardian_id", "dependent_id"], name: "index_guardian_relationships_on_guardian_id_and_dependent_id", unique: true
@@ -252,25 +253,25 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "invoices", force: :cascade do |t|
-    t.bigint "vendor_id", null: false
-    t.datetime "start_date", null: false
-    t.datetime "end_date", null: false
-    t.decimal "total_amount", precision: 10, scale: 2, default: "0.0", null: false
-    t.integer "status", default: 0, null: false
-    t.datetime "payment_date"
-    t.string "payment_reference"
-    t.text "notes"
-    t.string "invoice_number", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "check_number"
-    t.datetime "check_issued_at"
+    t.datetime "approved_at"
     t.datetime "check_cashed_at"
     t.string "check_cashed_by"
+    t.datetime "check_issued_at"
+    t.string "check_number"
+    t.datetime "created_at", null: false
+    t.datetime "end_date", null: false
     t.string "gad_invoice_reference"
+    t.string "invoice_number", null: false
+    t.text "notes"
+    t.datetime "payment_date"
     t.text "payment_notes"
-    t.datetime "approved_at"
     t.datetime "payment_recorded_at"
+    t.string "payment_reference"
+    t.datetime "start_date", null: false
+    t.integer "status", default: 0, null: false
+    t.decimal "total_amount", precision: 10, scale: 2, default: "0.0", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "vendor_id", null: false
     t.index ["approved_at"], name: "index_invoices_on_approved_at"
     t.index ["check_cashed_at"], name: "index_invoices_on_check_cashed_at"
     t.index ["check_issued_at"], name: "index_invoices_on_check_issued_at"
@@ -286,20 +287,20 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "notifications", force: :cascade do |t|
-    t.bigint "recipient_id", null: false
-    t.bigint "actor_id"
     t.string "action"
-    t.datetime "read_at"
-    t.jsonb "metadata"
-    t.string "notifiable_type", null: false
-    t.bigint "notifiable_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "message_id"
-    t.string "delivery_status"
-    t.datetime "delivered_at"
-    t.datetime "opened_at"
+    t.bigint "actor_id"
     t.boolean "audited", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "delivered_at"
+    t.string "delivery_status"
+    t.string "message_id"
+    t.jsonb "metadata"
+    t.bigint "notifiable_id"
+    t.string "notifiable_type", null: false
+    t.datetime "opened_at"
+    t.datetime "read_at"
+    t.bigint "recipient_id", null: false
+    t.datetime "updated_at", null: false
     t.index ["actor_id"], name: "index_notifications_on_actor_id"
     t.index ["audited"], name: "index_notifications_on_audited"
     t.index ["message_id"], name: "index_notifications_on_message_id"
@@ -308,32 +309,32 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "policies", force: :cascade do |t|
-    t.string "key"
-    t.integer "value"
     t.datetime "created_at", null: false
+    t.string "key"
     t.datetime "updated_at", null: false
+    t.integer "value"
     t.index ["key"], name: "index_policies_on_key", unique: true
   end
 
   create_table "policy_changes", force: :cascade do |t|
-    t.bigint "policy_id", null: false
-    t.bigint "user_id", null: false
-    t.integer "previous_value"
-    t.integer "new_value"
     t.datetime "created_at", null: false
+    t.integer "new_value"
+    t.bigint "policy_id", null: false
+    t.integer "previous_value"
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["policy_id"], name: "index_policy_changes_on_policy_id"
     t.index ["user_id"], name: "index_policy_changes_on_user_id"
   end
 
   create_table "print_queue_items", force: :cascade do |t|
-    t.integer "letter_type", null: false
-    t.integer "status", default: 0, null: false
-    t.bigint "constituent_id", null: false
-    t.bigint "application_id"
     t.bigint "admin_id"
-    t.datetime "printed_at"
+    t.bigint "application_id"
+    t.bigint "constituent_id", null: false
     t.datetime "created_at", null: false
+    t.integer "letter_type", null: false
+    t.datetime "printed_at"
+    t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index ["admin_id"], name: "index_print_queue_items_on_admin_id"
     t.index ["application_id"], name: "index_print_queue_items_on_application_id"
@@ -342,18 +343,18 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "products", force: :cascade do |t|
-    t.string "name"
-    t.text "description"
-    t.decimal "price"
     t.datetime "archived_at"
+    t.text "compatibility_notes"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.text "description"
+    t.text "device_types", default: [], array: true
+    t.string "documentation_url"
+    t.text "features"
     t.string "manufacturer"
     t.string "model_number"
-    t.text "features"
-    t.text "compatibility_notes"
-    t.string "documentation_url"
-    t.text "device_types", default: [], array: true
+    t.string "name"
+    t.decimal "price"
+    t.datetime "updated_at", null: false
     t.index ["device_types"], name: "index_products_on_device_types", using: :gin
   end
 
@@ -365,17 +366,17 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "proof_reviews", force: :cascade do |t|
-    t.bigint "application_id", null: false
     t.bigint "admin_id", null: false
-    t.integer "proof_type"
-    t.integer "status"
-    t.text "rejection_reason"
-    t.integer "submission_method"
-    t.datetime "reviewed_at", null: false
+    t.bigint "application_id", null: false
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.text "notes"
+    t.integer "proof_type"
+    t.text "rejection_reason"
     t.string "rejection_reason_code"
+    t.datetime "reviewed_at", null: false
+    t.integer "status"
+    t.integer "submission_method"
+    t.datetime "updated_at", null: false
     t.index ["admin_id", "created_at"], name: "index_proof_reviews_on_admin_id_and_created_at"
     t.index ["admin_id"], name: "index_proof_reviews_on_admin_id"
     t.index ["application_id", "proof_type", "created_at"], name: "idx_on_application_id_proof_type_created_at_4b8ffa7c5f"
@@ -387,94 +388,94 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "recovery_requests", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "status"
+    t.datetime "created_at", null: false
     t.text "details"
     t.string "ip_address"
-    t.text "user_agent"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.datetime "resolved_at"
     t.integer "resolved_by_id"
+    t.string "status"
+    t.datetime "updated_at", null: false
+    t.text "user_agent"
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_recovery_requests_on_user_id"
   end
 
   create_table "rejection_reasons", force: :cascade do |t|
-    t.string "code", null: false
-    t.string "proof_type", null: false
-    t.string "locale", default: "en", null: false
     t.text "body", null: false
-    t.boolean "needs_sync", default: false, null: false
-    t.integer "version", default: 1, null: false
-    t.text "previous_body"
-    t.bigint "updated_by_id"
+    t.string "code", null: false
     t.datetime "created_at", null: false
+    t.string "locale", default: "en", null: false
+    t.boolean "needs_sync", default: false, null: false
+    t.text "previous_body"
+    t.string "proof_type", null: false
     t.datetime "updated_at", null: false
+    t.bigint "updated_by_id"
+    t.integer "version", default: 1, null: false
     t.index ["code", "proof_type", "locale"], name: "index_rejection_reasons_on_code_proof_type_locale", unique: true
     t.index ["updated_by_id"], name: "index_rejection_reasons_on_updated_by_id"
   end
 
   create_table "role_capabilities", force: :cascade do |t|
-    t.bigint "user_id", null: false
     t.string "capability", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["user_id", "capability"], name: "index_role_capabilities_on_user_id_and_capability", unique: true
     t.index ["user_id"], name: "index_role_capabilities_on_user_id"
   end
 
   create_table "sessions", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "user_agent"
-    t.string "ip_address"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "session_token"
-    t.integer "failed_attempts", default: 0
     t.datetime "expires_at"
+    t.integer "failed_attempts", default: 0
+    t.string "ip_address"
+    t.string "session_token"
+    t.datetime "updated_at", null: false
+    t.string "user_agent"
+    t.bigint "user_id", null: false
     t.index ["expires_at"], name: "index_sessions_on_expires_at"
     t.index ["session_token"], name: "index_sessions_on_session_token", unique: true
     t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
   create_table "sms_credentials", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "phone_number", null: false
-    t.datetime "last_sent_at", null: false
     t.text "code_digest"
     t.datetime "code_expires_at"
     t.datetime "created_at", null: false
+    t.datetime "last_sent_at", null: false
+    t.string "phone_number", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_sms_credentials_on_user_id"
   end
 
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "queue_name", null: false
-    t.integer "priority", default: 0, null: false
     t.string "concurrency_key", null: false
-    t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
     t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
     t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
     t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
   end
 
   create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.bigint "job_id", null: false
     t.bigint "process_id"
-    t.datetime "created_at", null: false
     t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
     t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
   end
 
   create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.text "backtrace"
+    t.datetime "created_at", null: false
+    t.text "error"
+    t.datetime "failed_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.bigint "job_id", null: false
     t.bigint "process_id"
-    t.text "error"
-    t.text "backtrace"
-    t.datetime "failed_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["failed_at"], name: "index_solid_queue_failed_executions_on_failed_at"
     t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id"
@@ -482,15 +483,15 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "solid_queue_jobs", force: :cascade do |t|
-    t.string "queue_name", null: false
-    t.string "class_name", null: false
-    t.text "arguments"
-    t.integer "priority", default: 0, null: false
     t.string "active_job_id"
-    t.datetime "scheduled_at"
-    t.datetime "finished_at"
+    t.text "arguments"
+    t.string "class_name", null: false
     t.string "concurrency_key"
     t.datetime "created_at", null: false
+    t.datetime "finished_at"
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at"
     t.datetime "updated_at", null: false
     t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
     t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
@@ -500,76 +501,76 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "solid_queue_pauses", force: :cascade do |t|
-    t.string "queue_name", null: false
     t.datetime "created_at", null: false
+    t.string "queue_name", null: false
     t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
   end
 
   create_table "solid_queue_processes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "hostname"
     t.string "kind", null: false
     t.datetime "last_heartbeat_at", null: false
-    t.bigint "supervisor_id"
-    t.integer "pid", null: false
-    t.string "hostname"
     t.text "metadata"
-    t.datetime "created_at", null: false
     t.string "name", null: false
+    t.integer "pid", null: false
+    t.bigint "supervisor_id"
     t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
     t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
     t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
   end
 
   create_table "solid_queue_ready_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "queue_name", null: false
-    t.integer "priority", default: 0, null: false
     t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
     t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
     t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
     t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
   end
 
   create_table "solid_queue_recurring_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "task_key", null: false
-    t.datetime "run_at", null: false
     t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.datetime "run_at", null: false
+    t.string "task_key", null: false
     t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
     t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
   end
 
   create_table "solid_queue_recurring_tasks", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "schedule", null: false
-    t.string "command", limit: 2048
-    t.string "class_name"
     t.text "arguments"
-    t.string "queue_name"
-    t.integer "priority", default: 0
-    t.boolean "static", default: true, null: false
-    t.text "description"
+    t.string "class_name"
+    t.string "command", limit: 2048
     t.datetime "created_at", null: false
+    t.text "description"
+    t.string "key", null: false
+    t.integer "priority", default: 0
+    t.string "queue_name"
+    t.string "schedule", null: false
+    t.boolean "static", default: true, null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
     t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
   end
 
   create_table "solid_queue_scheduled_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "queue_name", null: false
-    t.integer "priority", default: 0, null: false
-    t.datetime "scheduled_at", null: false
     t.datetime "created_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at", null: false
     t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
     t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
   end
 
   create_table "solid_queue_semaphores", force: :cascade do |t|
-    t.string "key", null: false
-    t.integer "value", default: 1, null: false
-    t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "key", null: false
     t.datetime "updated_at", null: false
+    t.integer "value", default: 1, null: false
     t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
     t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
@@ -581,95 +582,95 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "totp_credentials", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.text "secret", null: false
-    t.string "nickname", null: false
-    t.datetime "last_used_at", null: false
     t.datetime "created_at", null: false
+    t.datetime "last_used_at", null: false
+    t.string "nickname", null: false
+    t.text "secret", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_totp_credentials_on_user_id"
   end
 
   create_table "training_sessions", force: :cascade do |t|
     t.bigint "application_id", null: false
-    t.bigint "trainer_id", null: false
-    t.datetime "scheduled_for"
-    t.datetime "completed_at"
-    t.integer "status", default: 0
-    t.text "notes"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text "reschedule_reason"
-    t.datetime "cancelled_at"
     t.text "cancellation_reason"
-    t.bigint "product_trained_on_id"
+    t.datetime "cancelled_at"
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
     t.text "no_show_notes"
+    t.text "notes"
+    t.bigint "product_trained_on_id"
+    t.text "reschedule_reason"
+    t.datetime "scheduled_for"
+    t.integer "status", default: 0
+    t.bigint "trainer_id", null: false
+    t.datetime "updated_at", null: false
     t.index ["application_id"], name: "index_training_sessions_on_application_id"
     t.index ["product_trained_on_id"], name: "index_training_sessions_on_product_trained_on_id"
     t.index ["trainer_id"], name: "index_training_sessions_on_trainer_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "email", limit: 510, null: false
-    t.string "password_digest", limit: 500, null: false
-    t.boolean "verified", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "type"
-    t.string "first_name"
-    t.string "middle_initial"
-    t.string "last_name"
-    t.string "phone", limit: 300
-    t.string "ssn_last4", limit: 300
-    t.string "physical_address_1", limit: 1000
-    t.string "physical_address_2", limit: 1000
-    t.string "city", limit: 500
-    t.string "state", limit: 300
-    t.string "zip_code", limit: 300
-    t.string "county_of_residence"
-    t.datetime "last_sign_in_at"
-    t.string "last_sign_in_ip"
-    t.integer "failed_attempts"
-    t.datetime "locked_at"
-    t.integer "status"
-    t.boolean "valid_dcf", default: false
-    t.boolean "previous_application_submitted", default: false
-    t.boolean "newsletter_signup", default: false
-    t.boolean "home_internet_service", default: false
     t.json "availability_schedule"
-    t.integer "communication_preference"
-    t.string "timezone"
-    t.string "locale"
-    t.string "preferred_means_of_communication"
-    t.boolean "hearing_disability", default: false
-    t.boolean "vision_disability", default: false
-    t.boolean "speech_disability", default: false
-    t.boolean "mobility_disability", default: false
-    t.boolean "cognition_disability", default: false
-    t.bigint "income_verified_by_id"
-    t.bigint "evaluator_id"
-    t.bigint "recipient_id"
-    t.bigint "medical_provider_id"
-    t.boolean "email_verified"
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.string "fax"
     t.string "business_name"
     t.string "business_tax_id"
-    t.datetime "terms_accepted_at"
-    t.integer "w9_status", default: 0, null: false
-    t.integer "w9_rejections_count", default: 0, null: false
-    t.datetime "last_w9_reminder_sent_at"
-    t.boolean "force_password_change", default: false, null: false
-    t.string "website_url"
-    t.string "webauthn_id"
-    t.boolean "needs_duplicate_review", default: false, null: false
-    t.string "phone_type", default: "voice"
+    t.string "city", limit: 500
+    t.boolean "cognition_disability", default: false
+    t.integer "communication_preference"
+    t.string "county_of_residence"
+    t.datetime "created_at", null: false
     t.text "date_of_birth"
     t.string "dependent_email", comment: "Optional email for dependents; if blank, uses guardian email"
     t.string "dependent_phone", comment: "Optional phone for dependents; if blank, uses guardian phone"
-    t.integer "vendor_authorization_status"
+    t.string "email", limit: 510, null: false
+    t.boolean "email_verified"
+    t.bigint "evaluator_id"
+    t.integer "failed_attempts"
+    t.string "fax"
+    t.string "first_name"
+    t.boolean "force_password_change", default: false, null: false
+    t.boolean "hearing_disability", default: false
+    t.boolean "home_internet_service", default: false
+    t.bigint "income_verified_by_id"
+    t.string "last_name"
+    t.datetime "last_sign_in_at"
+    t.string "last_sign_in_ip"
+    t.datetime "last_w9_reminder_sent_at"
+    t.string "locale"
+    t.datetime "locked_at"
+    t.bigint "medical_provider_id"
+    t.string "middle_initial"
+    t.boolean "mobility_disability", default: false
+    t.boolean "needs_duplicate_review", default: false, null: false
+    t.boolean "newsletter_signup", default: false
+    t.string "password_digest", limit: 500, null: false
+    t.string "phone", limit: 300
+    t.string "phone_type", default: "voice"
+    t.string "physical_address_1", limit: 1000
+    t.string "physical_address_2", limit: 1000
+    t.string "preferred_means_of_communication"
+    t.boolean "previous_application_submitted", default: false
+    t.bigint "recipient_id"
     t.string "referral_source"
+    t.datetime "reset_password_sent_at"
+    t.string "reset_password_token"
+    t.boolean "speech_disability", default: false
+    t.string "ssn_last4", limit: 300
+    t.string "state", limit: 300
+    t.integer "status"
+    t.datetime "terms_accepted_at"
+    t.string "timezone"
+    t.string "type"
+    t.datetime "updated_at", null: false
+    t.boolean "valid_dcf", default: false
+    t.integer "vendor_authorization_status"
+    t.boolean "verified", default: false, null: false
+    t.boolean "vision_disability", default: false
+    t.integer "w9_rejections_count", default: 0, null: false
+    t.integer "w9_status", default: 0, null: false
+    t.string "webauthn_id"
+    t.string "website_url"
+    t.string "zip_code", limit: 300
     t.index ["business_name"], name: "index_users_on_business_name"
     t.index ["business_tax_id"], name: "index_users_on_business_tax_id"
     t.index ["dependent_email"], name: "index_users_on_dependent_email"
@@ -691,28 +692,28 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "voucher_transaction_products", force: :cascade do |t|
-    t.bigint "voucher_transaction_id", null: false
+    t.datetime "created_at", null: false
     t.bigint "product_id", null: false
     t.integer "quantity", default: 1, null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "voucher_transaction_id", null: false
     t.index ["product_id"], name: "index_voucher_transaction_products_on_product_id"
     t.index ["voucher_transaction_id", "product_id"], name: "idx_on_voucher_txn_product"
     t.index ["voucher_transaction_id"], name: "index_voucher_transaction_products_on_voucher_transaction_id"
   end
 
   create_table "voucher_transactions", force: :cascade do |t|
-    t.bigint "voucher_id", null: false
-    t.bigint "vendor_id", null: false
-    t.bigint "invoice_id"
     t.decimal "amount", precision: 10, scale: 2, null: false
-    t.integer "transaction_type", default: 0, null: false
-    t.integer "status", default: 0, null: false
-    t.datetime "processed_at"
-    t.text "notes"
-    t.string "reference_number"
     t.datetime "created_at", null: false
+    t.bigint "invoice_id"
+    t.text "notes"
+    t.datetime "processed_at"
+    t.string "reference_number"
+    t.integer "status", default: 0, null: false
+    t.integer "transaction_type", default: 0, null: false
     t.datetime "updated_at", null: false
+    t.bigint "vendor_id", null: false
+    t.bigint "voucher_id", null: false
     t.index ["invoice_id"], name: "index_voucher_transactions_on_invoice_id"
     t.index ["processed_at"], name: "index_voucher_transactions_on_processed_at"
     t.index ["reference_number"], name: "index_voucher_transactions_on_reference_number"
@@ -725,19 +726,19 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "vouchers", force: :cascade do |t|
+    t.bigint "application_id", null: false
     t.string "code", null: false
+    t.datetime "created_at", null: false
     t.decimal "initial_value", precision: 10, scale: 2, null: false
+    t.bigint "invoice_id"
+    t.datetime "issued_at"
+    t.datetime "last_used_at"
+    t.text "notes"
+    t.datetime "redeemed_at"
     t.decimal "remaining_value", precision: 10, scale: 2, null: false
     t.integer "status", default: 0, null: false
-    t.bigint "application_id", null: false
-    t.bigint "vendor_id"
-    t.datetime "issued_at"
-    t.datetime "redeemed_at"
-    t.datetime "last_used_at"
-    t.bigint "invoice_id"
-    t.text "notes"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "vendor_id"
     t.index ["application_id"], name: "index_vouchers_on_application_id"
     t.index ["code"], name: "index_vouchers_on_code", unique: true
     t.index ["invoice_id"], name: "index_vouchers_on_invoice_id"
@@ -748,27 +749,27 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_153000) do
   end
 
   create_table "w9_reviews", force: :cascade do |t|
-    t.bigint "vendor_id", null: false
     t.bigint "admin_id", null: false
-    t.integer "status", default: 0, null: false
-    t.integer "rejection_reason_code"
-    t.text "rejection_reason"
-    t.datetime "reviewed_at", null: false
     t.datetime "created_at", null: false
+    t.text "rejection_reason"
+    t.integer "rejection_reason_code"
+    t.datetime "reviewed_at", null: false
+    t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
+    t.bigint "vendor_id", null: false
     t.index ["admin_id"], name: "index_w9_reviews_on_admin_id"
     t.index ["vendor_id"], name: "index_w9_reviews_on_vendor_id"
   end
 
   create_table "webauthn_credentials", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "external_id", null: false
-    t.text "public_key", null: false
-    t.string "nickname", null: false
-    t.bigint "sign_count", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "authenticator_type"
+    t.datetime "created_at", null: false
+    t.string "external_id", null: false
+    t.string "nickname", null: false
+    t.text "public_key", null: false
+    t.bigint "sign_count", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["external_id"], name: "index_webauthn_credentials_on_external_id", unique: true
     t.index ["user_id"], name: "index_webauthn_credentials_on_user_id"
   end

--- a/test/system/admin/paper_application_upload_test.rb
+++ b/test/system/admin/paper_application_upload_test.rb
@@ -94,6 +94,7 @@ module Admin
         # Fill in Alternate Contact (optional) - This was missing from previous tests
         within 'fieldset', text: 'Alternate Contact (optional)' do
           fill_in 'application[alternate_contact_name]', with: 'Jane Doe'
+          select 'Neighbor', from: 'application[alternate_contact_relationship_type]'
           fill_in 'application[alternate_contact_phone]', with: '555-123-4567'
           fill_in 'application[alternate_contact_email]', with: 'jane.doe@example.com'
         end
@@ -145,6 +146,7 @@ module Admin
       assert_equal 'dr.smith@example.com', application.medical_provider_email
       assert_equal '555-987-6544', application.medical_provider_fax
       assert_equal 'Jane Doe', application.alternate_contact_name
+      assert_equal 'neighbor', application.alternate_contact_relationship_type
       assert_equal '555-123-4567', application.alternate_contact_phone
       assert_equal 'jane.doe@example.com', application.alternate_contact_email
       assert application.user.date_of_birth.present?


### PR DESCRIPTION
This change adds a field for alternate_contact_relationship_type so that admins can know how the constituent knows their related contact.