### PR TITLE
Harden PII access controls

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -66,7 +66,8 @@ class NotificationsController < ApplicationController
   private
 
   def set_notification
-    @notification = Notification.find(params[:id])
+    scope = current_user.admin? ? Notification.all : current_user.received_notifications
+    @notification = scope.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     respond_to do |format|
       format.html do

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -19,13 +19,13 @@ class SessionsController < ApplicationController
     user = User.find_by_email(params[:email])
 
     if user&.account_locked?
-      @errors = { email: 'Invalid email or password' }
+      @errors = { email: invalid_credentials_message }
       return render_form_errors
     end
 
     unless user&.authenticate(params[:password])
       user&.record_failed_login!
-      @errors = { email: 'Invalid email or password' }
+      @errors = { email: invalid_credentials_message }
       return render_form_errors
     end
 
@@ -63,7 +63,7 @@ class SessionsController < ApplicationController
         render turbo_stream: turbo_stream.replace('sign_in_form', partial: 'sessions/form')
       end
       format.html do
-        redirect_to sign_in_path(email_hint: params[:email]), alert: 'Invalid email or password'
+        redirect_to sign_in_path(email_hint: params[:email]), alert: invalid_credentials_message
       end
     end
   end
@@ -72,7 +72,11 @@ class SessionsController < ApplicationController
     # Add user feedback for failed login attempts if User model supports it
     # user = User.find_by_email(params[:email])
     # user&.track_failed_attempt!(request.remote_ip) if user # Assuming track_failed_attempt! exists
-    redirect_to sign_in_path(email_hint: params[:email]), alert: 'Invalid email or password'
+    redirect_to sign_in_path(email_hint: params[:email]), alert: invalid_credentials_message
+  end
+
+  def invalid_credentials_message
+    t('controllers.sessions.invalid_credentials')
   end
 
   def setup_two_factor_session(user)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -18,7 +18,13 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by_email(params[:email])
 
+    if user&.account_locked?
+      @errors = { email: 'Invalid email or password' }
+      return render_form_errors
+    end
+
     unless user&.authenticate(params[:password])
+      user&.record_failed_login!
       @errors = { email: 'Invalid email or password' }
       return render_form_errors
     end

--- a/app/models/concerns/user_authentication.rb
+++ b/app/models/concerns/user_authentication.rb
@@ -38,6 +38,29 @@ module UserAuthentication
   end
 
   # Authentication methods
+  def account_locked?
+    return false if locked_at.blank?
+    return true if locked_at > LOCK_DURATION.ago
+
+    unlock_account!
+    false
+  end
+
+  def record_failed_login!
+    next_attempt_count = failed_attempts.to_i + 1
+
+    # Failed login counters are auth bookkeeping and should not be blocked by
+    # unrelated legacy profile validations.
+    # rubocop:disable Rails/SkipsModelValidations
+    update_columns(
+      failed_attempts: next_attempt_count,
+      updated_at: Time.current
+    )
+    # rubocop:enable Rails/SkipsModelValidations
+
+    lock_account! if next_attempt_count >= MAX_LOGIN_ATTEMPTS
+  end
+
   def track_sign_in!(ip)
     if failed_attempts.to_i >= MAX_LOGIN_ATTEMPTS
       lock_account!
@@ -60,6 +83,16 @@ module UserAuthentication
 
   def lock_account!
     update!(locked_at: Time.current)
+  end
+
+  def unlock_account!
+    # rubocop:disable Rails/SkipsModelValidations
+    update_columns(
+      failed_attempts: 0,
+      locked_at: nil,
+      updated_at: Time.current
+    )
+    # rubocop:enable Rails/SkipsModelValidations
   end
 
   # Password reset methods

--- a/app/services/applications/autosave_service.rb
+++ b/app/services/applications/autosave_service.rb
@@ -2,7 +2,8 @@
 
 module Applications
   class AutosaveService < BaseService
