### PR TITLE
Trainer dashboard links

### DIFF
--- a/app/controllers/evaluators/dashboards_controller.rb
+++ b/app/controllers/evaluators/dashboards_controller.rb
@@ -13,19 +13,12 @@ module Evaluators
     before_action :require_evaluator!
 
     def show
-      # Set current filter from params or default to nil
-      @current_filter = params[:filter]
-      @current_status = params[:status]
-
       # Load data based on user type
       if current_user.admin?
         load_admin_data
       else
         load_evaluator_data
       end
-
-      # Apply filter status if provided
-      apply_filter if @current_filter.present?
 
       # Load display data (always needed)
       load_display_data
@@ -52,60 +45,12 @@ module Evaluators
       @assigned_constituents = current_user.assigned_constituents.to_a.uniq(&:id)
     end
 
-    def apply_filter
-      evaluations = evaluations_for_filter(@current_filter)
-      @filtered_evaluations = order_evaluations(evaluations, @current_filter)
-      @section_title = section_title_for_filter(@current_filter)
-    end
-
-    def evaluations_for_filter(filter_type)
-      case filter_type
-      when 'requested'
-        (current_user.admin? ? Evaluation.requested_sessions : current_user.evaluations.requested_sessions)
-          .includes(:constituent, :application)
-      when 'scheduled'
-        (current_user.admin? ? Evaluation.active : current_user.evaluations.active)
-          .includes(:constituent, :application)
-      when 'completed'
-        (current_user.admin? ? Evaluation.completed_sessions : current_user.evaluations.completed_sessions)
-          .includes(:constituent, :application)
-      when 'needs_followup'
-        (current_user.admin? ? Evaluation.needing_followup : current_user.evaluations.needing_followup)
-          .includes(:constituent, :application)
-      end
-    end
-
-    def order_evaluations(evaluations, filter_type)
-      case filter_type
-      when 'requested'
-        evaluations.order(created_at: :desc)
-      when 'scheduled'
-        evaluations.order(evaluation_date: :asc)
-      when 'completed'
-        evaluations.order(evaluation_date: :desc)
-      when 'needs_followup'
-        evaluations.order(updated_at: :desc)
-      end
-    end
-
-    def section_title_for_filter(filter_type)
-      {
-        'requested' => 'Requested Evaluations',
-        'scheduled' => 'Scheduled Evaluations',
-        'completed' => 'Completed Evaluations',
-        'needs_followup' => 'Evaluations Needing Follow-up'
-      }[filter_type]
-    end
-
     def load_display_data
       # Always initialize these variables to empty arrays
       @requested_evaluations_display = []
       @upcoming_evaluations = []
       @recent_evaluations = []
       @my_scheduled_evaluations_display = []
-
-      # If we're filtering, don't load all the display data
-      return if @current_filter.present?
 
       # Data for dashboard tables - limit to 5 items for each section
       @requested_evaluations_display = @requested_evaluations.includes(:constituent).order(created_at: :desc).limit(5)

--- a/app/controllers/evaluators/dashboards_controller.rb
+++ b/app/controllers/evaluators/dashboards_controller.rb
@@ -102,6 +102,7 @@ module Evaluators
       @requested_evaluations_display = []
       @upcoming_evaluations = []
       @recent_evaluations = []
+      @my_scheduled_evaluations_display = []
 
       # If we're filtering, don't load all the display data
       return if @current_filter.present?
@@ -112,6 +113,12 @@ module Evaluators
                               .includes(:constituent).order(evaluation_date: :asc).limit(5)
       @recent_evaluations = (current_user.admin? ? Evaluation.completed_sessions : current_user.evaluations.completed_sessions)
                             .includes(:constituent, :application).order(evaluation_date: :desc).limit(5)
+
+      # For admins, also load their own scheduled evaluations
+      if current_user.admin?
+        @my_scheduled_evaluations_display = Evaluation.where(evaluator_id: current_user.id).active
+                                            .includes(:constituent).order(evaluation_date: :asc).limit(5)
+      end
     end
 
     def load_recent_activity

--- a/app/controllers/evaluators/evaluations_controller.rb
+++ b/app/controllers/evaluators/evaluations_controller.rb
@@ -12,13 +12,15 @@ module Evaluators
       # Redirect to dashboard for main entry point
       # If specific filters are applied, still show the filtered list
       if params[:status].present? || params[:scope].present? || params[:filter].present?
-        @evaluations = if current_user.evaluator?
-                         # For evaluators, show only their evaluations
-                         current_user.evaluations.includes(:constituent).order(created_at: :desc)
-                       else
-                         # For admins, show all evaluations
-                         Evaluation.includes(:constituent).order(created_at: :desc)
-                       end
+        scope_param = params[:scope] || (current_user.admin? ? 'all' : 'mine')
+        status_param = params[:status]
+
+        # Apply filters
+        @evaluations = filter_evaluations(scope_param, status_param)
+
+        # Set current selections for UI state
+        @current_scope = scope_param
+        @current_status = status_param
       else
         redirect_to evaluators_dashboard_path
       end
@@ -270,7 +272,7 @@ module Evaluators
 
       # Apply status filter if provided
       filtered_query = if status.present?
-                         base_query.where(status: status)
+                         base_query.where(status: status.to_sym)
                        else
                          base_query
                        end

--- a/app/controllers/trainers/dashboards_controller.rb
+++ b/app/controllers/trainers/dashboards_controller.rb
@@ -14,15 +14,8 @@ module Trainers
     ].freeze
 
     def show
