### PR TITLE
Make lifecycle APIs the source of truth for application status and audit events

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -95,15 +95,17 @@ module Admin
 
     def update
       if @application.update(application_params)
-        AuditEventService.log(
-          action: 'application_updated',
-          actor: current_user,
-          auditable: @application,
-          metadata: {
-            admin_id: current_user.id,
-            admin_name: current_user.full_name
-          }
-        )
+        if @application.saved_changes.except('updated_at').any?
+          AuditEventService.log(
+            action: 'application_updated',
+            actor: current_user,
+            auditable: @application,
+            metadata: {
+              admin_id: current_user.id,
+              admin_name: current_user.full_name
+            }
+          )
+        end
         # If this is a modal request, respond with success so the modal can close
         if params[:modal] == 'true'
           head :ok

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -323,17 +323,17 @@ class Application < ApplicationRecord
   end
 
   # Status methods- Delegate approval logic to the Applications::Approver service object
-  def approve!(user: Current.user)
+  def approve!(user:)
     Applications::Approver.new(self, by: user).call
   end
 
   # Delegate rejection logic to the Applications::Rejecter service object
-  def reject!(user: Current.user)
+  def reject!(user:)
     Applications::Rejecter.new(self, by: user).call
   end
 
   # Delegate document request logic to the Applications::DocumentRequester service object
-  def request_documents!(user: Current.user)
+  def request_documents!(user:)
     Applications::DocumentRequester.new(self, by: user).call
   end
 

--- a/app/services/applications/application_creator.rb
+++ b/app/services/applications/application_creator.rb
@@ -143,13 +143,13 @@ module Applications
       target_application.save!
       actor = determine_audit_actor
 
-      target_application.submit!(actor: actor) if @form.is_submission
-
       if was_new_record
         log_application_created_event(actor)
-      else
+      elsif should_log_application_updated_event?
         log_application_updated_event(actor)
       end
+
+      target_application.submit!(actor: actor) if @form.is_submission
     end
 
     def determine_audit_actor
@@ -193,6 +193,10 @@ module Applications
           submission_method: @form.submission_method
         }
       )
+    end
+
+    def should_log_application_updated_event?
+      target_application.saved_changes.except('updated_at').any?
     end
 
     def log_events

--- a/app/services/applications/autosave_service.rb
+++ b/app/services/applications/autosave_service.rb
@@ -148,8 +148,11 @@ module Applications
       value = cast_user_field_value(attribute, field_value)
       # Update the target user (dependent if this is a dependent application, otherwise current_user)
       target_user = @application.for_dependent? ? @application.user : current_user
+      # Autosave persists individual draft fields without running full-form validations.
+      # rubocop:disable Rails/SkipsModelValidations
       target_user.update_column(attribute, value)
       @application.update_column(:last_visited_step, attribute) if @application.persisted?
+      # rubocop:enable Rails/SkipsModelValidations
       { success: true }
     rescue StandardError => e
       Rails.logger.error("Error autosaving user field #{attribute}: #{e.message}")
@@ -171,8 +174,14 @@ module Applications
       @application.valid?
       return { success: false, errors: { "application[#{attribute}]" => @application.errors[attribute] } } if @application.errors[attribute].any?
 
+      was_new_record = @application.new_record?
+
       @application.save(validate: false)
+      log_application_created_event if was_new_record
+      # Autosave records draft progress field-by-field without full validation.
+      # rubocop:disable Rails/SkipsModelValidations
       @application.update_column(:last_visited_step, attribute)
+      # rubocop:enable Rails/SkipsModelValidations
       { success: true }
     rescue StandardError => e
       Rails.logger.error("Error autosaving application field #{attribute}: #{e.message}")
@@ -213,6 +222,18 @@ module Applications
 
     def autosave_error_result(message)
       { success: false, errors: { base: [message] } }
+    end
+
+    def log_application_created_event
+      AuditEventService.log(
+        action: 'application_created',
+        actor: current_user,
+        auditable: @application,
+        metadata: {
+          submission_method: @application.submission_method,
+          initial_status: @application.status
+        }
+      )
     end
   end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -26,7 +26,8 @@
 # Any libraries that use a connection pool or another resource pool should
 # be configured to provide at least as many connections as the number of
 # threads. This includes Active Record's `pool` parameter in `database.yml`.
