### PR TITLE
Tighten practitioner boundaries and enforce service windows

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -28,7 +28,7 @@ module Admin
     before_action :set_application, only: %i[
       show edit update
       request_documents review_proof update_proof_status
-      approve reject assign_evaluator assign_trainer schedule_training complete_training
+      approve reject assign_evaluator assign_trainer
       update_certification_status resend_medical_certification assign_voucher
       upload_medical_certification send_document_signing_request
       queue_medical_certification_form
@@ -234,7 +234,7 @@ module Admin
                     notice: t('.eval_assign_pass')
       else
         redirect_to admin_application_path(@application),
-                    alert: t('.eval_assign_fail')
+                    alert: @application.errors.full_messages.to_sentence.presence || t('.eval_assign_fail')
       end
     end
 
@@ -247,37 +247,8 @@ module Admin
                     notice: t('.trainer_assign_pass')
       else
         redirect_to admin_application_path(@application),
-                    alert: t('.trainer_assign_fail')
+                    alert: @application.errors.full_messages.to_sentence.presence || t('.trainer_assign_fail')
       end
-    end
-
-    def schedule_training
-      trainer = Users::Trainer.active.find_by(id: params[:trainer_id])
-      unless trainer
-        redirect_to admin_application_path(@application), alert: t('.t_schedule_invalid')
-        return
-      end
-
-      training_session = @application.schedule_training!(
-        trainer: trainer,
-        scheduled_for: params[:scheduled_for]
-      )
-
-      if training_session.persisted?
-        redirect_to admin_application_path(@application),
-                    notice: "Training session scheduled with #{trainer.full_name}"
-      else
-        redirect_to admin_application_path(@application),
-                    alert: t('.t_schedule_fail')
-      end
-    end
-
-    def complete_training
-      training_session = @application.training_sessions.find(params[:training_session_id])
-      training_session.complete!
-
-      redirect_to admin_application_path(@application),
-                  notice: t('.t_completed')
     end
 
     # Updates medical certification status and handles file uploads

--- a/app/controllers/evaluators/evaluations_controller.rb
+++ b/app/controllers/evaluators/evaluations_controller.rb
@@ -6,6 +6,7 @@ module Evaluators
     before_action :require_evaluator!
     before_action :set_evaluation,
                   except: %i[index new create pending completed requested scheduled needs_followup filter]
+    before_action :authorize_evaluation_mutation!, only: %i[edit update schedule reschedule submit_report request_additional_info]
 
     def index
       # Redirect to dashboard for main entry point
@@ -93,6 +94,7 @@ module Evaluators
 
     def show
       # @evaluation is set by set_evaluation
+      @can_manage_evaluation = assigned_evaluator?
     end
 
     def new
@@ -210,6 +212,13 @@ module Evaluators
       redirect_to root_path, alert: 'Not authorized'
     end
 
+    def authorize_evaluation_mutation!
+      return if assigned_evaluator?
+
+      redirect_target = current_user&.admin? ? evaluators_evaluation_path(@evaluation) : evaluators_evaluations_path
+      redirect_to redirect_target, alert: 'Only the assigned evaluator can update this evaluation.'
+    end
+
     def filter_evaluations(_scope, status)
       # Base query - either all sessions or just mine
       base_query = if current_user.admin?
@@ -265,6 +274,10 @@ module Evaluators
         { 'product_id' => product_id, 'reaction' => 'Recorded during evaluation' }
       end
       params[:products_tried] = products_tried
+    end
+
+    def assigned_evaluator?
+      @evaluation&.evaluator_id == current_user&.id
     end
   end
 end

--- a/app/controllers/trainers/training_sessions_controller.rb
+++ b/app/controllers/trainers/training_sessions_controller.rb
@@ -5,6 +5,7 @@ module Trainers
   # Handles listing, filtering, showing, and updating the status of training sessions.
   class TrainingSessionsController < Trainers::BaseController
     before_action :set_training_session, only: %i[show update_status complete schedule reschedule cancel] # Removed :edit
+    before_action :authorize_training_session_mutation!, only: %i[update_status complete schedule reschedule cancel]
 
     def index
       if params[:status].present? || params[:scope].present? || params[:filter].present?
@@ -205,10 +206,19 @@ module Trainers
       end
 
       # Authorization check: Allow admins or the assigned trainer
-      return if current_user&.admin? || (@training_session && @training_session.trainer_id == current_user&.id)
+      return if current_user&.admin? || assigned_trainer?
 
       # If not authorized, redirect with an alert
       redirect_to trainers_dashboard_path, alert: "You don't have access to this training session."
+    ensure
+      @can_manage_training_session = assigned_trainer?
+    end
+
+    def authorize_training_session_mutation!
+      return if assigned_trainer?
+
+      redirect_target = current_user&.admin? ? trainers_training_session_path(@training_session) : trainers_dashboard_path
+      redirect_to redirect_target, alert: 'Only the assigned trainer can update this training session.'
     end
 
     def training_session_params
@@ -261,6 +271,10 @@ module Trainers
       Event.where('metadata @> ?', { training_session_id: @training_session.id }.to_json)
            .includes(:user)
            .order(created_at: :asc)
+    end
+
+    def assigned_trainer?
+      @training_session&.trainer_id == current_user&.id
     end
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -140,6 +140,8 @@ class Application < ApplicationRecord
   validate :constituent_must_have_disability, if: :validate_disability?
   validate :managing_guardian_cannot_be_applicant
 
+  delegate :present?, to: :active_training_session, prefix: true
+
   before_validation :scrub_income_fields, if: :should_scrub_income?
   before_save :ensure_managing_guardian_set, if: :user_id_changed?
   # Callbacks
@@ -228,6 +230,20 @@ class Application < ApplicationRecord
     )
   }
 
