### PR TITLE
Move notifications, decrease limit, add links

### DIFF
--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -16,7 +16,7 @@ module Admin
                               .includes(:actor, :notifiable)
                               .where('created_at > ?', 7.days.ago)
                               .order(created_at: :desc)
-                              .limit(5)
+                              .limit(3)
 
       preload_notification_message_dependencies(@recent_notifications)
 

--- a/app/services/notification_composer.rb
+++ b/app/services/notification_composer.rb
@@ -15,6 +15,7 @@
 #
 class NotificationComposer
   include ActionView::Helpers::TextHelper # For helpers like pluralize
+  include ActionView::Helpers::UrlHelper # For link_to
 
   def self.generate(notification_action, notifiable, actor = nil, metadata = {})
     new(notification_action, notifiable, actor, metadata).generate
@@ -38,6 +39,12 @@ class NotificationComposer
 
   private
 
+  def application_reference
+    return "Application missing" unless @notifiable&.id
+
+    link_to("Application ##{@notifiable.id}", "/admin/applications/#{@notifiable.id}", class: "text-indigo-600 hover:text-indigo-500")
+  end
+
   # --- Message Generation Methods ---
 
   def message_for_trainer_assigned
@@ -48,12 +55,12 @@ class NotificationComposer
     training_session = find_training_session(application, @actor)
     status_info = training_session ? " (#{training_session.status.humanize})" : ''
 
-    "#{trainer_name} assigned to train #{constituent_name} for Application ##{@notifiable&.id}#{status_info}."
+    "#{trainer_name} assigned to train #{constituent_name} for #{application_reference}#{status_info}."
   end
 
   def message_for_training_requested
     constituent_name = @actor&.full_name || @notifiable&.constituent_full_name || 'A constituent'
-    "#{constituent_name} requested training for Application ##{@notifiable&.id}."
+    "#{constituent_name} requested training for #{application_reference}."
   end
 
   def message_for_training_scheduled
@@ -77,38 +84,38 @@ class NotificationComposer
     reason = @metadata['rejection_reason']
     reason_text = reason.present? ? " - #{reason}" : ''
 
-    "#{proof_type} rejected for application ##{@notifiable&.id}#{reason_text}."
+    "#{proof_type} rejected for #{application_reference.downcase}#{reason_text}."
   end
 
   def message_for_proof_approved
     proof_type = @metadata['proof_type']&.titleize || 'Proof'
-    "#{proof_type} approved for application ##{@notifiable&.id}."
+    "#{proof_type} approved for #{application_reference.downcase}."
   end
 
   def message_for_medical_certification_requested
-    "Disability certification requested for application ##{@notifiable&.id}"
+    "Disability certification requested for #{application_reference.downcase}"
   end
 
   def message_for_medical_certification_received
-    "Disability certification received for application ##{@notifiable&.id}"
+    "Disability certification received for #{application_reference.downcase}"
   end
 
   def message_for_medical_certification_approved
-    "Disability certification approved for application ##{@notifiable&.id}"
+    "Disability certification approved for #{application_reference.downcase}"
   end
 
   def message_for_medical_certification_rejected
     reason = @metadata['reason']
     reason_text = reason.present? ? " - #{reason}" : ''
-    "Disability certification rejected for application ##{@notifiable&.id}#{reason_text}."
+    "Disability certification rejected for #{application_reference.downcase}#{reason_text}."
   end
 
   def message_for_documents_requested
-    "Documents requested for application ##{@notifiable&.id}"
+    "Documents requested for #{application_reference.downcase}"
   end
 
   def message_for_review_requested
-    "Review requested for application ##{@notifiable&.id}"
+    "Review requested for #{application_reference.downcase}"
   end
 
   def default_message
@@ -130,7 +137,7 @@ class NotificationComposer
                        'a constituent'
     application_id = @metadata['application_id'].presence || application&.id
 
-    "#{trainer_name} #{verb_phrase} for #{constituent_name} for Application ##{application_id}."
+    "#{trainer_name} #{verb_phrase} for #{constituent_name} for #{application_reference}."
   end
 
   def preloaded_trainer_name