-    APPLICATION_AUTOSAVE_FIELDS = %w[
+    # Only these Application attributes may be assigned through autosave.
+    APPLICATION_AUTOSAVE_FIELD_ALLOWLIST = %w[
       annual_income
       household_size
       maryland_resident
@@ -167,7 +168,7 @@ module Applications
 
       if user_fields.include?(attribute_name)
         [:user, attribute_name]
-      elsif ignored_fields.include?(attribute_name) || APPLICATION_AUTOSAVE_FIELDS.exclude?(attribute_name)
+      elsif ignored_fields.include?(attribute_name) || APPLICATION_AUTOSAVE_FIELD_ALLOWLIST.exclude?(attribute_name)
         [:ignored, attribute_name]
       else
         [:application, attribute_name]

--- a/app/services/applications/autosave_service.rb
+++ b/app/services/applications/autosave_service.rb
@@ -2,6 +2,24 @@
 
 module Applications
   class AutosaveService < BaseService
+    APPLICATION_AUTOSAVE_FIELDS = %w[
+      annual_income
+      household_size
+      maryland_resident
+      self_certify_disability
+      terms_accepted
+      information_verified
+      medical_release_authorized
+      medical_provider_name
+      medical_provider_phone
+      medical_provider_fax
+      medical_provider_email
+      alternate_contact_name
+      alternate_contact_phone
+      alternate_contact_email
+      alternate_contact_relationship_type
+    ].freeze
+
     attr_reader :current_user, :params
 
     def initialize(current_user:, params:)
@@ -53,7 +71,8 @@ module Applications
     def find_or_create_draft_application
       # Determine if this is for a dependent based on params
       # Could come from multiple sources: user_id param or nested application[user_id]
-      dependent_id = params[:user_id].presence || params.dig(:application, :user_id).presence
+      dependent_id = authorized_dependent_id
+      return nil if dependent_id == :unauthorized
 
       # Build query to find existing draft
       # For dependent applications: match both user_id (the dependent) and managing_guardian_id (current user)
@@ -92,6 +111,17 @@ module Applications
           app.managing_guardian_id = current_user.id
         end
       end
+    end
+
+    def dependent_id_param
+      params[:user_id].presence || params.dig(:application, :user_id).presence
+    end
+
+    def authorized_dependent_id
+      dependent_id = dependent_id_param
+      return nil if dependent_id.blank?
+
+      current_user.dependents.exists?(id: dependent_id) ? dependent_id : :unauthorized
     end
 
     def apply_default_attributes(app)
@@ -137,7 +167,7 @@ module Applications
 
       if user_fields.include?(attribute_name)
         [:user, attribute_name]
-      elsif ignored_fields.include?(attribute_name)
+      elsif ignored_fields.include?(attribute_name) || APPLICATION_AUTOSAVE_FIELDS.exclude?(attribute_name)
         [:ignored, attribute_name]
       else
         [:application, attribute_name]

--- a/app/services/applications/autosave_service.rb
+++ b/app/services/applications/autosave_service.rb
@@ -2,46 +2,6 @@
 
 module Applications
   class AutosaveService < BaseService
-    USER_AUTOSAVE_FIELD_ALLOWLIST = %w[
-      hearing_disability
-      vision_disability
-      speech_disability
-      mobility_disability
-      cognition_disability
-    ].freeze
-
-    # These form fields can appear in autosave requests, but this service does
-    # not persist them because they are saved through user/profile or proof flows.
-    NON_AUTOSAVED_FORM_FIELDS = %w[
-      physical_address_1
-      physical_address_2
-      city
-      state
-      zip_code
-      residency_proof
-      income_proof
-    ].freeze
-
-    # Unlike NON_AUTOSAVED_FORM_FIELDS, this is a security allowlist: only these
-    # Application attributes may fall through to assign_attributes via autosave.
-    APPLICATION_AUTOSAVE_FIELD_ALLOWLIST = %w[
-      annual_income
-      household_size
-      maryland_resident
-      self_certify_disability
-      terms_accepted
-      information_verified
-      medical_release_authorized
-      medical_provider_name
-      medical_provider_phone
-      medical_provider_fax
-      medical_provider_email
-      alternate_contact_name
-      alternate_contact_phone
-      alternate_contact_email
-      alternate_contact_relationship_type
-    ].freeze
-
     attr_reader :current_user, :params
 
     def initialize(current_user:, params:)
@@ -155,14 +115,14 @@ module Applications
 
     def save_field
       attribute_name = extract_attribute_name
-      target_model, actual_attribute = determine_target_model_and_attribute(attribute_name)
+      target_model = autosave_target_for(attribute_name)
 
       result = if target_model == :user
-                 save_user_field(actual_attribute)
+                 save_user_field(attribute_name)
                elsif target_model == :ignored
                  { success: false, errors: { field_name => ['This field cannot be autosaved'] } }
                else
-                 save_application_field(actual_attribute)
+                 save_application_field(attribute_name)
                end
 
       result[:success] ? autosave_success_result : result
@@ -181,12 +141,20 @@ module Applications
       field_name
     end
 
-    def determine_target_model_and_attribute(attribute_name)
-      return [:user, attribute_name] if USER_AUTOSAVE_FIELD_ALLOWLIST.include?(attribute_name)
-      return [:ignored, attribute_name] if NON_AUTOSAVED_FORM_FIELDS.include?(attribute_name)
-      return [:ignored, attribute_name] unless APPLICATION_AUTOSAVE_FIELD_ALLOWLIST.include?(attribute_name)
+    def autosave_target_for(attribute_name)
+      user_fields = %w[hearing_disability vision_disability speech_disability
+                       mobility_disability cognition_disability]
+      application_fields = %w[annual_income household_size maryland_resident
+                              self_certify_disability terms_accepted information_verified
+                              medical_release_authorized medical_provider_name
+                              medical_provider_phone medical_provider_fax medical_provider_email
+                              alternate_contact_name alternate_contact_phone alternate_contact_email
+                              alternate_contact_relationship_type]
 
-      [:application, attribute_name]
+      return :user if user_fields.include?(attribute_name)
+      return :application if application_fields.include?(attribute_name)
+
+      :ignored
     end
 
     def save_user_field(attribute)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -603,6 +603,8 @@ en:
           failure: "Unable to revoke secure W9 upload link."
           not_active: "This secure W9 upload link is not active."
   controllers:
+    sessions:
+      invalid_credentials: "Invalid email or password"
     application:
       check_password_change_required:
         password_security_change: "For security reasons, you must change your password before continuing."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -655,6 +655,8 @@ es:
       body: "Este enlace seguro para cargar el W9 ya no está disponible. Comuníquese con el equipo de soporte de MAT si todavía necesita ayuda con esta solicitud."
       contact_info: "Envíe un correo electrónico a %{email} o llame al %{phone}."
   controllers:
+    sessions:
+      invalid_credentials: "Correo electrónico o contraseña inválidos"
     application:
       check_password_change_required:
         password_security_change: "Por razones de seguridad, debe cambiar su contraseña antes de continuar."

--- a/test/controllers/admin/applications_controller_test.rb
+++ b/test/controllers/admin/applications_controller_test.rb
@@ -34,6 +34,7 @@ module Admin
         :application,
         :with_residency_proof,
         :with_id_proof,
+        application_date: Time.current,
         user: create(:constituent, email: generate(:email))
       )
       application.update!(

--- a/test/controllers/constituent_portal/applications_controller_autosave_test.rb
+++ b/test/controllers/constituent_portal/applications_controller_autosave_test.rb
@@ -66,6 +66,46 @@ module ConstituentPortal
       assert_equal @user.id, new_application.user_id
     end
 
+    test 'should not create dependent draft for unrelated user id' do
+      @draft_application.destroy
+      unrelated_user = create(:constituent, :with_disabilities)
+
+      assert_no_difference('Application.count') do
+        patch autosave_field_constituent_portal_applications_path,
+              params: {
+                user_id: unrelated_user.id,
+                field_name: 'application[household_size]',
+                field_value: '3'
+              },
+              as: :json
+      end
+
+      assert_response :unprocessable_content
+      assert_not response.parsed_body['success']
+      assert_nil Application.find_by(user_id: unrelated_user.id, managing_guardian_id: @user.id)
+    end
+
+    test 'should create dependent draft only for existing dependent relationship' do
+      @draft_application.destroy
+      dependent = create(:constituent, :with_disabilities)
+      create(:guardian_relationship, guardian_user: @user, dependent_user: dependent, relationship_type: 'Parent')
+
+      assert_difference('Application.count') do
+        patch autosave_field_constituent_portal_applications_path,
+              params: {
+                user_id: dependent.id,
+                field_name: 'application[household_size]',
+                field_value: '3'
+              },
+              as: :json
+      end
+
+      assert_response :success
+      new_application = Application.find(response.parsed_body['applicationId'])
+      assert_equal dependent.id, new_application.user_id
+      assert_equal @user.id, new_application.managing_guardian_id
+    end
+
     test 'should log application_created when autosave creates a new draft' do
       @draft_application.destroy
 
@@ -166,22 +206,30 @@ module ConstituentPortal
       assert_equal true, @user.hearing_disability
     end
 
-    test 'should autosave application as managing guardian' do
-      # Create a dependent user first
-      create(:constituent, :with_disabilities)
-
-      # Test updating the application to be managed by current user
+    test 'should not autosave managing guardian directly' do
       patch autosave_field_constituent_portal_application_path(@draft_application),
             params: { field_name: 'application[managing_guardian_id]', field_value: @user.id.to_s },
             as: :json
 
-      # Verify the response
-      assert_response :success
-      assert_json_response(success: true)
+      assert_response :unprocessable_content
+      assert_not response.parsed_body['success']
 
-      # Verify the application was updated
       @draft_application.reload
-      assert_equal @user.id, @draft_application.managing_guardian_id
+      assert_nil @draft_application.managing_guardian_id
+    end
+
+    test 'should not autosave applicant user directly' do
+      unrelated_user = create(:constituent, :with_disabilities)
+
+      patch autosave_field_constituent_portal_application_path(@draft_application),
+            params: { field_name: 'application[user_id]', field_value: unrelated_user.id.to_s },
+            as: :json
+
+      assert_response :unprocessable_content
+      assert_not response.parsed_body['success']
+
+      @draft_application.reload
+      assert_equal @user.id, @draft_application.user_id
     end
 
     test 'should create guardian relationship when setting up dependent application' do

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class NotificationsControllerTest < ActionDispatch::IntegrationTest
+  include AuthenticationTestHelper
+
+  setup do
+    @user = create(:constituent)
+    @other_user = create(:constituent)
+    @notification = create(:notification, recipient: @user)
+    @other_notification = create(:notification, recipient: @other_user)
+  end
+
+  test 'user can mark their own notification as read' do
+    sign_in_for_integration_test(@user)
+
+    post mark_as_read_notification_path(@notification)
+
+    assert_redirected_to notifications_path
+    assert_not_nil @notification.reload.read_at
+  end
+
+  test 'user cannot mark another users notification as read' do
+    sign_in_for_integration_test(@user)
+
+    post mark_as_read_notification_path(@other_notification)
+
+    assert_redirected_to root_path
+    assert_nil @other_notification.reload.read_at
+  end
+
+  test 'user cannot check another users email status' do
+    sign_in_for_integration_test(@user)
+    @other_notification.update!(message_id: 'postmark-message-id')
+
+    assert_no_enqueued_jobs only: UpdateEmailStatusJob do
+      post check_email_status_notification_path(@other_notification)
+    end
+
+    assert_redirected_to root_path
+  end
+
+  test 'admin can act on any notification' do
+    admin = create(:admin)
+    sign_in_for_integration_test(admin)
+
+    post mark_as_read_notification_path(@other_notification)
+
+    assert_redirected_to notifications_path
+    assert_not_nil @other_notification.reload.read_at
+  end
+end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -29,6 +29,37 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_match 'Invalid email or password', flash[:alert]
   end
 
+  def test_failed_login_increments_failed_attempts
+    user = create(:constituent)
+
+    assert_difference -> { user.reload.failed_attempts.to_i }, 1 do
+      post sign_in_path, params: { email: user.email, password: 'wrongpassword' }
+    end
+
+    assert_redirected_to sign_in_path(email_hint: user.email)
+  end
+
+  def test_repeated_failed_logins_lock_account
+    user = create(:constituent)
+
+    UserAuthentication::MAX_LOGIN_ATTEMPTS.times do
+      post sign_in_path, params: { email: user.email, password: 'wrongpassword' }
+    end
+
+    assert user.reload.account_locked?
+    assert_not_nil user.locked_at
+  end
+
+  def test_locked_account_cannot_sign_in_with_valid_password
+    user = create(:constituent, failed_attempts: UserAuthentication::MAX_LOGIN_ATTEMPTS, locked_at: Time.current)
+
+    assert_no_difference('Session.count') do
+      post sign_in_path, params: { email: user.email, password: 'password123' }
+    end
+
+    assert_redirected_to sign_in_path(email_hint: user.email)
+  end
+
   def test_should_sign_in_constituent_without_mfa
     user = create(:constituent)
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -26,7 +26,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     }
     assert_redirected_to sign_in_path(email_hint: @admin.email)
     follow_redirect!
-    assert_match 'Invalid email or password', flash[:alert]
+    assert_match I18n.t('controllers.sessions.invalid_credentials'), flash[:alert]
   end
 
   def test_failed_login_increments_failed_attempts

--- a/test/services/applications/reporting_service_test.rb
+++ b/test/services/applications/reporting_service_test.rb
@@ -572,6 +572,8 @@ module Applications
 
     test 'generate_mfr_reports_data counts approved transitions on June 30 and excludes July 1' do
       travel_to Time.zone.local(2026, 8, 1, 12, 0, 0) do
+        baseline = ReportingService.new.generate_mfr_reports_data
+                                   .data[:most_recent_fy][:summary]['Status changed to approved during FY']
         admin = create(:admin)
         jun30 = Time.zone.local(2026, 6, 30, 23, 59, 59)
         jul1 = Time.zone.local(2026, 7, 1, 0, 0, 0)
@@ -589,12 +591,16 @@ module Applications
                                .update!(changed_at: jul1)
 
         most_recent = ReportingService.new.generate_mfr_reports_data.data[:most_recent_fy]
-        assert_equal 1, most_recent[:summary]['Status changed to approved during FY']
+        assert_equal baseline + 1, most_recent[:summary]['Status changed to approved during FY']
       end
     end
 
     test 'generate_mfr_reports_data excludes cert and proof status-change rows from approved throughput' do
       travel_to Date.new(2026, 8, 1) do
+        report_baseline = ReportingService.new.generate_mfr_reports_data
+                                          .data[:most_recent_fy][:summary]['Status changed to approved during FY']
+        dashboard_baseline = ReportingService.new.generate_dashboard_data
+                                             .data[:mfr_applications_approved]
         admin = create(:admin)
         in_fy = Time.zone.local(2025, 10, 1, 12, 0, 0)
 
@@ -632,11 +638,11 @@ module Applications
         )
 
         most_recent = ReportingService.new.generate_mfr_reports_data.data[:most_recent_fy]