-worker_count = Integer(ENV['WEB_CONCURRENCY'] || (ENV['RAILS_ENV'] == 'development' ? 0 : 2))
+app_env = ENV.fetch('RAILS_ENV') { ENV.fetch('RACK_ENV', 'development') }
+worker_count = Integer(ENV['WEB_CONCURRENCY'] || (%w[development test].include?(app_env) ? 0 : 2))
 workers worker_count
 threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
 threads threads_count, threads_count
@@ -46,7 +47,7 @@ enable_keep_alives(false) if respond_to?(:enable_keep_alives)
 rackup      DefaultRackup if defined?(DefaultRackup)
 
 # fallback to RACK_ENV
-environment ENV.fetch('RAILS_ENV') { ENV.fetch('RACK_ENV', 'development') }
+environment app_env
 
 # Solid Queue needs database connection in worker processes.
 # Skip this hook in single-mode development to avoid Puma 7 startup warnings.

--- a/test/controllers/admin/applications_controller_test.rb
+++ b/test/controllers/admin/applications_controller_test.rb
@@ -409,6 +409,20 @@ module Admin
       assert_equal 55_000.0, @application.annual_income
     end
 
+    test 'update without real attribute changes does not log application_updated' do
+      assert_no_difference -> { Event.where(action: 'application_updated', auditable: @application).count } do
+        patch admin_application_path(@application), params: {
+          application: {
+            household_size: @application.household_size,
+            annual_income: @application.annual_income,
+            status: @application.status
+          }
+        }
+      end
+
+      assert_redirected_to admin_application_path(@application)
+    end
+
     test 'batch_approve updates multiple applications and redirects' do
       app1 = create(:application, :in_progress)
       app2 = create(:application, :in_progress)

--- a/test/controllers/constituent_portal/applications_controller_autosave_test.rb
+++ b/test/controllers/constituent_portal/applications_controller_autosave_test.rb
@@ -66,6 +66,26 @@ module ConstituentPortal
       assert_equal @user.id, new_application.user_id
     end
 
+    test 'should log application_created when autosave creates a new draft' do
+      @draft_application.destroy
+
+      assert_difference -> { Event.where(action: 'application_created').count }, 1 do
+        patch autosave_field_constituent_portal_applications_path,
+              params: { field_name: 'application[household_size]', field_value: '3' },
+              as: :json
+      end
+
+      assert_response :success
+
+      new_application = Application.find(response.parsed_body['applicationId'])
+      event = Event.where(action: 'application_created', auditable: new_application).order(:created_at).last
+
+      assert_not_nil event
+      assert_equal @user, event.user
+      assert_equal 'draft', event.metadata['initial_status']
+      assert_equal 'online', event.metadata['submission_method']
+    end
+
     test 'should not autosave invalid Application field' do
       # Test autosaving an invalid annual_income
       patch autosave_field_constituent_portal_application_path(@draft_application),

--- a/test/models/application_transition_status_test.rb
+++ b/test/models/application_transition_status_test.rb
@@ -69,6 +69,14 @@ class ApplicationTransitionStatusTest < ActiveSupport::TestCase
     assert_equal 'actor is required', error.message
   end
 
+  test 'application lifecycle wrappers require an explicit user' do
+    application = create(:application, :in_progress, user: @constituent)
+
+    assert_raises(ArgumentError) { application.approve! }
+    assert_raises(ArgumentError) { application.reject! }
+    assert_raises(ArgumentError) { application.request_documents! }
+  end
+
   test 'transition_status! rolls back the status change if status audit logging fails' do
     application = create(:application, :in_progress, user: @constituent)
 

--- a/test/services/applications/application_creator_test.rb
+++ b/test/services/applications/application_creator_test.rb
@@ -55,6 +55,25 @@ module Applications
       end
     end
 
