### PR TITLE
Simplify provider info request summary copy

### DIFF
--- a/app/controllers/concerns/admin/provider_info_request_loading.rb
+++ b/app/controllers/concerns/admin/provider_info_request_loading.rb
@@ -42,13 +42,12 @@ module Admin
       return {} if application_ids.blank?
 
       pending_ids = Application.pending_provider_info.where(id: application_ids).pluck(:id)
-      summaries = pending_ids.index_with { provider_info_empty_summary }
-      return summaries if pending_ids.blank?
+      return {} if pending_ids.blank?
 
-      provider_info_latest_batch_forms(pending_ids).each do |application_id, batch_forms|
-        summaries[application_id] = provider_info_batch_summary(batch_forms)
+      provider_info_latest_batch_forms(pending_ids).each_with_object({}) do |(application_id, batch_forms), summaries|
+        summary = provider_info_batch_summary(batch_forms)
+        summaries[application_id] = summary if summary
       end
-      summaries
     end
 
     def provider_info_guardian_relationships(application)
@@ -107,28 +106,38 @@ module Admin
         end
     end
 
-    def provider_info_empty_summary
+    def provider_info_batch_summary(batch_forms)
+      active_expirations = batch_forms.select(&:active?).filter_map(&:expires_at)
+      summary_status = provider_info_summary_status(batch_forms, active_expirations)
+      return nil if summary_status.blank?
+
       {
         pending: true,
-        recipient_count: 0,
-        status_counts: { active: 0, submitted: 0, expired: 0, revoked: 0 },
-        last_sent_at: nil,
-        nearest_expiration_at: nil
+        summary_status: summary_status,
+        last_sent_at: batch_forms.filter_map(&:sent_at).max,
+        nearest_expiration_at: active_expirations.min
       }
     end
 
-    def provider_info_batch_summary(batch_forms)
-      status_counts = { active: 0, submitted: 0, expired: 0, revoked: 0 }
-      batch_forms.each { |form| status_counts[form.display_status] += 1 }
+    def provider_info_summary_status(batch_forms, active_expirations)
+      return :active if active_expirations.any?
 
-      active_expirations = batch_forms.select(&:active?).filter_map(&:expires_at)
-      {
-        pending: true,
-        recipient_count: batch_forms.size,
-        status_counts: status_counts,
-        last_sent_at: batch_forms.filter_map(&:sent_at).max,
-        nearest_expiration_at: active_expirations.min || batch_forms.filter_map(&:expires_at).min
-      }
+      cutoff = provider_info_secure_link_recent_cutoff
+      return :expired if batch_forms.any? { |form| provider_info_recently_expired?(form, cutoff) }
+
+      :revoked if batch_forms.any? { |form| provider_info_recently_revoked?(form, cutoff) }
+    end
+
+    def provider_info_recently_expired?(form, cutoff)
+      form.display_status == :expired && form.expires_at.present? && form.expires_at >= cutoff
+    end
+
+    def provider_info_recently_revoked?(form, cutoff)
+      form.display_status == :revoked && form.revoked_at.present? && form.revoked_at >= cutoff
+    end
+
+    def provider_info_secure_link_recent_cutoff
+      (Policy.get('secure_form_link_expiration_hours') || 48).hours.ago
     end
   end
 end

--- a/app/helpers/secure_request_forms_helper.rb
+++ b/app/helpers/secure_request_forms_helper.rb
@@ -29,28 +29,11 @@ module SecureRequestFormsHelper
     t("admin.applications.secure_request_forms.statuses.#{secure_request_form.display_status}")
   end
 
-  def secure_request_summary_recipient_count(summary)
-    t('admin.applications.secure_request_forms.summary.recipients',
-      count: summary.fetch(:recipient_count))
-  end
-
-  def secure_request_summary_status_counts(summary)
-    counts = summary.fetch(:status_counts)
-    t('admin.applications.secure_request_forms.summary.status_counts',
-      active: counts.fetch(:active),
-      submitted: counts.fetch(:submitted),
-      expired: counts.fetch(:expired),
-      revoked: counts.fetch(:revoked))
-  end
-
   def secure_request_summary_accessible_label(summary)
     label = t('admin.applications.secure_request_forms.summary.label')