--- a/app/services/notification_composer.rb
+++ b/app/services/notification_composer.rb
@@ -39,10 +39,11 @@ class NotificationComposer
 
   private
 
-  def application_reference
-    return "Application missing" unless @notifiable&.id
+  def application_reference(application=nil)
+    application ||= @notifiable
+    return "Application missing" unless application&.id
 
-    link_to("Application ##{@notifiable.id}", "/admin/applications/#{@notifiable.id}", class: "text-indigo-600 hover:text-indigo-500")
+    link_to("Application ##{application.id}", "/admin/applications/#{application.id}", class: "text-indigo-600 hover:text-indigo-500")
   end
 
   # --- Message Generation Methods ---
@@ -137,7 +138,7 @@ class NotificationComposer
                        'a constituent'
     application_id = @metadata['application_id'].presence || application&.id
 
-    "#{trainer_name} #{verb_phrase} for #{constituent_name} for #{application_reference}."
+    "#{trainer_name} #{verb_phrase} for #{constituent_name} for #{application_reference(application)}."
   end
 
   def preloaded_trainer_name

--- a/app/views/admin/dashboards/index.html.erb
+++ b/app/views/admin/dashboards/index.html.erb
@@ -58,7 +58,7 @@
                 </div>
               </li>
             <% end %>
-          </ul>
+          </ul>          
 
           <% if @pagy_assigned_notes && @pagy_assigned_notes.pages > 1 %>
             <div class="mt-4 pt-4 border-t border-gray-200">
@@ -67,6 +67,32 @@
           <% end %>
         </section>
       <% end %>
+
+    <%# Notifications Section %>
+    <section aria-labelledby="notifications-heading" class="bg-white rounded-lg shadow p-4 mb-6">
+      <div class="flex items-center justify-between mb-4">
+        <h2 id="notifications-heading" class="text-lg font-medium text-gray-900">Recent Notifications</h2>
+        <%= link_to notifications_path(scope: 'all'), 
+            class: "text-sm font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 flex items-center",
+            aria: { label: "View all notifications" } do %>
+          View All
+          <svg class="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+          </svg>
+        <% end %>
+      </div>
+      
+      <% if @recent_notifications.present? %>
+        <ul class="divide-y divide-gray-200">
+          <% @recent_notifications.each do |notification| %>
+            <%= render "notifications/notification", notification: notification %>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="text-sm text-gray-500">No recent notifications</p>
+      <% end %>
+    </section>
+
       <%# 
         Administrative Action Buttons
       %>
@@ -290,31 +316,6 @@
           <span>Evaluation Requests (<%= @metrics[:evaluation_requests_count] %>)</span>
         <% end %>
       </div>
-    </section>
-
-    <%# Notifications Section %>
-    <section aria-labelledby="notifications-heading" class="bg-white rounded-lg shadow p-4 mb-6">
-      <div class="flex items-center justify-between mb-4">
-        <h2 id="notifications-heading" class="text-lg font-medium text-gray-900">Recent Notifications</h2>
-        <%= link_to notifications_path(scope: 'all'), 
-            class: "text-sm font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 flex items-center",
-            aria: { label: "View all notifications" } do %>
-          View All
-          <svg class="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-          </svg>
-        <% end %>
-      </div>
-      
-      <% if @recent_notifications.present? %>
-        <ul class="divide-y divide-gray-200">
-          <% @recent_notifications.each do |notification| %>
-            <%= render "notifications/notification", notification: notification %>
-          <% end %>
-        </ul>
-      <% else %>
-        <p class="text-sm text-gray-500">No recent notifications</p>
-      <% end %>
     </section>
 
     <%# Charts Section - Lazy-loaded via Turbo Frame for better performance %>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -62,7 +62,7 @@
   <div class="flex-1 min-w-0">
     <div class="flex justify-between">
       <p class="text-sm font-medium text-gray-900 <%= notification.read_at.nil? ? 'font-semibold' : '' %>">
-        <%= notification.message %>
+        <%= notification.message.html_safe %>
       </p>
       <% if notification.read_at.nil? %>
         <%= button_to mark_as_read_notification_path(notification), method: :post, 