+    test 'new submitted application logs creation as draft and submission as a separate status change' do
+      form = create_valid_form(@user)
+      form.is_submission = true
+
+      assert_difference -> { Event.where(action: 'application_created').count }, 1 do
+        assert_difference -> { Event.where(action: 'application_status_changed').count }, 1 do
+          result = ApplicationCreator.call(form)
+          assert result.success?
+
+          creation_event = Event.where(action: 'application_created', auditable: result.application).order(:created_at).last
+          status_event = Event.where(action: 'application_status_changed', auditable: result.application).order(:created_at).last
+
+          assert_equal 'draft', creation_event.metadata['initial_status']
+          assert_equal 'draft', status_event.metadata['old_status']
+          assert_equal 'in_progress', status_event.metadata['new_status']
+        end
+      end
+    end
+
     test 'updates user attributes' do
       form = create_valid_form(@user)
       form.hearing_disability = true
@@ -102,6 +121,43 @@ module Applications
 
       audit_event = Event.last
       assert_equal 'application_updated', audit_event.action
+    end
+
+    test 'submission without non-status changes does not log application_updated' do
+      application = create(
+        :application,
+        :draft,
+        user: @user,
+        annual_income: '40000',
+        household_size: 2,
+        submission_method: 'online',
+        terms_accepted: true,
+        information_verified: true,
+        medical_release_authorized: true
+      )
+      form = ApplicationForm.new(
+        current_user: @user,
+        application: application,
+        annual_income: application.annual_income,
+        household_size: application.household_size,
+        submission_method: application.submission_method,
+        hearing_disability: @user.hearing_disability,
+        vision_disability: true,
+        speech_disability: @user.speech_disability,
+        mobility_disability: @user.mobility_disability,
+        cognition_disability: @user.cognition_disability,
+        medical_provider_name: application.medical_provider_name,
+        medical_provider_phone: application.medical_provider_phone,
+        medical_provider_email: application.medical_provider_email,
+        is_submission: true
+      )
+
+      assert_no_difference -> { Event.where(action: 'application_updated', auditable: application).count } do
+        assert_difference -> { Event.where(action: 'application_status_changed', auditable: application).count }, 1 do
+          result = ApplicationCreator.call(form)
+          assert result.success?
+        end
+      end
     end
 
     test 'handles invalid form' do

--- a/test/support/system_test_authentication.rb
+++ b/test/support/system_test_authentication.rb
@@ -113,7 +113,7 @@ module SystemTestAuthentication
       # Wait for EITHER successful redirect OR error message
       # This is better than checking current_path immediately
       # Try to wait for successful redirect to dashboard
-      if page.has_current_path?(expected_dashboard_path, wait: 8)
+      if dashboard_path_reached?(user, wait: 8)
         # Success! Continue to dashboard verification below
       elsif page.has_text?('Invalid email or password', wait: 2)
         # Clear authentication failure
@@ -158,20 +158,7 @@ module SystemTestAuthentication
       debug_puts "User #{user.email} has 2FA enabled, on verification page: #{current_path}"
     else
       # For normal sign-in, we expect to be redirected to dashboard
-      expected_dashboard_path = user_dashboard_path(user)
-      assert_current_path(expected_dashboard_path, wait: 10)
-
-      # Check for appropriate dashboard heading based on user type
-      dashboard_heading = case user.type
-                          when 'Users::Administrator'
-                            'Admin Dashboard'
-                          when 'Users::Vendor'
-                            'Vendor Dashboard'
-                          else
-                            'Dashboard'
-                          end
-
-      assert_selector('h1', text: dashboard_heading, wait: 10)
+      assert_dashboard_landing!(user)
       wait_for_stimulus_controller('forms') if has_selector?('[data-controller*="forms"]', wait: 1)
       debug_puts "Successfully signed in as #{user.email}"
     end
@@ -212,20 +199,7 @@ module SystemTestAuthentication
       assert_selector('form', wait: 10)
       debug_puts "User #{user.email} has 2FA enabled, on verification page: #{current_path} on retry"
     else