-      # Set current filter from params or default to nil
-      @current_filter = params[:filter]
-      @current_status = params[:status]
-
       # Load base training sessions first
       load_training_sessions
-
-      # Apply filter if provided
-      apply_filter if @current_filter.present?
 
       # Load display data (always needed)
       load_display_data
@@ -72,26 +65,6 @@ module Trainers
                                               .order(scheduled_for: :asc)
     end
 
-    def apply_filter
-      case @current_filter
-      when 'requested'
-        @filtered_sessions = @requested_sessions.order(created_at: :desc)
-        @section_title = 'Requested Training Sessions'
-      when 'scheduled'
-        @filtered_sessions = @scheduled_sessions.order(scheduled_for: :asc)
-        @section_title = 'Scheduled Training Sessions'
-      when 'completed'
-        @filtered_sessions = @completed_sessions.order(completed_at: :desc)
-        @section_title = 'Completed Training Sessions'
-      when 'needs_followup'
-        @filtered_sessions = @followup_sessions
-        @section_title = 'Training Sessions Needing Follow-up'
-      end
-
-      # Always include applications for display
-      @filtered_sessions = @filtered_sessions.includes(application: :user) if @filtered_sessions.present?
-    end
-
     def load_display_data
       # Always initialize these to empty arrays to prevent nil errors
       @requested_sessions_display = []
@@ -99,9 +72,6 @@ module Trainers
       @my_scheduled_sessions_display = []
       @recent_completed_sessions = []
       @recent_followup_sessions = [] # Added for default display
-
-      # If we're filtering, don't load all the display data
-      return if @current_filter.present?
 
       # Data for dashboard tables - limit to 10 items for each section
       @requested_sessions_display = @requested_sessions.limit(10)

--- a/app/views/evaluators/dashboards/show.html.erb
+++ b/app/views/evaluators/dashboards/show.html.erb
@@ -10,11 +10,7 @@
       <p class="text-3xl font-bold text-purple-600"><%= @requested_evaluations.count %></p>
       <p class="text-sm text-gray-500 mt-1">New evaluation requests</p>
       <div class="mt-3">
-        <% if current_user.admin? %>
-          <%= link_to "View All", evaluators_dashboard_path(filter: "requested"), class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors duration-200 text-sm" %>
-        <% else %>
-          <%= link_to "View All", evaluators_dashboard_path(filter: "requested"), class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors duration-200 text-sm" %>
-        <% end %>
+        <%= link_to "View requested", evaluators_dashboard_path(anchor: "needs-scheduling-section"), class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors duration-200 text-sm" %>
       </div>
     </div>
 
@@ -23,11 +19,7 @@
       <p class="text-3xl font-bold text-blue-600"><%= @scheduled_evaluations.count %></p>
       <p class="text-sm text-gray-500 mt-1">Upcoming evaluations</p>
       <div class="mt-3">
-        <% if current_user.admin? %>
-          <%= link_to "View All", evaluators_dashboard_path(filter: "scheduled"), class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors duration-200 text-sm" %>
-        <% else %>
-          <%= link_to "View All", evaluators_dashboard_path(filter: "scheduled"), class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors duration-200 text-sm" %>
-        <% end %>
+        <%= link_to "View scheduled", evaluators_dashboard_path(anchor: "upcoming-evaluations-section"), class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors duration-200 text-sm" %>
       </div>
     </div>
 
@@ -36,11 +28,7 @@
       <p class="text-3xl font-bold text-green-600"><%= @completed_evaluations.count %></p>
       <p class="text-sm text-gray-500 mt-1">Evaluations completed</p>
       <div class="mt-3">
-        <% if current_user.admin? %>
-          <%= link_to "View All", evaluators_dashboard_path(filter: "completed"), class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors duration-200 text-sm" %>
-        <% else %>
-          <%= link_to "View All", evaluators_dashboard_path(filter: "completed"), class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors duration-200 text-sm" %>
-        <% end %>
+        <%= link_to "View completed", evaluators_dashboard_path(anchor: "recent-completed-heading"), class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors duration-200 text-sm" %>
       </div>
     </div>
 
@@ -49,20 +37,16 @@
       <p class="text-3xl font-bold text-yellow-600"><%= @followup_evaluations.count %></p>
       <p class="text-sm text-gray-500 mt-1">Cancellations and no-shows</p>
       <div class="mt-3">
-        <% if current_user.admin? %>
-          <%= link_to "View All", evaluators_dashboard_path(filter: "needs_followup"), class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors duration-200 text-sm" %>
-        <% else %>
-          <%= link_to "View All", evaluators_dashboard_path(filter: "needs_followup"), class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors duration-200 text-sm" %>
-        <% end %>
+        <%= link_to "View follow up", evaluators_dashboard_path(anchor: "followup-evaluations-section"), class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors duration-200 text-sm" %>
       </div>
     </div>
   </div>
 
   <!-- Requested Evaluations (Needs Scheduling) -->
-  <div class="bg-white shadow rounded-lg p-6 mb-8">
+  <div id="needs-scheduling-section" class="bg-white shadow rounded-lg p-6 mb-8">
     <div class="flex justify-between items-center mb-4">
       <h2 class="text-xl font-semibold">Needs Scheduling</h2>