--- a/test/services/notification_composer_test.rb
+++ b/test/services/notification_composer_test.rb
@@ -16,7 +16,8 @@ class NotificationComposerTest < ActiveSupport::TestCase
       @admin,
       { 'proof_type' => 'income' }
     )
-    assert_equal "Income approved for application ##{@application.id}.", message
+    assert message.include?('Income approved for')
+    assert message.include?(@application.id.to_s)
   end
 
   test 'generate message for proof_rejected with reason' do
@@ -26,7 +27,9 @@ class NotificationComposerTest < ActiveSupport::TestCase
       @admin,
       { 'proof_type' => 'residency', 'rejection_reason' => 'Illegible document' }
     )
-    assert_equal "Residency rejected for application ##{@application.id} - Illegible document.", message
+    assert message.include?('Residency rejected for')
+    assert message.include?(@application.id.to_s)
+    assert message.include?('Illegible document')
   end
 
   test 'generate message for trainer_assigned' do
@@ -38,7 +41,8 @@ class NotificationComposerTest < ActiveSupport::TestCase
       @application,
       trainer
     )
-    assert_equal "Jane Trainer assigned to train John Doe for Application ##{@application.id} (Scheduled).", message
+    assert message.include?('Jane Trainer assigned to train John Doe for')
+    assert message.include?(@application.id.to_s)
   end
 
   test 'generate message for training_requested' do
@@ -47,8 +51,8 @@ class NotificationComposerTest < ActiveSupport::TestCase
       @application,
       @constituent
     )
-
-    assert_equal "John Doe requested training for Application ##{@application.id}.", message
+    assert message.include?('John Doe requested training for')
+    assert message.include?(@application.id.to_s)
   end
 
   test 'generate messages for training session lifecycle notifications' do
@@ -68,7 +72,8 @@ class NotificationComposerTest < ActiveSupport::TestCase
         { 'application_id' => @application.id }
       )
 
-      assert_equal "Jane Trainer #{verb_phrase} for John Doe for Application ##{@application.id}.", message
+      assert message.include?("Jane Trainer #{verb_phrase} for John Doe for")
+      assert message.include?(@application.id.to_s)
     end
   end
 
@@ -79,7 +84,9 @@ class NotificationComposerTest < ActiveSupport::TestCase
       @admin,
       { 'reason' => 'Missing signature' }
     )
-    assert_equal "Disability certification rejected for application ##{@application.id} - Missing signature.", message
+    assert message.include?('Disability certification rejected for')
+    assert message.include?(@application.id.to_s)
+    assert message.include?('Missing signature')
   end
 
   test 'generate default message for unknown action' do
@@ -91,8 +98,26 @@ class NotificationComposerTest < ActiveSupport::TestCase
     assert_equal "Some new action notification regarding Application ##{@application.id}.", message
   end
 
+  test 'application_reference returns HTML link when notifiable has id' do
+    composer = NotificationComposer.new('test', @application, @admin, {})
+    result = composer.send(:application_reference)
+    assert result.include?(@application.id.to_s)
+    assert result.include?('<a')
+    assert result.include?('</a>')
+  end
+
+  test 'application_reference returns Application missing when notifiable is nil' do
+    composer = NotificationComposer.new('test', nil, @admin, {})
+    assert_equal 'Application missing', composer.send(:application_reference)
+  end
+
+  test 'application_reference returns Application missing when notifiable has no id' do
+    composer = NotificationComposer.new('test', Application.new(id: nil), @admin, {})
+    assert_equal 'Application missing', composer.send(:application_reference)
+  end
+
   test 'handles nil notifiable object gracefully' do
     message = NotificationComposer.generate('proof_approved', nil, @admin)
-    assert_equal 'Proof approved for application #.', message
+    assert_equal 'Proof approved for application missing.', message
   end
 end


### PR DESCRIPTION
These changes place notifications below notes on the dashboard, and link them to applications. It also decreased the applications listed from 5 to 3 so it doesn't crowd the whole screen.

<img width="1172" height="548" alt="Screenshot 2026-05-04 at 11 08 25 AM" src="https://github.com/user-attachments/assets/f9e4c919-1a54-4d0d-a21b-4648297a432b" />