-    return "#{label}. #{t('admin.applications.secure_request_forms.summary.none')}." if summary.fetch(:recipient_count).zero?
 
     segments = [
       label,
-      secure_request_summary_recipient_count(summary),
-      secure_request_summary_status_counts(summary),
       secure_request_summary_sent_text(summary),
       secure_request_summary_expiration_text(summary)
     ].compact
@@ -61,14 +44,21 @@ module SecureRequestFormsHelper
     return if summary[:last_sent_at].blank?
 
     t('admin.applications.secure_request_forms.summary.last_sent',
-      time: l(summary.fetch(:last_sent_at), format: :short))
+      time: secure_request_summary_date(summary.fetch(:last_sent_at)))
   end
 
   def secure_request_summary_expiration_text(summary)
-    return if summary[:nearest_expiration_at].blank?
+    case summary[:summary_status]&.to_sym
+    when :active
+      return if summary[:nearest_expiration_at].blank?
 
-    t('admin.applications.secure_request_forms.summary.nearest_expiration',
-      time: l(summary.fetch(:nearest_expiration_at), format: :short))
+      t('admin.applications.secure_request_forms.summary.nearest_expiration',
+        time: secure_request_summary_date(summary.fetch(:nearest_expiration_at)))
+    when :expired
+      t('admin.applications.secure_request_forms.summary.expired')
+    when :revoked
+      t('admin.applications.secure_request_forms.summary.revoked')
+    end
   end
 
   def secure_request_masked_email(email)
@@ -132,6 +122,10 @@ module SecureRequestFormsHelper
   alias secure_request_revocation_event_detail secure_request_lifecycle_event_detail
 
   private
+
+  def secure_request_summary_date(time)
+    l(time.to_date, format: :month_day)
+  end
 
   def secure_request_notification_expires_text(metadata)
     expires_at = metadata['expires_at']

--- a/app/views/admin/applications/_applications_table.html.erb
+++ b/app/views/admin/applications/_applications_table.html.erb
@@ -134,17 +134,11 @@
               <div class="mt-2 rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-xs text-amber-900"
                    aria-label="<%= secure_request_summary_accessible_label(provider_info_summary) %>">
                 <div class="font-medium"><%= t('admin.applications.secure_request_forms.summary.label') %></div>
-                <% if provider_info_summary[:recipient_count].zero? %>
-                  <div class="text-amber-800"><%= t('admin.applications.secure_request_forms.summary.none') %></div>
-                <% else %>
-                  <div class="text-amber-800"><%= secure_request_summary_recipient_count(provider_info_summary) %></div>
-                  <div class="text-amber-800"><%= secure_request_summary_status_counts(provider_info_summary) %></div>
-                  <% if (sent_text = secure_request_summary_sent_text(provider_info_summary)) %>
-                    <div class="text-amber-800"><%= sent_text %></div>
-                  <% end %>
-                  <% if (expiration_text = secure_request_summary_expiration_text(provider_info_summary)) %>
-                    <div class="text-amber-800"><%= expiration_text %></div>
-                  <% end %>
+                <% if (sent_text = secure_request_summary_sent_text(provider_info_summary)) %>
+                  <div class="text-amber-800"><%= sent_text %></div>
+                <% end %>
+                <% if (expiration_text = secure_request_summary_expiration_text(provider_info_summary)) %>
+                  <div class="text-amber-800"><%= expiration_text %></div>
                 <% end %>
               </div>
             <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -304,6 +304,7 @@ en:
   date:
     formats:
       long: "%B %d, %Y"
+      month_day: "%B %-d"
   document_signing:
     medical_certification_request:
       submission_name: "Medical Certification - %{constituent_full_name} (Application %{application_id})"
@@ -400,14 +401,11 @@ en:
           no_actions: "No actions"
           empty: "No secure provider information requests have been sent."
         summary:
-          label: "Pending provider info"
-          none: "No secure request sent"
-          recipients:
-            one: "1 recipient"
-            other: "%{count} recipients"
-          status_counts: "%{active} active, %{submitted} submitted, %{expired} expired, %{revoked} revoked"
+          label: "Provider info requested"
           last_sent: "Sent %{time}"
           nearest_expiration: "Expires %{time}"
+          expired: "Expired"
+          revoked: "Revoked"
       secure_request_form_revocations:
         create:
           success: "Secure link revoked."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -193,14 +193,11 @@ es:
           no_actions: "Sin acciones"
           empty: "No se han enviado solicitudes seguras de información del proveedor."
         summary:
-          label: "Información del proveedor pendiente"
-          none: "No se ha enviado ninguna solicitud segura"
-          recipients:
-            one: "1 destinatario"
-            other: "%{count} destinatarios"
-          status_counts: "%{active} activos, %{submitted} enviados, %{expired} vencidos, %{revoked} revocados"
+          label: "Información del proveedor solicitada"
           last_sent: "Enviado %{time}"
           nearest_expiration: "Vence %{time}"
+          expired: "Vencido"
+          revoked: "Revocado"
       secure_request_form_revocations:
         create:
           success: "Enlace seguro revocado."
@@ -426,6 +423,7 @@ es:
   date:
     formats:
       long: "%d de %B de %Y"
+      month_day: "%-d de %B"
     month_names:
       - ~
       - enero

--- a/test/controllers/admin/applications_controller_test.rb
+++ b/test/controllers/admin/applications_controller_test.rb
@@ -30,29 +30,113 @@ module Admin
     end
 
     test 'index shows compact provider info request summary for pending applications' do
-      pending_application = create(:application, :with_residency_proof, :with_id_proof)
-      pending_application.update!(
-        residency_proof_status: :approved,
-        id_proof_status: :approved,
-        income_proof_required: false,
-        status: :awaiting_proof,
-        medical_provider_name: nil
-      )
-      batch_id = SecureRandom.uuid
-      create(:secure_request_form, application: pending_application, recipient: pending_application.user,
-                                   request_batch_id: batch_id)
-      create(:secure_request_form, :submitted, application: pending_application, recipient: create(:constituent),
-                                               request_batch_id: batch_id)
+      travel_to Time.zone.local(2026, 5, 22, 15, 43) do
+        pending_application = create_pending_provider_info_application
+        batch_id = SecureRandom.uuid
+        expires_at = 2.days.from_now
+        create(:secure_request_form, application: pending_application, recipient: pending_application.user,
+                                     request_batch_id: batch_id,
+                                     sent_at: Time.current,
+                                     expires_at: expires_at)
+        create(:secure_request_form, :submitted, application: pending_application, recipient: create(:constituent),
+                                                 request_batch_id: batch_id,
+                                                 sent_at: Time.current,
+                                                 expires_at: expires_at)
+
+        get admin_applications_path(filter: 'pending_provider_info')
+
+        assert_response :success
+        assert_select "tr#application_#{pending_application.id}" do
+          assert_select 'div', text: I18n.t('admin.applications.secure_request_forms.summary.label')
+          assert_select 'div', text: provider_info_summary_sent_text(Time.current)
+          assert_select 'div', text: provider_info_summary_expires_text(expires_at)
+          assert_select 'div', text: '2 recipients', count: 0
+          assert_select 'div', text: '1 active, 1 submitted, 0 expired, 0 revoked', count: 0
+        end
+      end
+    end
+
+    test 'index hides provider info request summary when no secure link was sent' do
+      pending_application = create_pending_provider_info_application
 
       get admin_applications_path(filter: 'pending_provider_info')
 
       assert_response :success
       assert_select "tr#application_#{pending_application.id}" do