-      <%= link_to "View All", evaluators_dashboard_path(filter: "requested"), class: "text-blue-600 hover:text-blue-800" %>
+      <%= link_to "View All", evaluators_evaluations_path(status: "requested"), class: "text-blue-600 hover:text-blue-800" %>
     </div>
 
     <% if @requested_evaluations_display.any? %>
@@ -104,14 +88,10 @@
   </div>
 
   <!-- Upcoming Evaluations -->
-  <div class="bg-white shadow rounded-lg p-6 mb-8">
+  <div id="upcoming-evaluations-section" class="bg-white shadow rounded-lg p-6 mb-8">
     <div class="flex justify-between items-center mb-4">
       <h2 class="text-xl font-semibold">Upcoming Evaluations</h2>
-      <% if current_user.admin? %>
-        <%= link_to "View All", evaluators_dashboard_path(filter: "scheduled"), class: "text-blue-600 hover:text-blue-800" %>
-      <% else %>
-        <%= link_to "View All", evaluators_dashboard_path(filter: "scheduled"), class: "text-blue-600 hover:text-blue-800" %>
-      <% end %>
+      <%= link_to "View All", evaluators_evaluations_path(status: "scheduled"), class: "text-blue-600 hover:text-blue-800" %>
     </div>
 
     <% if @upcoming_evaluations.any? %>
@@ -154,7 +134,7 @@
 
   <% if @current_filter.present? && @filtered_evaluations.present? %>
     <!-- Filtered Results -->
-    <div class="bg-white shadow rounded-lg p-6 mb-8">
+    <div id="followup-evaluations-section" class="bg-white shadow rounded-lg p-6 mb-8">
       <div class="flex justify-between items-center mb-4">
         <h2 class="text-xl font-semibold"><%= @section_title %></h2>
         <%= link_to "Clear Filter", evaluators_dashboard_path, class: "inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
@@ -221,12 +201,8 @@
   <!-- Recent Activity -->
   <div class="bg-white shadow rounded-lg p-6">
     <div class="flex justify-between items-center mb-4">
-      <h2 class="text-xl font-semibold">Recent Completed Evaluations</h2>
-      <% if current_user.admin? %>
-        <%= link_to "View All", evaluators_dashboard_path(filter: "completed"), class: "text-blue-600 hover:text-blue-800" %>
-      <% else %>
-        <%= link_to "View All", evaluators_dashboard_path(filter: "completed"), class: "text-blue-600 hover:text-blue-800" %>
-      <% end %>
+      <h2 id="recent-completed-heading" class="text-xl font-semibold">Recent Completed Evaluations</h2>
+      <%= link_to "View All", evaluators_evaluations_path(status: "completed"), class: "text-blue-600 hover:text-blue-800" %>
     </div>
 
     <% if @recent_evaluations.any? %>

--- a/app/views/evaluators/dashboards/show.html.erb
+++ b/app/views/evaluators/dashboards/show.html.erb
@@ -17,10 +17,27 @@
     <div class="bg-white shadow rounded-lg p-5">
       <h2 class="text-lg font-semibold text-gray-700 mb-3">Scheduled Evaluations</h2>
       <p class="text-3xl font-bold text-blue-600"><%= @scheduled_evaluations.count %></p>
-      <p class="text-sm text-gray-500 mt-1">Upcoming evaluations</p>
-      <div class="mt-3">
-        <%= link_to "View scheduled", evaluators_dashboard_path(anchor: "upcoming-evaluations-section"), class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors duration-200 text-sm" %>
-      </div>
+      <p class="text-sm text-gray-500 mt-1">
+        <% if current_user.admin? %>
+          Upcoming evaluations
+        <% else %>
+          Upcoming evaluations
+        <% end %>
+      </p>
+      <% if current_user.admin? %>
+        <div class="mt-3 flex flex-wrap gap-2">
+          <%= link_to "My scheduled", evaluators_dashboard_path(anchor: "upcoming-evaluations-section"),
+              class: "inline-flex items-center px-4 py-2 border border-blue-300 bg-white hover:bg-blue-50 text-blue-700 rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
+              aria: { label: "View scheduled evaluations assigned to me" } %>
+          <%= link_to "View scheduled", evaluators_evaluations_path(status: "scheduled"),
+              class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
+              aria: { label: "View scheduled evaluations for all evaluators" } %>
+        </div>
+      <% else %>
+        <div class="mt-3">
+          <%= link_to "View scheduled", evaluators_dashboard_path(anchor: "upcoming-evaluations-section"), class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors duration-200 text-sm" %>
+        </div>
+      <% end %>
     </div>
 
     <div class="bg-white shadow rounded-lg p-5">
@@ -86,6 +103,56 @@
       <p class="text-gray-500 text-center py-4">No evaluations currently awaiting scheduling.</p>
     <% end %>
   </div>