+  scope :with_pending_training_request, lambda {
+    where(status: :approved)
+      .where.not(training_requested_at: nil)
+      .where.not(id: TrainingSession.assigned_or_scheduled.select(:application_id))
+      .where(<<~SQL.squish)
+        NOT EXISTS (
+          SELECT 1
+          FROM training_sessions
+          WHERE training_sessions.application_id = applications.id
+            AND training_sessions.created_at >= applications.training_requested_at
+        )
+      SQL
+  }
+
   scope :with_pending_training, lambda {
     joins(:training_sessions).merge(TrainingSession.where(status: %i[requested scheduled confirmed])).distinct
   }
@@ -269,6 +285,11 @@ class Application < ApplicationRecord
       .group(:last_visited_step)
       .order(count_all: :desc)
       .count
+  end
+
+  def self.expire_training_request_metrics_cache!
+    Rails.cache.delete('admin_dashboard_metrics')
+    Rails.cache.delete('dashboard_metrics_training_requests')
   end
 
   def self.batch_update_status(ids, new_status, actor:) # rubocop:disable Metrics/PerceivedComplexity
@@ -514,6 +535,24 @@ class Application < ApplicationRecord
       status_approved? &&
       medical_certification_status_approved? &&
       !vouchers.exists?
+  end
+
+  def active_training_session
+    training_sessions.assigned_or_scheduled.order(created_at: :desc).first
+  end
+
+  def training_request_pending?
+    training_requested_at.present? &&
+      !active_training_session_present? &&
+      training_sessions.where(created_at: training_requested_at..).none?
+  end
+
+  def service_window_active?
+    return false unless status_approved?
+    return false if application_date.blank?
+
+    waiting_period = Policy.get('waiting_period_years') || 3
+    application_date.to_date + waiting_period.years > Date.current
   end
 
   # Returns the guardian relationship type for this application

--- a/app/models/concerns/evaluation_management.rb
+++ b/app/models/concerns/evaluation_management.rb
@@ -5,15 +5,12 @@
 module EvaluationManagement
   extend ActiveSupport::Concern
 
-  EVALUATION_SERVICE_WINDOW_ERROR = 'This application is outside the service window for evaluation services.'
-  private_constant :EVALUATION_SERVICE_WINDOW_ERROR
-
   # Assigns an evaluator to this application
   # @param evaluator [Evaluator] The evaluator to assign
   # @return [Boolean] True if the evaluator was assigned successfully
   def assign_evaluator!(evaluator)
     unless service_window_active?
-      errors.add(:base, EVALUATION_SERVICE_WINDOW_ERROR)
+      errors.add(:base, :evaluation_service_window)
       return false
     end
 

--- a/app/models/concerns/evaluation_management.rb
+++ b/app/models/concerns/evaluation_management.rb
@@ -5,10 +5,18 @@
 module EvaluationManagement
   extend ActiveSupport::Concern
 
+  EVALUATION_SERVICE_WINDOW_ERROR = 'This application is outside the service window for evaluation services.'
+  private_constant :EVALUATION_SERVICE_WINDOW_ERROR
+
   # Assigns an evaluator to this application
   # @param evaluator [Evaluator] The evaluator to assign
   # @return [Boolean] True if the evaluator was assigned successfully
   def assign_evaluator!(evaluator)