-        assert_select 'div', text: I18n.t('admin.applications.secure_request_forms.summary.label')
-        assert_select 'div', text: I18n.t('admin.applications.secure_request_forms.summary.recipients', count: 2)
-        assert_select 'div',
-                      text: I18n.t('admin.applications.secure_request_forms.summary.status_counts',
-                                   active: 1, submitted: 1, expired: 0, revoked: 0)
+        assert_select 'span', text: 'Requested'
+        assert_select 'div', text: I18n.t('admin.applications.secure_request_forms.summary.label'), count: 0
+      end
+    end
+
+    test 'index shows recently expired provider info request summary' do
+      travel_to Time.zone.local(2026, 5, 22, 15, 43) do
+        pending_application = create_pending_provider_info_application
+        sent_at = provider_info_link_ttl_hours.hours.ago
+        create(:secure_request_form, application: pending_application, recipient: pending_application.user,
+                                     sent_at: sent_at,
+                                     expires_at: provider_info_recent_link_offset.ago)
+
+        get admin_applications_path(filter: 'pending_provider_info')
+
+        assert_response :success
+        assert_select "tr#application_#{pending_application.id}" do
+          assert_select 'div', text: I18n.t('admin.applications.secure_request_forms.summary.label')
+          assert_select 'div', text: provider_info_summary_sent_text(sent_at)
+          assert_select 'div', text: I18n.t('admin.applications.secure_request_forms.summary.expired')
+        end
+      end
+    end
+
+    test 'index hides stale expired provider info request summary' do
+      travel_to Time.zone.local(2026, 5, 22, 15, 43) do
+        pending_application = create_pending_provider_info_application
+        create(:secure_request_form, application: pending_application, recipient: pending_application.user,
+                                     sent_at: (provider_info_link_ttl_hours + 2).hours.ago,
+                                     expires_at: (provider_info_link_ttl_hours + 1).hours.ago)
+
+        get admin_applications_path(filter: 'pending_provider_info')
+
+        assert_response :success
+        assert_select "tr#application_#{pending_application.id}" do
+          assert_select 'span', text: 'Requested'
+          assert_select 'div', text: I18n.t('admin.applications.secure_request_forms.summary.label'), count: 0
+        end
+      end
+    end
+
+    test 'index shows recently revoked provider info request summary' do
+      travel_to Time.zone.local(2026, 5, 22, 15, 43) do
+        pending_application = create_pending_provider_info_application
+        sent_at = 2.hours.ago
+        create(:secure_request_form, :revoked, application: pending_application, recipient: pending_application.user,
+                                               sent_at: sent_at,
+                                               revoked_at: provider_info_recent_link_offset.ago)
+
+        get admin_applications_path(filter: 'pending_provider_info')
+
+        assert_response :success
+        assert_select "tr#application_#{pending_application.id}" do
+          assert_select 'div', text: I18n.t('admin.applications.secure_request_forms.summary.label')
+          assert_select 'div', text: provider_info_summary_sent_text(sent_at)
+          assert_select 'div', text: I18n.t('admin.applications.secure_request_forms.summary.revoked')
+        end
+      end
+    end
+
+    test 'index hides stale revoked provider info request summary' do
+      travel_to Time.zone.local(2026, 5, 22, 15, 43) do
+        pending_application = create_pending_provider_info_application
+        create(:secure_request_form, :revoked, application: pending_application, recipient: pending_application.user,
+                                               sent_at: (provider_info_link_ttl_hours + 2).hours.ago,
+                                               revoked_at: (provider_info_link_ttl_hours + 1).hours.ago)
+
+        get admin_applications_path(filter: 'pending_provider_info')
+
+        assert_response :success
+        assert_select "tr#application_#{pending_application.id}" do
+          assert_select 'span', text: 'Requested'
+          assert_select 'div', text: I18n.t('admin.applications.secure_request_forms.summary.label'), count: 0
+        end
       end
     end
 
@@ -334,8 +418,8 @@ module Admin
       RejectionReason.where(code: 'missing_name', proof_type: 'income', locale: 'en').destroy_all
       RejectionReason.where(code: 'missing_signature', proof_type: 'medical_certification', locale: 'en').destroy_all
 
-      income_reason = RejectionReason.create!(code: 'missing_name', proof_type: 'income', locale: 'en', body: income_body)
-      medical_reason = RejectionReason.create!(code: 'missing_signature', proof_type: 'medical_certification', locale: 'en', body: medical_body)
+      RejectionReason.create!(code: 'missing_name', proof_type: 'income', locale: 'en', body: income_body)
+      RejectionReason.create!(code: 'missing_signature', proof_type: 'medical_certification', locale: 'en', body: medical_body)
 
       get admin_application_path(@application)
       assert_response :success