+
+  <% if current_user.admin? %>
+    <!-- Admin's own scheduled evaluations -->
+    <div id="my-upcoming-evaluations-section" class="bg-white shadow rounded-lg p-6 mb-8">
+      <div class="flex justify-between items-center mb-4">
+        <h2 id="my-upcoming-evaluations-table-heading" class="text-xl font-semibold">My Upcoming Evaluations</h2>
+        <%= link_to "View My Scheduled", evaluators_evaluations_path(scope: "mine", status: "scheduled"), class: "text-blue-600 hover:text-blue-800",
+            aria: { label: "View all scheduled evaluations assigned to me" } %>
+      </div>
+
+      <% if @my_scheduled_evaluations_display.any? %>
+        <div class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-gray-200" aria-labelledby="my-upcoming-evaluations-table-heading">
+            <thead class="bg-gray-50">
+              <tr>
+                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date/Time</th>
+                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Constituent</th>
+                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+              </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+              <% @my_scheduled_evaluations_display.each do |evaluation| %>
+                <tr>
+                  <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    <%= evaluation.evaluation_date.strftime("%B %d, %Y at %I:%M %p") %>
+                  </td>
+                  <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    <%= evaluation.constituent.full_name %>
+                  </td>
+                  <td class="px-6 py-4 whitespace-nowrap">
+                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
+                      <span class="sr-only">Status: </span><%= evaluation.status.titleize %>
+                    </span>
+                  </td>
+                  <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                    <%= link_to "View Details", evaluators_evaluation_path(evaluation),
+                        class: "bg-indigo-600 hover:bg-indigo-700 text-white py-1 px-3 rounded-md inline-block transition-colors duration-200",
+                        aria: { label: "View details for #{evaluation.constituent.full_name}" } %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% else %>
+        <p class="text-gray-500 text-center py-4">No upcoming evaluations are assigned to you.</p>
+      <% end %>
+    </div>
+  <% end %>
 
   <!-- Upcoming Evaluations -->
   <div id="upcoming-evaluations-section" class="bg-white shadow rounded-lg p-6 mb-8">

--- a/app/views/evaluators/evaluations/index.html.erb
+++ b/app/views/evaluators/evaluations/index.html.erb
@@ -16,6 +16,12 @@
       <% else %>
         Evaluations
       <% end %>
+      
+      <% if current_user.admin? && @current_scope.present? %>
+        <span class="text-lg font-normal ml-2 text-gray-600">
+          (<%= @current_scope == 'mine' ? 'Assigned to Me' : 'All Evaluators' %>)
+        </span>
+      <% end %>
     </h1>
     
     <div>
@@ -23,33 +29,50 @@
     </div>
   </div>
 
-  <!-- Status filter pills -->
-  <div class="flex flex-wrap items-center gap-2 bg-gray-100 p-1 rounded-lg mb-6">
-    <span class="text-xs font-semibold text-gray-500 px-2">STATUS:</span>
-    <%= link_to "All", 
-        evaluators_evaluations_path,
-        class: "#{@current_status.blank? ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200",
-        aria: { current: (@current_status.blank? ? "page" : nil) } %>
+  <!-- Unified filter bar -->
+  <div class="mb-6 flex flex-wrap gap-4">
+    <!-- Scope selection (for admins only) -->
+    <% if current_user.admin? %>
+      <div class="flex items-center gap-2 bg-gray-100 p-1 rounded-lg">
+        <span class="text-xs font-semibold text-gray-500 px-2">VIEW:</span>
+        <%= link_to "All Evaluators", 
+            evaluators_evaluations_path(scope: "all", status: @current_status),
+            class: "#{@current_scope == 'all' ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200" %>
         
-    <%= link_to "Needs Scheduling",
-        evaluators_evaluations_path(status: 'requested'),
-        class: "#{@current_status == 'requested' ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200",
-        aria: { current: (@current_status == 'requested' ? "page" : nil) } %>
-        
-    <%= link_to "Scheduled", 
-        evaluators_evaluations_path(status: 'scheduled'),
-        class: "#{@current_status == 'scheduled' ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200",
-        aria: { current: (@current_status == 'scheduled' ? "page" : nil) } %>
-        
-    <%= link_to "Completed", 
-        evaluators_evaluations_path(status: 'completed'),
-        class: "#{@current_status == 'completed' ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200",
-        aria: { current: (@current_status == 'completed' ? "page" : nil) } %>
-        
-    <%= link_to "Needs Follow-up", 
-        evaluators_evaluations_path(status: 'needs_followup'),
-        class: "#{%w[needs_followup cancelled no_show].include?(@current_status) ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200",
-        aria: { current: (%w[needs_followup cancelled no_show].include?(@current_status) ? "page" : nil) } %>
+        <%= link_to "My Evaluations", 
+            evaluators_evaluations_path(scope: "mine", status: @current_status),
+            class: "#{@current_scope == 'mine' ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200" %>
+      </div>
+    <% end %>
+    
+    <!-- Status filter pills -->
+    <div class="flex flex-wrap items-center gap-2 bg-gray-100 p-1 rounded-lg">
+      <span class="text-xs font-semibold text-gray-500 px-2">STATUS:</span>
+      <%= link_to "All", 
+          evaluators_evaluations_path(scope: @current_scope),
+          class: "#{@current_status.blank? ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200",
+          aria: { current: (@current_status.blank? ? "page" : nil) } %>
+          
+      <%= link_to "Needs Scheduling",
+          evaluators_evaluations_path(scope: @current_scope, status: 'requested'),
+          class: "#{@current_status == 'requested' ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200",
+          aria: { current: (@current_status == 'requested' ? "page" : nil) } %>
+          
+      <%= link_to "Scheduled", 
+          evaluators_evaluations_path(scope: @current_scope, status: 'scheduled'),
+          class: "#{@current_status == 'scheduled' ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200",
+          aria: { current: (@current_status == 'scheduled' ? "page" : nil) } %>
+          
+      <%= link_to "Completed", 
+          evaluators_evaluations_path(scope: @current_scope, status: 'completed'),
+          class: "#{@current_status == 'completed' ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200",
+          aria: { current: (@current_status == 'completed' ? "page" : nil) } %>
+          
+      <%= link_to "Needs Follow-up", 
+          evaluators_evaluations_path(scope: @current_scope, status: 'needs_followup'),
+          class: "#{%w[needs_followup cancelled no_show].include?(@current_status) ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200",
+          aria: { current: (%w[needs_followup cancelled no_show].include?(@current_status) ? "page" : nil) } %>
+    </div>
   </div>
 
   <!-- Evaluations Table -->

