### PR TITLE
Small cleanups for disability certification

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -139,7 +139,7 @@ class Application < ApplicationRecord
   validates :maryland_resident, inclusion: { in: [true], message: 'You must be a Maryland resident to apply' }, unless: :status_draft?
   validates :terms_accepted, acceptance: { accept: true }, if: :submitted?
   validates :information_verified, acceptance: { accept: true }, if: :submitted?
-  validates :medical_release_authorized, acceptance: { accept: true }, if: :submitted?
+  validates :medical_release_authorized, acceptance: { accept: true }, if: -> { submitted? && !skip_medical_provider_validation? }
   validates :medical_provider_name, presence: true, unless: :skip_medical_provider_validation?
   validates :medical_provider_phone, presence: true, unless: :skip_medical_provider_validation?
   validates :medical_provider_email, presence: true, unless: :skip_medical_provider_validation?

--- a/app/views/admin/paper_applications/new.html.erb
+++ b/app/views/admin/paper_applications/new.html.erb
@@ -517,7 +517,7 @@
                       "aria-required": "true",
                       "aria-describedby": "self_certify_hint" %>
                   <label for="applicant_attributes_self_certify_disability" class="ml-3">
-                    <span class="block text-sm font-medium text-gray-700">The applicant certifies that they have a disability that affects their ability to access telecommunications services</span>
+                    <span class="block text-sm font-medium text-gray-700 required-label">The applicant certifies that they have a disability that affects their ability to access telecommunications services</span>
                     <span id="self_certify_hint" class="block text-xs text-gray-500 mt-1">Required for program eligibility</span>
                   </label>
                 </div>
@@ -637,7 +637,7 @@
 
                 <%# Upload Field %>
                 <div id="medical_certification_upload" class="mb-4" data-document-proof-handler-target="uploadSection">
-                  <label for="medical_certification" class="block text-sm font-medium text-gray-700 mb-1 required-label">Upload Medical Certification</label>
+                  <label for="medical_certification" class="block text-sm font-medium text-gray-700 mb-1 required-label">Upload Disability Certification</label>
                   <input type="file"
                          name="medical_certification"
                          id="medical_certification"


### PR DESCRIPTION
Medical release authorization was being hidden but still required, creating an error.
Changes Medical to disability on the front-end.