-      expected_dashboard_path = user_dashboard_path(user)
-      assert_current_path(expected_dashboard_path, wait: 10)
-
-      # Check for appropriate dashboard heading based on user type
-      dashboard_heading = case user.type
-                          when 'Users::Administrator'
-                            'Admin Dashboard'
-                          when 'Users::Vendor'
-                            'Vendor Dashboard'
-                          else
-                            'Dashboard'
-                          end
-
-      assert_selector('h1', text: dashboard_heading, wait: 10)
+      assert_dashboard_landing!(user)
       wait_for_stimulus_controller('forms') if has_selector?('[data-controller*="forms"]', wait: 1)
       debug_puts "Successfully signed in as #{user.email} on retry"
     end
@@ -427,6 +401,43 @@ module SystemTestAuthentication
       # Default to root path if user type is unknown
       root_path
     end
+  end
+
+  def dashboard_path_reached?(user, wait:)
+    if user.type == 'Users::Administrator'
+      page.has_current_path?(admin_dashboard_path, wait: wait) ||
+        page.has_current_path?(admin_applications_path, wait: wait)
+    else
+      page.has_current_path?(user_dashboard_path(user), wait: wait)
+    end
+  end
+
+  def assert_dashboard_landing!(user)
+    if user.type == 'Users::Administrator'
+      assert_admin_dashboard_landing!
+      return
+    end
+
+    assert_current_path(user_dashboard_path(user), wait: 10)
+
+    dashboard_heading = case user.type
+                        when 'Users::Vendor'
+                          'Vendor Dashboard'
+                        else
+                          'Dashboard'
+                        end
+
+    assert_selector('h1', text: dashboard_heading, wait: 10)
+  end
+
+  def assert_admin_dashboard_landing!
+    assert(
+      page.has_current_path?(admin_dashboard_path, wait: 10) ||
+      page.has_current_path?(admin_applications_path, wait: 10),
+      "expected current path to be #{admin_dashboard_path} or #{admin_applications_path}, got #{current_path}"
+    )
+
+    assert_selector('h1', text: /Applications|Admin Dashboard/, wait: 10)
   end
 
   # Visit method that handles pending connections gracefully

--- a/test/system/admin/application_creation_audit_test.rb
+++ b/test/system/admin/application_creation_audit_test.rb
@@ -36,11 +36,11 @@ module Admin
       check 'I certify that I have a disability that affects my ability to access telecommunications services'
 
       # Fill in medical provider info
-      within('section', text: 'Medical Professional Information') do
+      within('section', text: 'Certifying Professional Information and Authorization to Contact') do
         fill_in 'Name', with: 'Dr. Smith'
         fill_in 'Email', with: 'smith@example.com'
         fill_in 'Phone', with: '555-123-4567'
-        check 'I authorize the release and sharing of my medical information as described above'
+        check 'I authorize the release and sharing of my disability-related information as described above'
       end
 
       # Submit the form instead of saving as draft
@@ -48,27 +48,6 @@ module Admin
 
       # Verify application was submitted
       assert_text 'Application submitted successfully'
-
-      # Debug: Check if application was actually created
-      created_application = Application.find_by(user: @constituent)
-      puts "Created application: #{created_application.inspect}"
-      puts "Application ID: #{created_application&.id}"
-      puts "Application user: #{created_application&.user&.full_name}"
-      puts "Application status: #{created_application&.status}"
-
-      # Verify audit event with debug info
-      events = Event.where(auditable: created_application).order(created_at: :desc)
-      puts "Events for application #{created_application.id}:"
-      events.each do |e|
-        puts "- #{e.action} by #{e.user&.email} at #{e.created_at}: #{e.metadata.inspect}"
-      end
-
-      event = events.find { |e| e.action == 'application_created' }
-      if event
-        puts "Found application_created event: #{event.attributes}"
-      else
-        puts "ERROR: No application_created event found for application #{created_application.id}"
-      end
 
       # Sign out and sign in as admin
       sign_out
@@ -78,34 +57,15 @@ module Admin
       # Sign in as admin
       sign_in(@admin)
 