--- a/app/views/evaluators/evaluations/index.html.erb
+++ b/app/views/evaluators/evaluations/index.html.erb
@@ -1,24 +1,134 @@
-<div class="container mx-auto px-4 py-8">
-  <h1 class="text-2xl font-bold mb-6">
-    <%= params[:action].capitalize %> Evaluations
-  </h1>
-
-  <% if @evaluations.any? %>
-    <ul class="space-y-4">
-      <% @evaluations.each do |evaluation| %>
-        <li class="bg-white shadow rounded-lg p-4">
-          <h2 class="text-xl font-semibold">
-            <%= link_to evaluation.constituent.full_name, evaluators_evaluation_path(evaluation) %>
-          </h2>
-          <p>Status: <%= evaluation.status.capitalize %></p>
-          <p>Type: <%= evaluation.evaluation_type.capitalize %></p>
-          <p> Evaluation Date: <%= evaluation.evaluation_date&.strftime("%B %d, %Y") || "No evaluation date" %> </p>
-
-          <!-- Add more fields as necessary -->
-        </li>
+<a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:p-2 focus:bg-indigo-600 focus:text-white focus:z-50 focus:rounded">
+  Skip to main content
+</a>
+<div id="main-content" tabindex="-1" class="container mx-auto px-4 py-8">
+  <!-- Header with context-aware title -->
+  <div class="flex justify-between items-center mb-6">
+    <h1 id="evaluations-list-heading" class="text-2xl font-bold">
+      <% if @current_status == 'requested' %>
+        Needs Scheduling
+      <% elsif @current_status == 'scheduled' %>
+        Scheduled Evaluations
+      <% elsif @current_status == 'completed' %>
+        Completed Evaluations
+      <% elsif %w[needs_followup no_show cancelled].include?(@current_status) %>
+        Evaluations Needing Follow-up
+      <% else %>
+        Evaluations
       <% end %>
-    </ul>
+    </h1>
+    
+    <div>
+      <%= link_to "Back to Dashboard", evaluators_dashboard_path, class: "bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-2 px-4 rounded inline-flex items-center" %>
+    </div>
+  </div>
+
+  <!-- Status filter pills -->
+  <div class="flex flex-wrap items-center gap-2 bg-gray-100 p-1 rounded-lg mb-6">
+    <span class="text-xs font-semibold text-gray-500 px-2">STATUS:</span>
+    <%= link_to "All", 
+        evaluators_evaluations_path,
+        class: "#{@current_status.blank? ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200",
+        aria: { current: (@current_status.blank? ? "page" : nil) } %>
+        
+    <%= link_to "Needs Scheduling",
+        evaluators_evaluations_path(status: 'requested'),
+        class: "#{@current_status == 'requested' ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200",
+        aria: { current: (@current_status == 'requested' ? "page" : nil) } %>
+        
+    <%= link_to "Scheduled", 
+        evaluators_evaluations_path(status: 'scheduled'),
+        class: "#{@current_status == 'scheduled' ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200",
+        aria: { current: (@current_status == 'scheduled' ? "page" : nil) } %>
+        
+    <%= link_to "Completed", 
+        evaluators_evaluations_path(status: 'completed'),
+        class: "#{@current_status == 'completed' ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200",
+        aria: { current: (@current_status == 'completed' ? "page" : nil) } %>
+        
+    <%= link_to "Needs Follow-up", 
+        evaluators_evaluations_path(status: 'needs_followup'),
+        class: "#{%w[needs_followup cancelled no_show].include?(@current_status) ? 'bg-white shadow-sm text-blue-600' : 'text-gray-700 hover:bg-gray-200'} px-4 py-2 rounded-md font-medium transition-colors duration-200",
+        aria: { current: (%w[needs_followup cancelled no_show].include?(@current_status) ? "page" : nil) } %>
+  </div>
+
+  <!-- Evaluations Table -->
+  <% if @evaluations.any? %>
+    <div class="bg-white shadow overflow-hidden sm:rounded-lg">
+      <table class="min-w-full divide-y divide-gray-200" aria-labelledby="evaluations-list-heading">
+        <thead class="bg-gray-50">
+          <tr>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date/Time</th>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Constituent</th>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Application ID</th>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <% @evaluations.each do |evaluation| %>
+            <tr>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                <% if evaluation.status == 'completed' && evaluation.evaluation_date.present? %>
+                  Completed: <%= evaluation.evaluation_date.strftime("%B %d, %Y") %>
+                <% else %>
+                  <%= evaluation.evaluation_date&.strftime("%B %d, %Y at %I:%M %p") || "Not scheduled" %>
+                <% end %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                <%= evaluation.constituent.full_name %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <!-- Status badge with color coding -->
+                <% status_classes = case evaluation.status 
+                   when 'scheduled' then 'bg-blue-100 text-blue-800'
+                   when 'confirmed' then 'bg-green-100 text-green-800'
+                   when 'completed' then 'bg-purple-100 text-purple-800'
+                   when 'cancelled' then 'bg-yellow-100 text-yellow-800'
+                   when 'no_show' then 'bg-red-100 text-red-800'
+                   else 'bg-gray-100 text-gray-800'
+                   end %>
+                
+                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full <%= status_classes %>">
+                  <span class="sr-only">Status: </span>
+                  <% if evaluation.status == 'requested' %>
+                    Needs Scheduling
+                  <% else %>
+                    <%= evaluation.status.titleize %>
+                  <% end %>
+                </span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                <%= evaluation.application.id %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                <% if evaluation.status == 'requested' %>
+                  <%= link_to "View/Schedule", evaluators_evaluation_path(evaluation),
+                      class: "bg-indigo-600 hover:bg-indigo-700 text-white py-1 px-3 rounded-md inline-block transition-colors duration-200",
+                      aria: { label: "View/Schedule evaluation for #{evaluation.constituent.full_name}" } %>
+                <% elsif evaluation.status == 'scheduled' %>
+                  <%= link_to "Complete Report", evaluators_evaluation_path(evaluation),
+                      class: "bg-indigo-600 hover:bg-indigo-700 text-white py-1 px-3 rounded-md inline-block transition-colors duration-200",
+                      aria: { label: "Complete report for #{evaluation.constituent.full_name}" } %>
+                <% else %>
+                  <%= link_to "View Details", evaluators_evaluation_path(evaluation),
+                      class: "bg-indigo-600 hover:bg-indigo-700 text-white py-1 px-3 rounded-md inline-block transition-colors duration-200",
+                      aria: { label: "View details for #{evaluation.constituent.full_name}" } %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+    
+    <!-- Pagination -->
+    <div class="py-4">
+      <%== pagy_nav(@pagy) if defined?(@pagy) %>
+    </div>
   <% else %>