-        assert_equal 1, most_recent[:summary]['Status changed to approved during FY']
+        assert_equal report_baseline + 1, most_recent[:summary]['Status changed to approved during FY']
 
         dashboard = ReportingService.new.generate_dashboard_data
         assert dashboard.success?
-        assert_equal 1, dashboard.data[:mfr_applications_approved]
+        assert_equal dashboard_baseline + 1, dashboard.data[:mfr_applications_approved]
         assert_equal dashboard.data[:mfr_applications_approved],
                      dashboard.data[:mfr_chart_data][:current]['Approved (status changed during FY)']
       end
@@ -670,6 +676,8 @@ module Applications
 
     test 'generate_mfr_reports_data uses lifecycle changed_at not created_at approval' do
       travel_to Date.new(2026, 8, 1) do
+        baseline = ReportingService.new.generate_mfr_reports_data
+                                   .data[:most_recent_fy][:summary]
         admin = create(:admin)
         in_fy = Date.new(2025, 8, 1)
 
@@ -686,8 +694,10 @@ module Applications
         assert result.success?
 
         most_recent = result.data[:most_recent_fy]
-        assert_equal 1, most_recent[:summary]['Draft to in progress during FY']
-        assert_equal 1, most_recent[:summary]['Status changed to approved during FY']
+        assert_equal baseline['Draft to in progress during FY'] + 1,
+                     most_recent[:summary]['Draft to in progress during FY']
+        assert_equal baseline['Status changed to approved during FY'] + 1,
+                     most_recent[:summary]['Status changed to approved during FY']
         assert_equal most_recent[:chart_data]['Approved (status changed during FY)'],
                      most_recent[:summary]['Status changed to approved during FY']
       end


### PR DESCRIPTION
- Block dependent draft creation forgery by requiring a real guardian/dependent relationship before autosave can use a dependent user_id\
- Prevent autosave from directly changing sensitive ownership fields like user_id and managing_guardian_id
- Fix login controls so failed login attempts increment and lock out after too many tries within a certain time period