+    unless service_window_active?
+      errors.add(:base, EVALUATION_SERVICE_WINDOW_ERROR)
+      return false
+    end
+
     with_lock do
       evaluation = evaluations.create!(
         evaluator: evaluator,
@@ -43,6 +51,7 @@ module EvaluationManagement
     true
   rescue ::ActiveRecord::RecordInvalid => e
     Rails.logger.error "Failed to assign evaluator: #{e.message}"
+    errors.add(:base, e.message)
     false
   end
 

--- a/app/models/concerns/training_management.rb
+++ b/app/models/concerns/training_management.rb
@@ -5,15 +5,12 @@
 module TrainingManagement
   extend ActiveSupport::Concern
 
-  TRAINING_SERVICE_WINDOW_ERROR = 'This application is outside the service window for training services.'
-  private_constant :TRAINING_SERVICE_WINDOW_ERROR
-
   # Assigns a trainer to this application
   # @param trainer [Trainer] The trainer to assign
   # @return [Boolean] True if the trainer was assigned successfully
   def assign_trainer!(trainer)
     unless service_window_active?
-      errors.add(:base, TRAINING_SERVICE_WINDOW_ERROR)
+      errors.add(:base, :training_service_window)
       return false
     end
 

--- a/app/models/concerns/training_management.rb
+++ b/app/models/concerns/training_management.rb
@@ -5,10 +5,18 @@
 module TrainingManagement
   extend ActiveSupport::Concern
 
+  TRAINING_SERVICE_WINDOW_ERROR = 'This application is outside the service window for training services.'
+  private_constant :TRAINING_SERVICE_WINDOW_ERROR
+
   # Assigns a trainer to this application
   # @param trainer [Trainer] The trainer to assign
   # @return [Boolean] True if the trainer was assigned successfully
   def assign_trainer!(trainer)
+    unless service_window_active?
+      errors.add(:base, TRAINING_SERVICE_WINDOW_ERROR)
+      return false
+    end
+
     with_lock do
       training_session = training_sessions.create!(
         trainer: trainer,
@@ -45,24 +53,6 @@ module TrainingManagement
     true
   rescue ::ActiveRecord::RecordInvalid => e
     Rails.logger.error "Failed to assign trainer: #{e.message}"
-    false
-  end
-
-  # Schedules a training session
-  # @param trainer [Trainer] The trainer to schedule with
-  # @param scheduled_for [DateTime] The date and time of the training
-  # @return [Boolean] True if the training was scheduled successfully
-  def schedule_training!(trainer:, scheduled_for:)
-    with_lock do
-      training_sessions.create!(
-        trainer: trainer,
-        scheduled_for: scheduled_for,
-        status: :scheduled
-      )
-    end
-    true
-  rescue ::ActiveRecord::RecordInvalid => e
-    Rails.logger.error "[Application #{id}] Failed to schedule training: #{e.message}"
     errors.add(:base, e.message)
     false
   end

--- a/app/models/training_session.rb
+++ b/app/models/training_session.rb
@@ -10,6 +10,8 @@ class TrainingSession < ApplicationRecord
   has_one :constituent, through: :application, source: :user
   belongs_to :product_trained_on, class_name: 'Product', optional: true # Added association
 
+  scope :assigned_or_scheduled, -> { where(status: %i[requested scheduled confirmed]) }
+
   # Validations
   validates :scheduled_for, presence: true, if: -> { status_scheduled? || status_confirmed? || will_be_scheduled? }
   validates :reschedule_reason, presence: true, if: :rescheduling?

--- a/app/services/applications/training_request_service.rb
+++ b/app/services/applications/training_request_service.rb
@@ -2,6 +2,10 @@
 
 module Applications
   class TrainingRequestService < BaseService
+    DUPLICATE_REQUEST_MESSAGE = 'Training session requested. A trainer will reach out soon to schedule your training.'
+    ACTIVE_SESSION_MESSAGE = 'You already have a training session in progress.'
+    SERVICE_WINDOW_MESSAGE = 'Training is no longer available because this application is outside the service window.'
+
     attr_reader :application, :current_user
 
     def initialize(application:, current_user:)
@@ -11,23 +15,24 @@ module Applications
     end
 
     def call
-      return failure('Only approved applications are eligible for training.') unless validate_eligibility
+      return failure('Only approved applications are eligible for training.') unless application.status_approved?
+      return failure(SERVICE_WINDOW_MESSAGE) unless application.service_window_active?
+      return failure(DUPLICATE_REQUEST_MESSAGE) if application.training_request_pending?
+      return failure(ACTIVE_SESSION_MESSAGE) if application.active_training_session_present?
       return failure('You have used all of your available training sessions.') unless check_session_limit?
 
+      application.update!(training_requested_at: Time.current)
       create_notifications
       log_request
+      Application.expire_training_request_metrics_cache!
       success('Training request submitted. An administrator will contact you to schedule your session.')
     end
 
     private
 
-    def validate_eligibility
-      application.status_approved?
-    end
-
     def check_session_limit?
       max_sessions = Policy.get('max_training_sessions') || 3
-      application.training_sessions.count < max_sessions
+      application.training_sessions.completed_sessions.count < max_sessions
     end
 
     def create_notifications

--- a/app/views/admin/applications/_assignment_section.html.erb
+++ b/app/views/admin/applications/_assignment_section.html.erb
@@ -30,9 +30,9 @@
         <% end %>
       </div>
       <% if !entity.respond_to?(:status_completed?) || !entity.status_completed? %>
-        <%= link_to "View #{type.titleize == 'Trainer' ? 'Training' : type.titleize}",
+        <%= link_to(type == 'trainer' ? 'View Session' : "View #{type.titleize}",
             view_path,
-            class: "mt-4 md:mt-0 inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+            class: "mt-4 md:mt-0 inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500") %>
       <% end %>
     </div>
   <% else %>

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -348,7 +348,7 @@
 
           <!-- Trainer Section (Conditional based on policy limit) -->
           <% if @completed_training_sessions_count < @max_training_sessions %>
-            <% latest_training = @application.training_sessions.where(status: [:requested, :scheduled, :confirmed]).order(created_at: :desc).first %>
+            <% latest_training = @application.active_training_session %>
             <%
               # Get trainers by type and by capability
               trainers_by_type = User.where(type: "Users::Trainer", status: :active)
@@ -406,14 +406,9 @@
                       <%= training_session_status_badge(session) %>
                     </div>
                     <div class="flex space-x-2 mt-2 md:mt-0">
-                      <% if session.status_scheduled? %>
-                        <%= button_to complete_training_admin_application_path(@application, training_session_id: session.id),
-                            method: :patch,
-                            class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500",
-                            data: { confirm: "Mark training session with #{session.trainer.full_name} as completed?" } do %>
-                          Complete
-                        <% end %>
-                      <% end %>
+                      <%= link_to "View Session",
+                          trainers_training_session_path(session),
+                          class: "inline-flex items-center px-4 py-2 border border-indigo-300 rounded-md shadow-sm text-sm font-medium text-indigo-700 bg-indigo-50 hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
                       <% if session.status_completed? %>
                         <span class="text-sm text-gray-600">Completed on <%= session.completed_at&.strftime("%B %d, %Y") %></span>
                       <% end %>

--- a/app/views/evaluators/evaluations/show.html.erb
+++ b/app/views/evaluators/evaluations/show.html.erb
@@ -133,7 +133,11 @@
 
   <!-- Form sections for managing evaluation - Start -->
   <div class="mt-8" data-controller="evaluation-management">
-    <% if @evaluation.evaluation_date.blank? %>
+    <% if !@can_manage_evaluation %>
+      <div class="bg-slate-50 border border-slate-200 rounded-lg p-4 text-sm text-slate-700">
+        This is a read-only oversight view. Only the assigned evaluator can update this evaluation.
+      </div>
+    <% elsif @evaluation.evaluation_date.blank? %>
       <!-- Initial Schedule Evaluation Form (only if not scheduled yet) -->
       <div class="bg-white shadow rounded-lg mb-6">
         <div class="px-4 py-5 sm:p-6">

--- a/app/views/trainers/training_sessions/index.html.erb
+++ b/app/views/trainers/training_sessions/index.html.erb
@@ -112,7 +112,7 @@
               <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
                 <%= link_to "View Details", trainers_training_session_path(session), class: "bg-indigo-600 hover:bg-indigo-700 text-white py-1 px-3 rounded-md inline-block transition-colors duration-200 mr-2" %>
                 
-                <% if session.status == 'scheduled' %>
+                <% if session.status == 'scheduled' && session.trainer_id == current_user.id %>
                   <%= button_to "Mark Complete", complete_trainers_training_session_path(session), 
                       method: :post, 
                       class: "bg-green-600 hover:bg-green-700 text-white py-1 px-3 rounded-md inline-block transition-colors duration-200 mt-1", 

--- a/app/views/trainers/training_sessions/show.html.erb
+++ b/app/views/trainers/training_sessions/show.html.erb
@@ -142,7 +142,11 @@
 
   <%# == Actions Section == %>
   <section aria-label="Training Session Actions" class="mt-8">
-    <% if @training_session.status_requested? && @training_session.scheduled_for.nil? %>
+    <% if !@can_manage_training_session %>
+      <div class="bg-slate-50 border border-slate-200 rounded-lg p-4 text-sm text-slate-700">
+        This is a read-only oversight view. Only the assigned trainer can update this training session.
+      </div>
+    <% elsif @training_session.status_requested? && @training_session.scheduled_for.nil? %>
       <!-- Initial Schedule Training Form -->
       <div class="bg-white shadow rounded-lg mb-6">
         <div class="px-4 py-5 sm:p-6">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,14 @@
 #       enabled: "ON"
 
 en:
+  activerecord:
+    errors:
+      models:
+        application:
+          attributes:
+            base:
+              training_service_window: "This application is outside the service window for training services."
+              evaluation_service_window: "This application is outside the service window for evaluation services."
   applications:
     alternate_contact_relationship_types:
       parent: "Parent"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,12 @@
 es:
+  activerecord:
+    errors:
+      models:
+        application:
+          attributes:
+            base:
+              training_service_window: "Esta solicitud está fuera del período de servicio para los servicios de capacitación."
+              evaluation_service_window: "Esta solicitud está fuera del período de servicio para los servicios de evaluación."
   document_signing:
     medical_certification_request:
       submission_name: "Certificacion medica - %{constituent_full_name} (Solicitud %{application_id})"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,8 +156,6 @@ Rails.application.routes.draw do
         patch :reject
         post :assign_evaluator
         post :assign_trainer
-        post :schedule_training
-        post :complete_training
         patch :update_proof_status
         patch :update_certification_status
         post :resend_medical_certification

--- a/db/migrate/20260407120000_add_training_requested_at_to_applications.rb
+++ b/db/migrate/20260407120000_add_training_requested_at_to_applications.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddTrainingRequestedAtToApplications < ActiveRecord::Migration[8.0]
+  def change
+    add_column :applications, :training_requested_at, :datetime
+    add_index :applications, :training_requested_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -139,6 +139,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_000000) do
     t.integer "submission_method"
     t.boolean "terms_accepted"
     t.integer "total_rejections", default: 0, null: false
+    t.datetime "training_requested_at"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["document_signing_service"], name: "index_applications_on_document_signing_service"
@@ -156,6 +157,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_000000) do
     t.index ["residency_proof_status"], name: "idx_applications_on_residency_proof_status"
     t.index ["status", "needs_review_since"], name: "index_applications_on_status_and_needs_review_since"
     t.index ["total_rejections"], name: "index_applications_on_total_rejections"
+    t.index ["training_requested_at"], name: "index_applications_on_training_requested_at"
     t.index ["user_id"], name: "index_applications_on_user_id"
     t.check_constraint "income_proof_status = ANY (ARRAY[0, 1, 2])", name: "income_proof_status_check"
     t.check_constraint "residency_proof_status = ANY (ARRAY[0, 1, 2])", name: "residency_proof_status_check"

--- a/test/controllers/admin/applications_controller_test.rb
+++ b/test/controllers/admin/applications_controller_test.rb
@@ -239,6 +239,33 @@ module Admin
       assert_match(/Training Sessions \(1\)/, response.body)
     end
 
+    test 'admin training mutation routes are removed' do
+      assert_raises(NoMethodError) do
+        schedule_training_admin_application_path(@application)
+      end
+
+      assert_raises(NoMethodError) do
+        complete_training_admin_application_path(@application)
+      end
+    end
+
+    test 'show page keeps training visibility but removes admin mutation controls' do
+      voucher_app = create(
+        :application,
+        :completed,
+        :voucher_fulfillment,
+        user: create(:constituent, email: generate(:email))
+      )
+      training_session = create(:training_session, :scheduled, application: voucher_app, trainer: create(:trainer))
+
+      get admin_application_path(voucher_app)
+      assert_response :success
+
+      assert_select "a[href='#{trainers_training_session_path(training_session)}']", text: 'View Session'
+      assert_no_match(%r{/admin/applications/#{voucher_app.id}/complete_training}, response.body)
+      assert_no_match(/>Complete</, response.body)
+    end
+
     test 'show page uses db-backed rejection reason text in modal data attributes' do
       income_body = 'DB income missing-name reason for modal test.'
       medical_body = 'DB medical missing-signature reason for modal test.'

--- a/test/controllers/constituent_portal/training_requests_test.rb
+++ b/test/controllers/constituent_portal/training_requests_test.rb
@@ -11,7 +11,7 @@ module ConstituentPortal
       @admin = create(:admin)
 
       # Create and approve an application
-      @application = create(:application, user: @constituent)
+      @application = create(:application, user: @constituent, application_date: 2.years.ago.to_date)
 
       # Set Current.user to avoid validation errors in callbacks
       Current.user = @admin

--- a/test/controllers/evaluator/evaluations_controller_test.rb
+++ b/test/controllers/evaluator/evaluations_controller_test.rb
@@ -6,9 +6,12 @@ require 'test_helper'
 class EvaluationsControllerTest < ActionDispatch::IntegrationTest
   def setup
     @evaluator = create(:evaluator)
+    @other_evaluator = create(:evaluator)
+    @admin = create(:admin)
     sign_in_for_controller_test(@evaluator)
     @product = create(:product, name: 'iPad Air')
     @evaluation = create(:evaluation, evaluator: @evaluator, status: :scheduled)
+    @requested_evaluation = create(:evaluation, evaluator: @evaluator, status: :requested, evaluation_date: nil, location: nil)
   end
 
   test 'gets pending' do
@@ -43,5 +46,66 @@ class EvaluationsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to evaluators_evaluation_path(@evaluation)
+  end
+
+  test 'assigned evaluator can schedule an evaluation' do
+    post schedule_evaluators_evaluation_path(@requested_evaluation),
+         params: { evaluation_date: 2.days.from_now, location: 'Library', notes: 'Scheduled by evaluator' }
+
+    assert_redirected_to evaluators_evaluation_path(@requested_evaluation)
+    assert_equal 'scheduled', @requested_evaluation.reload.status
+  end
+
+  test 'admin can view evaluation but only in read-only mode' do
+    sign_in_for_controller_test(@admin)
+
+    get evaluators_evaluation_path(@evaluation)
+
+    assert_response :success
+    assert_includes @response.body, 'This is a read-only oversight view.'
+    assert_not_includes @response.body, 'Update Evaluation'
+    assert_not_includes @response.body, 'Reschedule Evaluation'
+  end
+
+  test 'admin cannot schedule an evaluation' do
+    sign_in_for_controller_test(@admin)
+
+    post schedule_evaluators_evaluation_path(@requested_evaluation),
+         params: { evaluation_date: 2.days.from_now, location: 'Admin attempt', notes: 'Admin attempt' }
+
+    assert_redirected_to evaluators_evaluation_path(@requested_evaluation)
+    assert_equal 'Only the assigned evaluator can update this evaluation.', flash[:alert]
+    assert_equal 'requested', @requested_evaluation.reload.status
+  end
+
+  test 'admin cannot submit an evaluation report' do
+    sign_in_for_controller_test(@admin)
+
+    post submit_report_evaluators_evaluation_path(@evaluation), params: {
+      evaluation: {
+        needs: 'Admin attempt',
+        notes: 'Admin attempt',
+        location: 'Admin attempt',
+        evaluation_date: Time.current,
+        recommended_product_ids: [@product.id],
+        products_tried: [{ product_id: @product.id, reaction: 'Positive' }],
+        attendees: [{ name: 'Test User', relationship: 'Self' }]
+      }
+    }
+
+    assert_redirected_to evaluators_evaluation_path(@evaluation)
+    assert_equal 'Only the assigned evaluator can update this evaluation.', flash[:alert]
+    assert_equal 'scheduled', @evaluation.reload.status
+  end
+
+  test 'other evaluator cannot mutate an evaluation' do
+    sign_in_for_controller_test(@other_evaluator)
+
+    post schedule_evaluators_evaluation_path(@requested_evaluation),
+         params: { evaluation_date: 2.days.from_now, location: 'Other evaluator attempt' }
+
+    assert_redirected_to evaluators_evaluations_path
+    assert_equal 'Evaluation not found.', flash[:alert]
+    assert_equal 'requested', @requested_evaluation.reload.status
   end
 end

--- a/test/controllers/trainers/training_sessions_controller_test.rb
+++ b/test/controllers/trainers/training_sessions_controller_test.rb
@@ -57,6 +57,51 @@ module Trainers
       assert_response :success
     end
 
+    test 'admin sees training session as read-only' do
+      sign_in_for_controller_test @admin
+
+      get trainers_training_session_url(@requested_session)
+
+      assert_response :success
+      assert_includes @response.body, 'This is a read-only oversight view.'
+      assert_not_includes @response.body, 'Schedule Training'
+      assert_not_includes @response.body, 'Mark as Completed'
+      assert_not_includes @response.body, 'Cancel Training'
+    end
+
+    test 'admin cannot schedule a training session' do
+      sign_in_for_controller_test @admin
+
+      post schedule_trainers_training_session_url(@requested_session),
+           params: { scheduled_for: 2.days.from_now, notes: 'Admin attempt' }
+
+      assert_redirected_to trainers_training_session_url(@requested_session)
+      assert_equal 'Only the assigned trainer can update this training session.', flash[:alert]
+      assert_equal 'requested', @requested_session.reload.status
+    end
+
+    test 'admin cannot complete a training session' do
+      sign_in_for_controller_test @admin
+
+      post complete_trainers_training_session_url(@training_session),
+           params: { notes: 'Admin attempt', product_trained_on_id: @product.id }
+
+      assert_redirected_to trainers_training_session_url(@training_session)
+      assert_equal 'Only the assigned trainer can update this training session.', flash[:alert]
+      assert_equal 'scheduled', @training_session.reload.status
+    end
+
+    test 'other trainer cannot mutate a training session' do
+      sign_in_for_controller_test @other_trainer
+
+      post schedule_trainers_training_session_url(@requested_session),
+           params: { scheduled_for: 2.days.from_now, notes: 'Other trainer attempt' }
+
+      assert_redirected_to trainers_dashboard_path
+      assert_equal "You don't have access to this training session.", flash[:alert]
+      assert_equal 'requested', @requested_session.reload.status
+    end
+
     test 'unauthenticated user should be redirected to login' do
       get trainers_training_session_url(@training_session)
       assert_redirected_to sign_in_url

--- a/test/models/application_test.rb
+++ b/test/models/application_test.rb
@@ -175,6 +175,50 @@ class ApplicationTest < ActiveSupport::TestCase
     assert_equal 'submission', status_change.metadata['trigger']
   end
 
+  test 'service_window_active? returns true for approved applications inside the service window' do
+    Policy.find_or_create_by(key: 'waiting_period_years').update!(value: 3)
+    application = create(:application, status: :approved, application_date: 2.years.ago.to_date)
+
+    assert application.service_window_active?
+  end
+
+  test 'service_window_active? returns false for approved applications outside the service window' do
+    Policy.find_or_create_by(key: 'waiting_period_years').update!(value: 3)
+    application = create(:application, status: :approved, application_date: 3.years.ago.to_date)
+
+    assert_not application.service_window_active?
+  end
+
+  test 'service_window_active? returns false for non-approved applications' do
+    application = create(:application, status: :in_progress, application_date: 1.year.ago.to_date)
+
+    assert_not application.service_window_active?
+  end
+
+  test 'assign_trainer! fails outside the service window' do
+    Policy.find_or_create_by(key: 'waiting_period_years').update!(value: 3)
+    application = create(:application, status: :approved, application_date: 4.years.ago.to_date)
+    trainer = create(:trainer)
+
+    assert_no_difference -> { TrainingSession.count } do
+      assert_not application.assign_trainer!(trainer)
+    end
+
+    assert_includes application.errors[:base], 'This application is outside the service window for training services.'
+  end
+
+  test 'assign_evaluator! fails outside the service window' do
+    Policy.find_or_create_by(key: 'waiting_period_years').update!(value: 3)
+    application = create(:application, status: :approved, application_date: 4.years.ago.to_date)
+    evaluator = create(:evaluator)
+
+    assert_no_difference -> { Evaluation.count } do
+      assert_not application.assign_evaluator!(evaluator)
+    end
+
+    assert_includes application.errors[:base], 'This application is outside the service window for evaluation services.'
+  end
+
   test 'batch_update_status updates multiple applications and returns success' do
     app1 = create(:application, :draft)
     app2 = create(:application, :draft)
@@ -216,7 +260,7 @@ class ApplicationTest < ActiveSupport::TestCase
     admin = create(:admin)
 
     assert_no_difference -> { ApplicationStatusChange.count } do
-      result = Application.batch_update_status([app1.id, 999999], :in_progress, actor: admin)
+      result = Application.batch_update_status([app1.id, 999_999], :in_progress, actor: admin)
       assert_not result[:success]
       assert_equal 0, result[:success_count]
       assert_includes result[:errors].first, 'Applications not found: 999999'

--- a/test/models/application_test.rb
+++ b/test/models/application_test.rb
@@ -204,7 +204,7 @@ class ApplicationTest < ActiveSupport::TestCase
       assert_not application.assign_trainer!(trainer)
     end
 
-    assert_includes application.errors[:base], 'This application is outside the service window for training services.'
+    assert_includes application.errors[:base], I18n.t('activerecord.errors.models.application.attributes.base.training_service_window')
   end
 
   test 'assign_evaluator! fails outside the service window' do
@@ -216,7 +216,7 @@ class ApplicationTest < ActiveSupport::TestCase
       assert_not application.assign_evaluator!(evaluator)
     end
 
-    assert_includes application.errors[:base], 'This application is outside the service window for evaluation services.'
+    assert_includes application.errors[:base], I18n.t('activerecord.errors.models.application.attributes.base.evaluation_service_window')
   end
 
   test 'batch_update_status updates multiple applications and returns success' do

--- a/test/services/applications/training_request_service_test.rb
+++ b/test/services/applications/training_request_service_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Applications
+  class TrainingRequestServiceTest < ActiveSupport::TestCase
+    setup do
+      @constituent = create(:constituent)
+      @admin = create(:admin)
+      @application = create_reviewed_application(user: @constituent)
+      Policy.find_or_create_by(key: 'max_training_sessions').update!(value: 3)
+      Policy.find_or_create_by(key: 'waiting_period_years').update!(value: 3)
+    end
+
+    test 'writes training_requested_at for a valid request' do
+      NotificationService.stubs(:create_and_deliver!).returns(nil)
+
+      result = TrainingRequestService.new(application: @application, current_user: @constituent).call
+
+      assert result.success?
+      assert_not_nil @application.reload.training_requested_at
+    end
+
+    test 'rejects requests outside the service window with a clear message' do
+      @application.update!(application_date: 4.years.ago.to_date)
+
+      result = TrainingRequestService.new(application: @application, current_user: @constituent).call
+
+      assert_not result.success?
+      assert_equal TrainingRequestService::SERVICE_WINDOW_MESSAGE, result.message
+    end
+
+    test 'rejects duplicate pending request' do
+      @application.update!(training_requested_at: 1.hour.ago)
+
+      result = TrainingRequestService.new(application: @application, current_user: @constituent).call
+
+      assert_not result.success?
+      assert_equal TrainingRequestService::DUPLICATE_REQUEST_MESSAGE, result.message
+    end
+
+    test 'rejects duplicate request when an active training session exists' do
+      create(:training_session, application: @application, trainer: create(:trainer), status: :requested)
+
+      result = TrainingRequestService.new(application: @application, current_user: @constituent).call
+
+      assert_not result.success?
+      assert_equal TrainingRequestService::ACTIVE_SESSION_MESSAGE, result.message
+    end
+
+    test 'allows re-request after cancelled session when quota remains' do
+      NotificationService.stubs(:create_and_deliver!).returns(nil)
+      create(:training_session, :cancelled, application: @application, trainer: create(:trainer))
+
+      result = TrainingRequestService.new(application: @application, current_user: @constituent).call
+
+      assert result.success?
+      assert_not_nil @application.reload.training_requested_at
+    end
+
+    test 'counts only completed sessions against quota' do
+      NotificationService.stubs(:create_and_deliver!).returns(nil)
+      trainer = create(:trainer)
+
+      create(:training_session, :completed, application: @application, trainer: trainer)
+      create(:training_session, :completed, application: @application, trainer: trainer)
+      create(:training_session, :cancelled, application: @application, trainer: trainer)
+      create(:training_session, application: @application, trainer: trainer, status: :no_show, scheduled_for: 1.day.ago, no_show_notes: 'missed it')
+
+      result = TrainingRequestService.new(application: @application, current_user: @constituent).call
+
+      assert result.success?
+    end
+
+    test 'rejects request when completed session quota is exhausted' do
+      trainer = create(:trainer)
+      create_list(:training_session, 3, :completed, application: @application, trainer: trainer)
+
+      result = TrainingRequestService.new(application: @application, current_user: @constituent).call
+
+      assert_not result.success?
+      assert_equal 'You have used all of your available training sessions.', result.message
+    end
+
+    private
+
+    def create_reviewed_application(user:)
+      application = create(:application, skip_proofs: true, user: user, status: :in_progress)
+      attach_required_proofs(application)
+      application.update_columns(
+        application_date: 2.years.ago.to_date,
+        status: Application.statuses[:approved],
+        income_proof_status: Application.income_proof_statuses[:approved],
+        residency_proof_status: Application.residency_proof_statuses[:approved],
+        medical_certification_status: Application.medical_certification_statuses[:approved],
+        updated_at: Time.current
+      )
+      application.reload
+    end
+
+    def attach_required_proofs(application)
+      application.income_proof.attach(
+        io: StringIO.new('income proof content'),
+        filename: 'income.pdf',
+        content_type: 'application/pdf'
+      )
+      application.residency_proof.attach(
+        io: StringIO.new('residency proof content'),
+        filename: 'residency.pdf',
+        content_type: 'application/pdf'
+      )
+    end
+  end
+end


### PR DESCRIPTION
- Enforce service-window eligibility for training requests and practitioner assignments
- Add Application#service_window_active? using the existing waiting-period Policy
- Prevent expired applications from requesting training or being assigned trainers/evaluators
- Remove admin-owned training scheduling and completion actions from the application workflow (trainers schedule and complete training sessions, not admins)
- Restrict session mutations to the assigned trainer/evaluator while preserving read-only access for admins
- Update admin and practitioner views
- Add regression tests for service-window checks, route removal, and practitioner authorization boundaries