-    <p class="text-gray-600">No evaluations found.</p>
+    <div class="bg-white shadow sm:rounded-lg p-6 text-center">
+      <p class="text-gray-500">No evaluations found.</p>
+    </div>
   <% end %>
 </div>

--- a/app/views/trainers/dashboards/show.html.erb
+++ b/app/views/trainers/dashboards/show.html.erb
@@ -21,7 +21,7 @@
         </p>
         <div class="mt-3">
           <%= link_to "View All", trainers_dashboard_path(anchor: "needs-scheduling-section"),
-              class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
+              class: "inline-flex items-center px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
               aria: { label: "View all training items needing scheduling" } %>
         </div>
       </li>
@@ -38,16 +38,16 @@
         </p>
         <% if current_user.admin? %>
           <div class="mt-3 flex flex-wrap gap-2">
-            <%= link_to "All Scheduled", trainers_dashboard_path(filter: "scheduled"),
+            <%= link_to "All Scheduled", trainers_dashboard_path(anchor: "upcoming-sessions-section"),
                 class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
                 aria: { label: "View all scheduled sessions" } %>
-            <%= link_to "My Scheduled", filtered_trainers_training_sessions_path(scope: "mine", status: "scheduled"),
+            <%= link_to "My Scheduled", trainers_dashboard_path(anchor: "my-upcoming-sessions-section"),
                 class: "inline-flex items-center px-4 py-2 border border-blue-300 bg-white hover:bg-blue-50 text-blue-700 rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
                 aria: { label: "View scheduled sessions assigned to me" } %>
           </div>
         <% else %>
           <div class="mt-3">
-            <%= link_to "View All", trainers_dashboard_path(filter: "scheduled"),
+            <%= link_to "View All", trainers_dashboard_path(anchor: "upcoming-sessions-section"),
                 class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
                 aria: { label: "View all scheduled sessions" } %>
           </div>
@@ -59,7 +59,7 @@
         <p class="text-3xl font-bold text-green-700"><%= @completed_sessions.count %><span class="sr-only"> completed sessions</span></p>
         <p class="text-sm text-gray-500 mt-1">Training sessions completed</p>
         <div class="mt-3">
-          <%= link_to "View All", trainers_dashboard_path(filter: "completed"),
+          <%= link_to "View All", trainers_dashboard_path(anchor: "recent-completed-heading"),
               class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
               aria: { label: "View all completed sessions" } %>
         </div>
@@ -70,7 +70,7 @@
         <p class="text-3xl font-bold text-yellow-700"><%= @followup_sessions_count %><span class="sr-only"> sessions needing follow-up</span></p>
         <p class="text-sm text-gray-500 mt-1">Cancellations and no-shows</p>
         <div class="mt-3">
-          <%= link_to "View All", trainers_dashboard_path(filter: "needs_followup"),
+          <%= link_to "View All", trainers_dashboard_path(anchor: "followup-sessions-table-heading"),
               class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
               aria: { label: "View all sessions needing follow-up" } %>
         </div>
@@ -145,7 +145,7 @@
 
     <% if current_user.admin? %>
       <!-- Admin's own scheduled training sessions -->
-      <div class="bg-white shadow rounded-lg p-6 mb-8">
+      <div id="my-upcoming-sessions-section" class="bg-white shadow rounded-lg p-6 mb-8">
         <div class="flex justify-between items-center mb-4">
           <h2 id="my-upcoming-sessions-table-heading" class="text-xl font-semibold">My Upcoming Training Sessions</h2>
           <%= link_to "View My Scheduled", filtered_trainers_training_sessions_path(scope: "mine", status: "scheduled"), class: "text-blue-600 hover:text-blue-800",