@@ -566,6 +650,41 @@ module Admin
 
       assert_response :unprocessable_content
       assert_equal 'Unable to reject applications', response.parsed_body['error']
+    end
+
+    private
+
+    def create_pending_provider_info_application
+      create(:application, :with_residency_proof, :with_id_proof).tap do |application|
+        application.update!(
+          residency_proof_status: :approved,
+          id_proof_status: :approved,
+          income_proof_required: false,
+          status: :awaiting_proof,
+          medical_certification_status: :requested,
+          medical_provider_name: nil,
+          medical_provider_phone: nil,
+          medical_provider_email: nil
+        )
+      end
+    end
+
+    def provider_info_link_ttl_hours
+      Policy.get('secure_form_link_expiration_hours') || 48
+    end
+
+    def provider_info_recent_link_offset
+      (provider_info_link_ttl_hours / 2.0).hours
+    end
+
+    def provider_info_summary_sent_text(time)
+      I18n.t('admin.applications.secure_request_forms.summary.last_sent',
+             time: I18n.l(time.to_date, format: :month_day))
+    end
+
+    def provider_info_summary_expires_text(time)
+      I18n.t('admin.applications.secure_request_forms.summary.nearest_expiration',
+             time: I18n.l(time.to_date, format: :month_day))
     end
   end
 end

--- a/test/helpers/secure_request_forms_helper_test.rb
+++ b/test/helpers/secure_request_forms_helper_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SecureRequestFormsHelperTest < ActionView::TestCase
+  include SecureRequestFormsHelper
+
+  test 'summary copy uses date-only sent and expiration details' do
+    summary = {
+      summary_status: :active,
+      last_sent_at: Time.zone.local(2026, 5, 22, 15, 43),
+      nearest_expiration_at: Time.zone.local(2026, 5, 24, 15, 43)
+    }
+
+    assert_equal 'Sent May 22', secure_request_summary_sent_text(summary)
+    assert_equal 'Expires May 24', secure_request_summary_expiration_text(summary)
+    assert_equal 'Provider info requested. Sent May 22. Expires May 24.',
+                 secure_request_summary_accessible_label(summary)
+  end
+
+  test 'summary copy shows expired instead of an expired timestamp' do
+    summary = {
+      summary_status: :expired,
+      last_sent_at: Time.zone.local(2026, 5, 22, 15, 43),
+      nearest_expiration_at: Time.zone.local(2026, 5, 24, 15, 43)
+    }
+
+    assert_equal 'Expired', secure_request_summary_expiration_text(summary)
+    assert_equal 'Provider info requested. Sent May 22. Expired.',
+                 secure_request_summary_accessible_label(summary)
+  end
+
+  test 'summary copy shows revoked for recently revoked requests' do
+    summary = {
+      summary_status: :revoked,
+      last_sent_at: Time.zone.local(2026, 5, 22, 15, 43),
+      nearest_expiration_at: nil
+    }
+
+    assert_equal 'Revoked', secure_request_summary_expiration_text(summary)
+    assert_equal 'Provider info requested. Sent May 22. Revoked.',
+                 secure_request_summary_accessible_label(summary)
+  end
+
+  test 'summary copy omits expiration text when status is not visible' do
+    summary = {
+      summary_status: nil,
+      last_sent_at: Time.zone.local(2026, 5, 22, 15, 43),
+      nearest_expiration_at: nil
+    }
+
+    assert_nil secure_request_summary_expiration_text(summary)
+  end
+end


### PR DESCRIPTION
- Show only provider info requested, sent date, and current link state
- Hide summaries for never-sent/stale expired/revoked forms
- Remove recipient status count copy from the index summary
- Remove link summaries after expiration/revocation; tie to secure link TTL window so the summary reverts to normal cert badges after
- Add focused coverage for active, expired, revoked, and hidden states