-      # Debug: Check admin authentication
-      puts "Admin user: #{@admin.email}, admin?: #{@admin.admin?}"
-      puts "Current URL after admin sign in: #{current_url}"
-      puts "Page has admin content: #{page.has_content?('Dashboard')}"
-
       # Find and view the application
       visit admin_applications_path
-
-      # Debug: Check what's on the admin applications page
-      puts "Admin applications page URL: #{current_url}"
-      puts "Page title: #{page.title}"
-      puts "Page has applications: #{page.has_content?('Applications')}"
-      puts "Page content (first 500 chars): #{page.text[0..500]}"
-
-      # Check if there are any applications in the database
-      puts "Total applications in DB: #{Application.count}"
-      puts "Applications by user: #{Application.all.map { |a| "#{a.id}: #{a.user.full_name}" }}"
-
-      # Debug: List all links on the page
-      all_links = all('a').map(&:text)
-      puts "All links on admin applications page: #{all_links}"
 
       # Find the "View" link for the application and get the href
       view_link = nil
       within 'table' do
         row = first('tr', text: @constituent.email)
         within row do
-          view_link = find_link('View')
+          view_link = find_link('View Application')
         end
       end
 
@@ -126,9 +86,9 @@ module Admin
       # Use Capybara's intelligent waiting to wait for the specific audit log text to appear
       # This handles the timing between application submission and audit log updates
       within '#audit-logs' do
-        # Wait for the audit log to show the in_progress status - Capybara will retry until timeout
-        assert_text 'Application created via Online method with status: In Progress', wait: 10
+        assert_text 'Application created via Online method with status: Draft', wait: 10
         assert_text 'Application created via Online method'
+        assert_text 'Application submitted for review'
       end
     end
 
@@ -140,13 +100,19 @@ module Admin
 
       # Select applicant type first to make form fields visible
       choose 'An Adult (applying for themselves)'
+      click_button 'Create New Applicant'
 
       # Fill in constituent info
       within '#self-info-section' do
         fill_in 'First Name', with: 'John'
         fill_in 'Last Name', with: 'Paper'
-        fill_in 'Email', with: 'john.paper@example.com'
-        fill_in 'Phone', with: '555-987-6543'
+        fill_in 'Date of Birth', with: '1980-01-15'
+        check 'I accept the terms and conditions'
+        fill_in 'Email Address', with: 'john.paper@example.com'
+        fill_in 'Phone Number', with: '555-987-6543'
+        fill_in 'Street Address', with: '123 Paper St'
+        fill_in 'City', with: 'Baltimore'
+        fill_in 'ZIP Code', with: '21201'
       end
 
       # Wait for the application fields to become visible after selecting applicant type
@@ -160,10 +126,11 @@ module Admin
       check 'Hearing'
 
       # Fill in medical provider info
-      within('fieldset', text: 'Medical Provider Information') do
-        fill_in 'Name', with: 'Dr. Jones'
+      within('fieldset', text: 'Certifying Professional Information') do
+        fill_in 'Provider Name', with: 'Dr. Jones'
         fill_in 'Email', with: 'jones@example.com'
         fill_in 'Phone', with: '555-333-4444'
+        check 'I authorize medical release'
       end
 
       # Upload proof documents
@@ -173,8 +140,8 @@ module Admin
       # Submit the form
       click_button 'Submit Paper Application'
 
-      # Verify application was created
-      assert_text 'Paper application successfully submitted'
+      # Verify we landed on the created paper application's detail page
+      assert_text(/Application #\d+ Details/i, wait: 10)
 
       # Verify the audit log shows the application creation
       within '#audit-logs' do


### PR DESCRIPTION
- Move application creation and update audit logging ahead of submission so application_status_changed remains the canonical submission lifecycle event
- Require explicit user: arguments for application lifecycle wrappers instead of falling back to ambient Current.user
- Log application_created when autosave creates the initial draft for a complete audit trail
- Avoid emitting application_updated for status-only submit flows or admin no-op updates
- Add regression coverage for submit-path audit ownership, autosave draft creation, explicit lifecycle actor requirements, and admin audit visibility
- Fix failing tests