@@ -194,7 +194,7 @@
     <% end %>
 
     <!-- Upcoming Training Sessions -->
-    <div class="bg-white shadow rounded-lg p-6 mb-8">
+    <div id="upcoming-sessions-section" class="bg-white shadow rounded-lg p-6 mb-8">
       <div class="flex justify-between items-center mb-4">
         <h2 id="upcoming-sessions-table-heading" class="text-xl font-semibold">Upcoming Training Sessions</h2>
         <%= link_to "View All", scheduled_trainers_training_sessions_path, class: "text-blue-600 hover:text-blue-800",

--- a/app/views/trainers/dashboards/show.html.erb
+++ b/app/views/trainers/dashboards/show.html.erb
@@ -20,9 +20,9 @@
           <% end %>
         </p>
         <div class="mt-3">
-          <%= link_to "View All", trainers_dashboard_path(anchor: "needs-scheduling-section"),
+          <%= link_to "View requested", trainers_dashboard_path(anchor: "needs-scheduling-section"),
               class: "inline-flex items-center px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
-              aria: { label: "View all training items needing scheduling" } %>
+              aria: { label: "View training items needing scheduling" } %>
         </div>
       </li>
 
@@ -38,18 +38,18 @@
         </p>
         <% if current_user.admin? %>
           <div class="mt-3 flex flex-wrap gap-2">
-            <%= link_to "All Scheduled", trainers_dashboard_path(anchor: "upcoming-sessions-section"),
-                class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
-                aria: { label: "View all scheduled sessions" } %>
-            <%= link_to "My Scheduled", trainers_dashboard_path(anchor: "my-upcoming-sessions-section"),
+            <%= link_to "My scheduled", trainers_dashboard_path(anchor: "my-upcoming-sessions-section"),
                 class: "inline-flex items-center px-4 py-2 border border-blue-300 bg-white hover:bg-blue-50 text-blue-700 rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
                 aria: { label: "View scheduled sessions assigned to me" } %>
+            <%= link_to "View scheduled", trainers_dashboard_path(anchor: "upcoming-sessions-section"),
+                class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
+                aria: { label: "View scheduled sessions assigned to all trainers" } %>
           </div>
         <% else %>
           <div class="mt-3">
-            <%= link_to "View All", trainers_dashboard_path(anchor: "upcoming-sessions-section"),
+            <%= link_to "View sessions", trainers_dashboard_path(anchor: "upcoming-sessions-section"),
                 class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
-                aria: { label: "View all scheduled sessions" } %>
+                aria: { label: "View scheduled sessions" } %>
           </div>
         <% end %>
       </li>
@@ -59,9 +59,9 @@
         <p class="text-3xl font-bold text-green-700"><%= @completed_sessions.count %><span class="sr-only"> completed sessions</span></p>
         <p class="text-sm text-gray-500 mt-1">Training sessions completed</p>
         <div class="mt-3">
-          <%= link_to "View All", trainers_dashboard_path(anchor: "recent-completed-heading"),
+          <%= link_to "View completed", trainers_dashboard_path(anchor: "recent-completed-heading"),
               class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
-              aria: { label: "View all completed sessions" } %>
+              aria: { label: "View completed sessions" } %>
         </div>
       </li>
 
@@ -70,9 +70,9 @@
         <p class="text-3xl font-bold text-yellow-700"><%= @followup_sessions_count %><span class="sr-only"> sessions needing follow-up</span></p>
         <p class="text-sm text-gray-500 mt-1">Cancellations and no-shows</p>
         <div class="mt-3">
-          <%= link_to "View All", trainers_dashboard_path(anchor: "followup-sessions-table-heading"),
+          <%= link_to "View follow up", trainers_dashboard_path(anchor: "followup-sessions-table-heading"),
               class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 min-h-[44px]",
-              aria: { label: "View all sessions needing follow-up" } %>
+              aria: { label: "View sessions needing follow-up" } %>
         </div>
       </li>
     </ul>
@@ -83,7 +83,7 @@
     <div id="needs-scheduling-section" class="bg-white shadow rounded-lg p-6 mb-8">
       <div class="flex justify-between items-center mb-4">
         <h2 id="needs-scheduling-table-heading" class="text-xl font-semibold">Needs Scheduling</h2>
-        <%= link_to "View All", requested_trainers_training_sessions_path, class: "text-blue-600 hover:text-blue-800",
+        <%= link_to "View All", trainers_training_sessions_path(status: "requested"), class: "text-blue-600 hover:text-blue-800",
             aria: { label: "View all sessions needing scheduling" } %>
       </div>
 
@@ -148,7 +148,7 @@
       <div id="my-upcoming-sessions-section" class="bg-white shadow rounded-lg p-6 mb-8">
         <div class="flex justify-between items-center mb-4">
           <h2 id="my-upcoming-sessions-table-heading" class="text-xl font-semibold">My Upcoming Training Sessions</h2>
-          <%= link_to "View My Scheduled", filtered_trainers_training_sessions_path(scope: "mine", status: "scheduled"), class: "text-blue-600 hover:text-blue-800",
+          <%= link_to "View My Scheduled", trainers_training_sessions_path(scope: "mine", status: "scheduled"), class: "text-blue-600 hover:text-blue-800",
               aria: { label: "View all scheduled sessions assigned to me" } %>
         </div>
 
@@ -197,7 +197,7 @@
     <div id="upcoming-sessions-section" class="bg-white shadow rounded-lg p-6 mb-8">
       <div class="flex justify-between items-center mb-4">
         <h2 id="upcoming-sessions-table-heading" class="text-xl font-semibold">Upcoming Training Sessions</h2>
-        <%= link_to "View All", scheduled_trainers_training_sessions_path, class: "text-blue-600 hover:text-blue-800",
+        <%= link_to "View All", trainers_training_sessions_path(status: "scheduled"), class: "text-blue-600 hover:text-blue-800",
             aria: { label: "View all upcoming scheduled sessions" } %>
       </div>
 
@@ -311,7 +311,7 @@
     <div class="bg-white shadow rounded-lg p-6 mb-8">
       <div class="flex justify-between items-center mb-4">
       <h2 id="followup-sessions-table-heading" class="text-xl font-semibold">Recent Training Sessions Needing Follow-up</h2>
-      <%= link_to "View All", trainers_dashboard_path(filter: "needs_followup"), class: "text-blue-600 hover:text-blue-800",
+      <%= link_to "View All", trainers_training_sessions_path(status: "needs_followup"), class: "text-blue-600 hover:text-blue-800",
           aria: { label: "View all sessions needing follow-up" } %>
       </div>
 
@@ -365,8 +365,8 @@
   <section aria-labelledby="recent-completed-heading" class="bg-white shadow rounded-lg p-6">
     <div class="flex justify-between items-center mb-4">
       <h2 id="recent-completed-heading" class="text-xl font-semibold">Recent Completed Sessions</h2>
-      <%= link_to "View All", completed_trainers_training_sessions_path, class: "text-blue-600 hover:text-blue-800",
-          aria: { label: "View all completed sessions" } %>
+        <%= link_to "View All", trainers_training_sessions_path(status: "completed"), class: "text-blue-600 hover:text-blue-800",
+            aria: { label: "View all completed sessions" } %>
     </div>
 
     <% if @recent_completed_sessions.any? %>

--- a/test/controllers/trainers/dashboards_controller_test.rb
+++ b/test/controllers/trainers/dashboards_controller_test.rb
@@ -100,25 +100,6 @@ module Trainers
       assert_includes assigns(:upcoming_sessions), scheduled_session
     end
 
-    test 'trainer dashboard and scheduled filter show only assigned sessions' do
-      sign_in_for_integration_test(@trainer)
-
-      get trainers_dashboard_path
-
-      assert_response :success
-      assert_includes assigns(:scheduled_sessions), @session
-      assert_not_includes assigns(:scheduled_sessions), @other_session
-      assert_includes assigns(:upcoming_sessions), @session
-      assert_not_includes assigns(:upcoming_sessions), @other_session
-      assert_includes @response.body, @constituent.full_name
-
-      get trainers_dashboard_path(filter: 'scheduled')
-
-      assert_response :success
-      assert_includes assigns(:filtered_sessions), @session
-      assert_not_includes assigns(:filtered_sessions), @other_session
-    end
-
     test 'admin dashboard surfaces scheduled sessions assigned to the admin separately' do
       sign_in_for_integration_test(@admin)
       admin_constituent = create(:constituent, first_name: 'Admin', last_name: 'Training')
@@ -133,19 +114,7 @@ module Trainers
       assert_includes assigns(:my_scheduled_sessions), admin_session
       assert_not_includes assigns(:my_scheduled_sessions), @session
       assert_select 'h2', text: 'My Upcoming Training Sessions', count: 1
-      assert_select 'a', text: 'My Scheduled', count: 1
       assert_select 'a', text: 'View My Scheduled', count: 1
-    end
-
-    test 'scheduled filter hides default dashboard tables' do
-      sign_in_for_integration_test(@trainer)
-
-      get trainers_dashboard_path(filter: 'scheduled')
-
-      assert_response :success
-      assert_select 'h2', text: 'Upcoming Training Sessions', count: 0
-      assert_select 'h2', text: 'Needs Scheduling', count: 0
-      assert_select 'h2', text: 'Scheduled Training Sessions', count: 1
     end
 
     private


### PR DESCRIPTION
- Match trainer and evaluator dashboard
- Change links to be consistent in behavior
- Card links at anchor to sections on page, view all links go to training_sessions index
<img width="664" height="27" alt="Screenshot 2026-05-20 at 9 58 48 AM" src="https://github.com/user-attachments/assets/3317142a-6a98-4dc2-82fc-83e7835c3fd8" />
<img width="1281" height="586" alt="Screenshot 2026-05-20 at 9 59 10 AM" src="https://github.com/user-attachments/assets/c1f2cebd-dfee-44de-b763-eadff05186e1" />
<img width="1306" height="616" alt="Screenshot 2026-05-20 at 9 59 24 AM" src="https://github.com/user-attachments/assets/a8117884-6363-4a7d-9c14-b22a3674ee93" />
<img width="1375" height="591" alt="Screenshot 2026-05-20 at 10 52 43 AM" src="https://github.com/user-attachments/assets/76beba8a-5e28-4d23-9396-7698c80775c4" />
<img width="1381" height="581" alt="Screenshot 2026-05-20 at 10 52 48 AM" src="https://github.com/user-attachments/assets/488af305-0b83-4e80-b335-b30e7e0ceed7" />
