### PR TITLE
Consolidate proof rejection delivery ownership

### DIFF
--- a/app/models/proof_review.rb
+++ b/app/models/proof_review.rb
@@ -51,8 +51,6 @@ class ProofReview < ApplicationRecord
     end
 
     log_rejection_audit_event
-    return if Current.paper_context
-
     issue_proof_resubmission_form
   end
 
@@ -145,11 +143,6 @@ class ProofReview < ApplicationRecord
     # Skip if associations aren't loaded properly
     return unless application&.user.present? && admin.present?
 
-    if Current.paper_context
-      log_rejection_audit_event if status_rejected?
-      return
-    end
-
     status_rejected? ? request_proof_resubmission : send_approval_notification
   end
 
@@ -175,7 +168,12 @@ class ProofReview < ApplicationRecord
       action: 'proof_rejected',
       actor: admin,
       auditable: application,
-      metadata: { proof_type: proof_type, rejection_reason: rejection_reason }
+      metadata: {
+        proof_type: proof_type,
+        rejection_reason: rejection_reason,
+        submission_method: submission_method,
+        rejection_reason_code: rejection_reason_code
+      }.compact
     )
   end
 

--- a/app/services/applications/paper_application_service.rb
+++ b/app/services/applications/paper_application_service.rb
@@ -3,6 +3,7 @@
 module Applications
   # This service handles paper application submissions by administrators
   # It follows the same patterns as ConstituentPortal for file uploads
+  # rubocop:disable Metrics/ClassLength
   class PaperApplicationService < BaseService
     include Rails.application.routes.url_helpers
 
@@ -100,6 +101,7 @@ module Applications
 
     def handle_successful_application(operation = :create)
       send_notifications
+      append_proof_resubmission_delivery_warnings
       case operation
       when :create
         log_application_creation
@@ -284,7 +286,7 @@ module Applications
 
     def process_self_applicant(applicant_data)
       # Handle no email address scenario
-      no_email = params[:no_email_address].present? && params[:no_email_address] == "1"
+      no_email = params[:no_email_address].present? && params[:no_email_address] == '1'
       if no_email
         applicant_data = applicant_data.dup
         applicant_data.delete(:email)
@@ -750,7 +752,7 @@ module Applications
     end
 
     def send_notifications
-      send_proof_rejection_notifications
+      send_medical_certification_not_provided_notice
       send_account_creation_notifications
     end
 
@@ -780,35 +782,29 @@ module Applications
       ].compact.join(' ')
     end
 
-    def send_proof_rejection_notifications
-      @application.proof_reviews.reload.each do |review|
-        next unless review.status_rejected?
+    # Income/residency/id proof rejections are delivered through ProofReview ->
+    # Applications::RequestProofResubmission, which owns the secure resubmission flow.
+    # The only constituent-facing rejection notice still sent directly from paper intake
+    # is the "medical certification not provided" notice, which has no resubmission form.
+    def send_medical_certification_not_provided_notice
+      not_provided = @application.proof_reviews.reload.rejections.find_by(
+        proof_type: :medical_certification,
+        rejection_reason_code: 'none_provided'
+      )
+      return unless not_provided
 
-        if review.proof_type == 'medical_certification' && review.rejection_reason_code == 'none_provided'
-          NotificationService.create_and_deliver!(
-            type: 'medical_certification_not_provided',
-            recipient: @constituent,
-            actor: @admin,
-            notifiable: @application,
-            channel: @constituent.communication_preference.to_sym
-          )
-          next
-        end
-
-        NotificationService.create_and_deliver!(
-          type: 'proof_rejected',
-          recipient: @constituent,
-          actor: @admin,
-          notifiable: review,
-          metadata: {
-            template_variables: proof_rejection_template_variables(review)
-          },
-          channel: @constituent.communication_preference.to_sym
-        )
-      end
+      NotificationService.create_and_deliver!(
+        type: 'medical_certification_not_provided',
+        recipient: @constituent,
+        actor: @admin,
+        notifiable: @application,
+        channel: @constituent.communication_preference.to_sym
+      )
     end
 
     def send_account_creation_notifications
+      return unless send_account_created_notice?
+
       new_user_accounts.each do |user|
         temp_password = @temp_passwords[user.id]
         next unless temp_password
@@ -825,6 +821,26 @@ module Applications
           },
           channel: user.communication_preference.to_sym
         )
+      end
+    end
+
+    # Account-created notices (and their printed letters) are voucher-only.
+    # Equipment-scope applicants and cert signers should use secure temporary
+    # form links for proof/cert uploads; announcing an account they cannot create
+    # or log in to would be misleading.
+    def send_account_created_notice?
+      FeatureFlag.enabled?(:vouchers_enabled)
+    end
+
+    def append_proof_resubmission_delivery_warnings
+      @application.proof_reviews.rejections
+                  .where(proof_type: ProofReview::REVIEWABLE_PROOF_TYPES)
+                  .find_each do |review|
+        next if Applications::RequestProofResubmission.delivery_confirmed_for_review?(review)
+
+        note = "#{review.proof_type.to_s.humanize} proof resubmission form could not be automatically sent. " \
+               'You can send it from the application page.'
+        @reconciliation_note = [@reconciliation_note, note].compact.join(' ')
       end
     end
 
@@ -848,15 +864,6 @@ module Applications
       }
     end
 
-    def proof_rejection_template_variables(review)
-      {
-        constituent_full_name: @constituent.full_name,
-        organization_name: Policy.get('organization_name') || 'MAT Program',
-        proof_type_formatted: review.proof_type.humanize,
-        rejection_reason: review.rejection_reason || 'Document did not meet requirements'
-      }
-    end
-
     def attributes_present?(attrs)
       attrs.present? && attrs.values.any?(&:present?)
     end
@@ -871,4 +878,5 @@ module Applications
       Rails.logger.error exception.backtrace.join("\n") if exception.backtrace
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/services/applications/request_proof_resubmission.rb
+++ b/app/services/applications/request_proof_resubmission.rb
@@ -31,6 +31,18 @@ module Applications
     end
     # rubocop:enable Metrics/ParameterLists
 
+    def self.delivery_confirmed_for_review?(proof_review)
+      proof_type = proof_review.proof_type.to_sym
+      return false unless PROOF_KIND_BY_TYPE.key?(proof_type)
+
+      # Only count still-usable forms. Failed deliveries revoke the request record even
+      # though the row remains for audit; those must not suppress admin warnings.
+      SecureRequestForm.public_send("#{proof_type}_proof")
+                       .active
+                       .where(application_id: proof_review.application_id)
+                       .exists?(created_at: proof_review.created_at..)
+    end
+
     def call
       return failure(message(:invalid_proof_type)) unless proof_kind
       return failure(message(:request_not_needed)) unless requestable_proof_state?

--- a/app/services/applications/secure_request_recipient_resolver.rb
+++ b/app/services/applications/secure_request_recipient_resolver.rb
@@ -226,24 +226,27 @@ module Applications
     end
 
     def preferred_secure_request_delivery_channel(recipient, email:, phone:)
-      return :email if letter_to_email_override_allowed?(recipient, email)
+      override_channel = channel_from_override(recipient, email: email, phone: phone)
+      return override_channel if override_channel.present?
 
-      phone_type = phone_type_for(recipient)
-      preferred_channel = channel_for_phone_type(phone_type, email: email, phone: phone)
-      return preferred_channel if preferred_channel.present?
       return :letter if recipient_letter_preferred?(recipient) && mailing_address_present?(recipient)
       return :email if email.present?
 
       nil
     end
 
-    def letter_to_email_override_allowed?(recipient, email)
-      channel_overrides[recipient.id] == 'email' && email.present? && recipient_letter_preferred?(recipient)
-    end
+    def channel_from_override(recipient, email:, phone:)
+      override = channel_overrides[recipient.id]
+      return if override.blank?
 
-    def channel_for_phone_type(phone_type, email:, phone:)
-      return :sms if phone_type == 'text' && phone.present?
-      return :email if phone_type == 'email' && email.present?
+      case override
+      when 'email'
+        return :email if email.present?
+      when 'sms'
+        return :sms if phone.present?
+      when 'letter'
+        return :letter if mailing_address_present?(recipient)
+      end
 
       nil
     end
@@ -259,16 +262,6 @@ module Applications
         end
 
       preference.to_s == 'letter'
-    end
-
-    def phone_type_for(recipient)
-      if recipient.id == application.user_id && dependent_application?
-        application_contact_guardian&.phone_type || recipient.phone_type
-      elsif recipient.respond_to?(:effective_phone_type)
-        recipient.effective_phone_type
-      elsif recipient.respond_to?(:phone_type)
-        recipient.phone_type
-      end.to_s
     end
 
     def mailing_address_present?(recipient)

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 class NotificationService
   VALID_CHANNELS = %i[email letter].freeze
 
@@ -163,6 +164,26 @@ class NotificationService
     medical_certification_approved
   ].freeze
 
+  # Reviewable proof rejections must deliver through Applications::RequestProofResubmission.
+  # These notification actions are legacy/mailer-test only; pass metadata: { delivery_path: 'legacy' }
+  # to create and deliver through NotificationService intentionally.
+  ORPHAN_PROOF_REJECTION_DELIVERY_ACTIONS = %w[
+    proof_rejected
+    id_proof_rejected
+    income_proof_rejected
+    residency_proof_rejected
+  ].freeze
+
+  def self.reviewable_proof_rejection_action?(action)
+    ORPHAN_PROOF_REJECTION_DELIVERY_ACTIONS.include?(action.to_s)
+  end
+
+  def self.reviewable_proof_rejection_notification_blocked?(opts)
+    return false unless reviewable_proof_rejection_action?(notification_type_from(opts))
+
+    !legacy_proof_rejection_delivery_metadata?(opts_metadata_from(opts))
+  end
+
   PREFERENCE_ROUTED_ACTIONS = %w[
     proof_rejected
     id_proof_rejected
@@ -193,6 +214,15 @@ class NotificationService
     channel = opts['channel']
 
     log_notification_creation_info(opts, channel)
+
+    if self.class.reviewable_proof_rejection_notification_blocked?(opts)
+      Rails.logger.error(
+        "NotificationService: Refused to create '#{opts[:type] || opts['type']}' notification. " \
+        'Use Applications::RequestProofResubmission for reviewable proof rejection delivery, ' \
+        "or metadata: { delivery_path: 'legacy' } for intentional mailer-only paths."
+      )
+      return nil
+    end
 
     notification = create_notification_with_rescue(opts)
     return nil unless notification
@@ -362,6 +392,19 @@ class NotificationService
       Rails.logger.info "NotificationService: No email for '#{notification.action}' (audit-only action) — Notification ##{notification.id}"
       persist_delivery_routing_metadata(notification, actual_delivery_channel: 'none', delivery_route_reason: 'no_email_action')
       return true
+    end
+
+    if orphan_proof_rejection_delivery_blocked?(notification)
+      Rails.logger.error(
+        "NotificationService: Blocked orphan proof-rejection delivery for '#{notification.action}' " \
+        "(Notification ##{notification.id}). Use Applications::RequestProofResubmission instead."
+      )
+      persist_delivery_routing_metadata(
+        notification,
+        actual_delivery_channel: 'none',
+        delivery_route_reason: 'use_request_proof_resubmission'
+      )
+      return false
     end
 
     enforce_delivery_contracts!(notification)
@@ -550,6 +593,29 @@ class NotificationService
     Rails.logger.warn "NotificationService: Failed to find proof review for #{action} notification: #{e.message}"
     nil
   end
+
+  def orphan_proof_rejection_delivery_blocked?(notification)
+    self.class.reviewable_proof_rejection_notification_blocked?(
+      'type' => notification.action,
+      'metadata' => notification.metadata
+    )
+  end
+
+  def self.notification_type_from(opts)
+    (opts[:type] || opts['type']).to_s
+  end
+  private_class_method :notification_type_from
+
+  def self.opts_metadata_from(opts)
+    metadata = opts[:metadata] || opts['metadata'] || {}
+    metadata.is_a?(Hash) ? metadata.stringify_keys : {}
+  end
+  private_class_method :opts_metadata_from
+
+  def self.legacy_proof_rejection_delivery_metadata?(metadata)
+    metadata['delivery_path'] == 'legacy'
+  end
+  private_class_method :legacy_proof_rejection_delivery_metadata?
 
   def resolve_mailer(notification)
     if (entry = MAILER_MAP[notification.action])
@@ -806,3 +872,4 @@ class NotificationService
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/services/proof_attachment_service.rb
+++ b/app/services/proof_attachment_service.rb
@@ -95,15 +95,13 @@ class ProofAttachmentService
     }
 
     with_service_flow(context) do |result|
-      success = perform_rejection(application: application, proof_type: proof_type, admin: admin,
-                                  submission_method: submission_method, rejection_details: rejection_details)
-
-      if success
-        log_rejection_events(application: application, proof_type: proof_type, admin: admin,
-                             submission_method: submission_method, rejection_details: rejection_details)
-      end
-
-      result[:success] = success
+      # perform_rejection creates the ProofReview, which is the canonical owner of the
+      # rejection audit event (generic `proof_rejected`) and of constituent-facing
+      # resubmission delivery via Applications::RequestProofResubmission. We intentionally
+      # do not emit a typed `#{proof_type}_proof_rejected` event or notification here to
+      # avoid duplicate audit rows and duplicate delivery.
+      result[:success] = perform_rejection(application: application, proof_type: proof_type, admin: admin,
+                                           submission_method: submission_method, rejection_details: rejection_details)
     end
   end
 
@@ -484,36 +482,6 @@ class ProofAttachmentService
           submission_method: submission_method
         )
       end
-    end
-
-    def log_rejection_events(application:, proof_type:, admin:, submission_method:, rejection_details:)
-      reason = rejection_details.fetch(:reason, 'other')
-      metadata = rejection_details.fetch(:metadata, {})
-      audit_metadata = metadata.merge(
-        proof_type: proof_type,
-        submission_method: submission_method,
-        status: :rejected,
-        has_attachment: false,
-        rejection_reason: reason
-      )
-
-      AuditEventService.log(
-        action: "#{proof_type}_proof_rejected",
-        auditable: application,
-        actor: admin,
-        metadata: audit_metadata
-      )
-
-      # Skip notifications if this is a paper application context as PaperApplicationService handles notifications
-      return if Current.paper_context
-
-      NotificationService.create_and_deliver!(
-        type: "#{proof_type}_proof_rejected",
-        recipient: application.user,
-        actor: admin,
-        notifiable: application,
-        metadata: audit_metadata
-      )
     end
 
     def prepare_flow_data(params)

--- a/test/controllers/admin/secure_request_forms_test.rb
+++ b/test/controllers/admin/secure_request_forms_test.rb
@@ -4,6 +4,8 @@ require 'test_helper'
 
 module Admin
   class SecureRequestFormsTest < ActionDispatch::IntegrationTest
+    include ProofResubmissionTestHelper
+
     setup do
       @admin = create(:admin)
       sign_in_for_integration_test(@admin)
@@ -247,7 +249,7 @@ module Admin
 
     test 'show page offers secure proof upload link for rejected unattached income proof' do
       application = create(:application, :in_progress, income_proof_status: :rejected)
-      create_rejected_proof_review_without_auto_request(application: application, proof_type: :income, reason: 'Missing income details')
+      create_rejected_proof_review_without_auto_resubmission(application: application, admin: @admin, proof_type: :income, rejection_reason: 'Missing income details')
       application.income_proof.purge if application.income_proof.attached?
 
       get admin_application_path(application)
@@ -259,7 +261,7 @@ module Admin
 
     test 'show page offers secure proof upload link for rejected attached income proof' do
       application = create(:application, :in_progress, :with_income_proof, income_proof_status: :rejected)
-      create_rejected_proof_review_without_auto_request(application: application, proof_type: :income, reason: 'Missing income details')
+      create_rejected_proof_review_without_auto_resubmission(application: application, admin: @admin, proof_type: :income, rejection_reason: 'Missing income details')
 
       get admin_application_path(application)
 
@@ -270,7 +272,7 @@ module Admin
 
     test 'show page offers secure proof upload link for rejected unattached residency proof' do
       application = create(:application, :in_progress, residency_proof_status: :rejected)
-      create_rejected_proof_review_without_auto_request(application: application, proof_type: :residency, reason: 'Missing residency details')
+      create_rejected_proof_review_without_auto_resubmission(application: application, admin: @admin, proof_type: :residency, rejection_reason: 'Missing residency details')
       application.residency_proof.purge if application.residency_proof.attached?
 
       get admin_application_path(application)
@@ -629,22 +631,6 @@ module Admin
       assert_predicate target_form.reload, :status_revoked?
       assert_not_predicate sibling_form.reload, :status_revoked?,
                            'Revoking one recipient link must not revoke sibling links in the same batch'
-    end
-
-    private
-
-    def create_rejected_proof_review_without_auto_request(application:, proof_type:, reason:)
-      original_paper_context = Current.paper_context
-      Current.paper_context = true
-
-      create(:proof_review,
-             application: application,
-             admin: @admin,
-             proof_type: proof_type,
-             status: :rejected,
-             rejection_reason: reason)
-    ensure
-      Current.paper_context = original_paper_context
     end
   end
 end

--- a/test/models/proof_review_test.rb
+++ b/test/models/proof_review_test.rb
@@ -3,6 +3,8 @@
 require 'test_helper'
 
 class ProofReviewTest < ActiveSupport::TestCase
+  include ProofRejectionNotificationAssertions
+
   def setup
     @admin = create(:admin)
     # Create a simple application without using problematic traits
@@ -176,19 +178,27 @@ class ProofReviewTest < ActiveSupport::TestCase
            status: :approved)
   end
 
-  def test_paper_rejection_does_not_request_secure_proof_resubmission
-    Applications::RequestProofResubmission.expects(:new).never
+  def test_paper_rejection_requests_secure_proof_resubmission_and_queues_letter
+    @application.user.update!(communication_preference: :letter, phone_type: :voice)
+    @application.update!(income_proof_status: :rejected)
+    @application.income_proof.purge if @application.income_proof.attached?
+    NotificationService.stubs(:create_and_deliver!).returns(true)
+    assert_no_orphan_proof_rejection_notification_delivery
 
     Current.paper_context = true
 
-    assert_difference -> { Event.where(action: 'proof_rejected', auditable: @application).count }, 1 do
-      create(:proof_review,
-             application: @application,
-             admin: @admin,
-             proof_type: :income,
-             status: :rejected,
-             rejection_reason: 'Invalid documentation',
-             submission_method: :paper)
+    assert_difference -> { SecureRequestForm.count }, 1 do
+      assert_difference -> { PrintQueueItem.where(letter_type: :income_proof_rejected).count }, 1 do
+        assert_difference -> { Event.where(action: 'proof_rejected', auditable: @application).count }, 1 do
+          create(:proof_review,
+                 application: @application,
+                 admin: @admin,
+                 proof_type: :income,
+                 status: :rejected,
+                 rejection_reason: 'Invalid documentation',
+                 submission_method: :paper)
+        end
+      end
     end
   ensure
     Current.reset

--- a/test/services/applications/paper_application_service_test.rb
+++ b/test/services/applications/paper_application_service_test.rb
@@ -578,5 +578,110 @@ module Applications
       assert_equal 'letter', dependent.communication_preference
       assert_equal 'asl', dependent.preferred_means_of_communication
     end
+
+    test 'paper application suppresses account_created notice when vouchers are disabled' do
+      service_params = {
+        constituent: @constituent_params.merge(email: generate(:email), phone: unique_paper_phone),
+        application: @application_params,
+        income_proof_action: 'accept',
+        income_proof: uploaded_pdf
+      }
+
+      ProofAttachmentService.stubs(:attach_proof).returns({ success: true })
+      NotificationService.stubs(:create_and_deliver!).returns(true)
+      NotificationService.expects(:create_and_deliver!).with(has_entry(type: 'account_created')).never
+
+      service = PaperApplicationService.new(params: service_params, admin: @admin)
+      assert service.create, "Service creation failed: #{service.errors.inspect}"
+      assert_predicate service.application, :fulfillment_type_equipment?
+    end
+
+    test 'paper application sends account_created notice when vouchers are enabled' do
+      FeatureFlag.enable!(:vouchers_enabled)
+
+      service_params = {
+        constituent: @constituent_params.merge(email: generate(:email), phone: unique_paper_phone),
+        application: @application_params,
+        income_proof_action: 'accept',
+        income_proof: uploaded_pdf
+      }
+
+      ProofAttachmentService.stubs(:attach_proof).returns({ success: true })
+      NotificationService.stubs(:create_and_deliver!).returns(true)
+      NotificationService.expects(:create_and_deliver!).with(has_entry(type: 'account_created')).at_least_once
+
+      service = PaperApplicationService.new(params: service_params, admin: @admin)
+      assert service.create, "Service creation failed: #{service.errors.inspect}"
+      assert_predicate service.application, :fulfillment_type_voucher?
+    ensure
+      FeatureFlag.disable!(:vouchers_enabled)
+    end
+
+    test 'voucher fulfillment does not send account_created notice when vouchers are disabled' do
+      application = build(:application, fulfillment_type: :voucher)
+      service = PaperApplicationService.new(params: {}, admin: @admin)
+      service.instance_variable_set(:@application, application)
+
+      FeatureFlag.disable!(:vouchers_enabled)
+
+      assert_not service.send(:send_account_created_notice?)
+    end
+
+    test 'medical certification not provided notice notifies constituent for none_provided review' do
+      constituent = create(:constituent, communication_preference: :email)
+      application = create(:application, :in_progress, skip_proofs: true, user: constituent)
+      %i[income residency].each do |proof_type|
+        application.public_send("#{proof_type}_proof").attach(
+          io: StringIO.new("#{proof_type} proof"),
+          filename: "#{proof_type}.pdf",
+          content_type: 'application/pdf'
+        )
+      end
+      create(:proof_review,
+             application: application,
+             admin: @admin,
+             proof_type: :medical_certification,
+             status: :rejected,
+             rejection_reason: 'none_provided',
+             rejection_reason_code: 'none_provided',
+             submission_method: :paper)
+
+      service = PaperApplicationService.new(params: {}, admin: @admin)
+      service.instance_variable_set(:@application, application)
+      service.instance_variable_set(:@constituent, constituent)
+
+      NotificationService.expects(:create_and_deliver!).with(has_entry(type: 'medical_certification_not_provided')).once
+
+      service.send(:send_medical_certification_not_provided_notice)
+    end
+
+    test 'append_proof_resubmission_delivery_warnings surfaces note when resubmission delivery failed' do
+      constituent = create(:constituent, communication_preference: :email)
+      application = create(:application, :in_progress, skip_proofs: true, user: constituent, income_proof_status: :rejected)
+      mailer_delivery = mock('proof-resubmission-mailer-delivery')
+      mailer_delivery.stubs(:deliver_now).raises(StandardError, 'smtp failed')
+      ApplicationNotificationsMailer.stubs(:proof_rejected).returns(mailer_delivery)
+
+      Current.paper_context = true
+      create(
+        :proof_review,
+        :rejected,
+        application: application,
+        admin: @admin,
+        proof_type: :income,
+        rejection_reason: 'Missing income details',
+        submission_method: :paper
+      )
+      Current.paper_context = false
+
+      service = PaperApplicationService.new(params: {}, admin: @admin)
+      service.instance_variable_set(:@application, application.reload)
+
+      service.send(:append_proof_resubmission_delivery_warnings)
+
+      assert_includes service.reconciliation_note,
+                      'Income proof resubmission form could not be automatically sent'
+      assert_includes service.reconciliation_note, 'You can send it from the application page.'
+    end
   end
 end

--- a/test/services/applications/paper_application_type_consistency_test.rb
+++ b/test/services/applications/paper_application_type_consistency_test.rb
@@ -40,16 +40,7 @@ module Applications
     end
 
     test 'creates constituent with proper Users::Constituent type' do
-      # Mock the NotificationService call instead of the direct mailer
-      # The service now uses NotificationService.create_and_deliver! which handles mailer calls internally
-      NotificationService.expects(:create_and_deliver!).with(
-        type: 'account_created',
-        recipient: anything,
-        actor: anything,
-        notifiable: anything,
-        metadata: anything,
-        channel: anything
-      ).at_least_once.returns(nil) # Returns nil when notification creation fails gracefully
+      NotificationService.stubs(:create_and_deliver!).returns(nil)
 
       service = PaperApplicationService.new(
         params: @valid_params,

--- a/test/services/applications/proof_reviewer_test.rb
+++ b/test/services/applications/proof_reviewer_test.rb
@@ -4,6 +4,8 @@ require 'test_helper'
 
 module Applications
   class ProofReviewerTest < ActiveSupport::TestCase
+    include ProofResubmissionTestHelper
+
     setup do
       @application = create(:application, :in_progress)
       @admin = create(:admin)
@@ -77,7 +79,7 @@ module Applications
         code: 'address_mismatch_test',
         proof_type: 'income',
         locale: 'en',
-        body: 'The address must match %{address}.'
+        body: 'The address must match %<address>s.'
       )
 
       @reviewer.review(
@@ -125,16 +127,17 @@ module Applications
       assert_equal 'approved', status_event.metadata['new_status']
     end
 
-    test 're-rejection requests secure proof resubmission when not in paper context' do
+    test 'paper-context re-rejection still requests secure proof resubmission' do
       Current.paper_context = true
-      @reviewer.review(
-        proof_type: :income,
-        status: :rejected,
-        rejection_reason_code: 'missing_name',
-        rejection_reason: 'First rejected reason text'
-      )
 
-      Current.paper_context = false
+      without_auto_resubmission do
+        @reviewer.review(
+          proof_type: :income,
+          status: :rejected,
+          rejection_reason_code: 'missing_name',
+          rejection_reason: 'First rejected reason text'
+        )
+      end
       travel AuditEventService::DEDUP_WINDOW + 1.second
 
       result = BaseService::Result.new(success: true, message: 'sent', data: {})

--- a/test/services/applications/request_proof_resubmission_test.rb
+++ b/test/services/applications/request_proof_resubmission_test.rb
@@ -5,17 +5,18 @@ require 'test_helper'
 module Applications
   class RequestProofResubmissionTest < ActiveSupport::TestCase
     include ActiveSupport::Testing::TimeHelpers
+    include ProofResubmissionTestHelper
 
     setup do
       @actor = create(:admin)
       @application = create(:application, :in_progress)
       Current.paper_context = true
-      @proof_review = create(:proof_review,
-                             application: @application,
-                             admin: @actor,
-                             proof_type: :income,
-                             status: :rejected,
-                             rejection_reason: 'Missing income details')
+      @proof_review = create_rejected_proof_review_without_auto_resubmission(
+        application: @application,
+        admin: @actor,
+        proof_type: :income,
+        rejection_reason: 'Missing income details'
+      )
       Current.paper_context = false
       @application.income_proof.purge if @application.income_proof.attached?
       @mailer_delivery = mock('proof-resubmission-mailer-delivery')
@@ -26,6 +27,26 @@ module Applications
 
     teardown do
       Current.reset
+    end
+
+    test 'delivery_confirmed_for_review? reflects active secure request forms' do
+      assert_not RequestProofResubmission.delivery_confirmed_for_review?(@proof_review)
+
+      @mailer_delivery.expects(:deliver_now).returns(true)
+      result = RequestProofResubmission.new(application: @application, actor: @actor, proof_type: :income).call
+      assert_predicate result, :success?
+
+      assert RequestProofResubmission.delivery_confirmed_for_review?(@proof_review.reload)
+    end
+
+    test 'delivery_confirmed_for_review? is false when delivery failed and form was revoked' do
+      @mailer_delivery.stubs(:deliver_now).raises(StandardError, 'smtp failed')
+
+      result = RequestProofResubmission.new(application: @application, actor: @actor, proof_type: :income).call
+
+      assert_not result.success?
+      assert_predicate result.data.fetch(:secure_request_forms).first.reload, :revoked?
+      assert_not RequestProofResubmission.delivery_confirmed_for_review?(@proof_review.reload)
     end
 
     test 'creates proof request notification and delivers proof rejection email immediately' do
@@ -144,12 +165,12 @@ module Applications
       create(:guardian_relationship, guardian_user: guardian, dependent_user: dependent, relationship_type: 'Parent')
       application = create(:application, :in_progress, user: dependent, managing_guardian: guardian)
       Current.paper_context = true
-      proof_review = create(:proof_review,
-                            application: application,
-                            admin: @actor,
-                            proof_type: :income,
-                            status: :rejected,
-                            rejection_reason: 'Missing income details')
+      proof_review = create_rejected_proof_review_without_auto_resubmission(
+        application: application,
+        admin: @actor,
+        proof_type: :income,
+        rejection_reason: 'Missing income details'
+      )
       Current.paper_context = false
       application.income_proof.purge if application.income_proof.attached?
 
@@ -182,8 +203,12 @@ module Applications
                            managing_guardian: guardian,
                            income_proof_status: :rejected)
       Current.paper_context = true
-      create(:proof_review, application: application, admin: @actor, proof_type: :income, status: :rejected,
-                            rejection_reason: 'Missing income details')
+      create_rejected_proof_review_without_auto_resubmission(
+        application: application,
+        admin: @actor,
+        proof_type: :income,
+        rejection_reason: 'Missing income details'
+      )
       Current.paper_context = false
       application.income_proof.purge if application.income_proof.attached?
 
@@ -205,8 +230,12 @@ module Applications
                            managing_guardian: guardian,
                            income_proof_status: :rejected)
       Current.paper_context = true
-      create(:proof_review, application: application, admin: @actor, proof_type: :income, status: :rejected,
-                            rejection_reason: 'Missing income details')
+      create_rejected_proof_review_without_auto_resubmission(
+        application: application,
+        admin: @actor,
+        proof_type: :income,
+        rejection_reason: 'Missing income details'
+      )
       Current.paper_context = false
       application.income_proof.purge if application.income_proof.attached?
 
@@ -229,7 +258,7 @@ module Applications
     end
 
     test 'sms request sends token-safe SMS and records requested channel' do
-      @application.user.update!(phone: '410-555-0100', phone_type: 'text')
+      @application.user.update!(phone: '410-555-0100', phone_type: 'text', communication_preference: 'email')
       SmsService.expects(:send_message).with(
         @application.user.phone,
         regexp_matches(/secure_proof_form/),
@@ -241,7 +270,12 @@ module Applications
         )
       ).returns(true)
 
-      result = RequestProofResubmission.new(application: @application, actor: @actor, proof_type: :income).call
+      result = RequestProofResubmission.new(
+        application: @application,
+        actor: @actor,
+        proof_type: :income,
+        channel_overrides: { @application.user_id => 'sms' }
+      ).call
 
       assert_predicate result, :success?
       form = result.data.fetch(:secure_request_forms).first
@@ -354,14 +388,12 @@ module Applications
 
     test 'stale rejected proof review does not force rejected request snapshot or email' do
       application = create(:application, :in_progress, id_proof_status: :not_reviewed)
-      Current.paper_context = true
-      create(:proof_review,
-             application: application,
-             admin: @actor,
-             proof_type: :id,
-             status: :rejected,
-             rejection_reason: 'Old blurry upload')
-      Current.paper_context = false
+      create_rejected_proof_review_without_auto_resubmission(
+        application: application,
+        admin: @actor,
+        proof_type: :id,
+        rejection_reason: 'Old blurry upload'
+      )
       application.update!(id_proof_status: :not_reviewed)
       application.id_proof.purge if application.id_proof.attached?
 

--- a/test/services/applications/request_provider_info_test.rb
+++ b/test/services/applications/request_provider_info_test.rb
@@ -111,10 +111,14 @@ module Applications
     end
 
     test 'sms request keeps NotificationService channel compatible while recording requested channel' do
-      @application.user.update!(phone_type: 'text')
+      @application.user.update!(phone_type: 'text', communication_preference: 'email')
       SmsService.stubs(:send_message).returns(true)
 
-      result = RequestProviderInfo.new(application: @application, actor: @actor).call
+      result = RequestProviderInfo.new(
+        application: @application,
+        actor: @actor,
+        channel_overrides: { @application.user_id => 'sms' }
+      ).call
 
       assert_predicate result, :success?
       secure_request_form = result.data.fetch(:secure_request_forms).first

--- a/test/services/applications/secure_request_recipient_resolver_test.rb
+++ b/test/services/applications/secure_request_recipient_resolver_test.rb
@@ -14,6 +14,36 @@ module Applications
       assert_equal :letter, candidate.channel
     end
 
+    test 'letter communication preference wins over text phone type' do
+      constituent = create(:constituent, communication_preference: 'letter', phone_type: 'text')
+      application = create(:application, user: constituent)
+
+      candidate = SecureRequestRecipientResolver.new(application: application).resolve.first
+
+      assert_equal :letter, candidate.channel
+    end
+
+    test 'email communication preference routes secure requests to email' do
+      constituent = create(:constituent, communication_preference: 'email', phone_type: 'text')
+      application = create(:application, user: constituent)
+
+      candidate = SecureRequestRecipientResolver.new(application: application).resolve.first
+
+      assert_equal :email, candidate.channel
+    end
+
+    test 'sms delivery requires explicit channel override' do
+      constituent = create(:constituent, communication_preference: 'email', phone_type: 'text')
+      application = create(:application, user: constituent)
+
+      candidate = SecureRequestRecipientResolver
+                  .new(application: application, channel_overrides: { constituent.id => 'sms' })
+                  .resolve
+                  .first
+
+      assert_equal :sms, candidate.channel
+    end
+
     test 'defaults adult application to applicant' do
       application = create(:application)
 

--- a/test/services/notification_service_test.rb
+++ b/test/services/notification_service_test.rb
@@ -3,6 +3,8 @@
 require 'test_helper'
 
 class NotificationServiceTest < ActiveSupport::TestCase
+  include ProofResubmissionTestHelper
+
   setup do
     @admin = create(:admin)
     @constituent = create(:constituent)
@@ -22,7 +24,11 @@ class NotificationServiceTest < ActiveSupport::TestCase
           recipient: @constituent,
           actor: @admin,
           notifiable: @application,
-          metadata: { proof_type: 'income', rejection_reason: 'Missing documentation' },
+          metadata: {
+            proof_type: 'income',
+            rejection_reason: 'Missing documentation',
+            delivery_path: 'legacy'
+          },
           channel: :email
         )
       end
@@ -134,7 +140,7 @@ class NotificationServiceTest < ActiveSupport::TestCase
       actor: @admin,
       action: 'proof_rejected',
       notifiable: @application,
-      metadata: { proof_type: 'income' }
+      metadata: { proof_type: 'income', delivery_path: 'legacy' }
     )
 
     # Call the delivery part which should fail and handle the error
@@ -248,9 +254,12 @@ class NotificationServiceTest < ActiveSupport::TestCase
   end
 
   test 'proof rejected with proof review notifiable routes application and review to mailer' do
-    Current.paper_context = true
-    proof_review = create(:proof_review, :rejected, application: @application, admin: @admin, proof_type: :income)
-    Current.paper_context = false
+    proof_review = create_rejected_proof_review_without_auto_resubmission(
+      application: @application,
+      admin: @admin,
+      proof_type: :income,
+      rejection_reason: 'Missing documentation'
+    )
 
     mail_delivery = mock('mail_delivery')
     mail_delivery.expects(:deliver_later).returns(true)
@@ -263,7 +272,7 @@ class NotificationServiceTest < ActiveSupport::TestCase
       recipient: @constituent,
       actor: @admin,
       notifiable: proof_review,
-      metadata: { proof_type: 'income' },
+      metadata: { proof_type: 'income', delivery_path: 'legacy' },
       channel: :email
     )
 
@@ -272,9 +281,12 @@ class NotificationServiceTest < ActiveSupport::TestCase
   end
 
   test 'typed proof rejected routes proof review lookup to proof rejected mailer' do
-    Current.paper_context = true
-    proof_review = create(:proof_review, :rejected, application: @application, admin: @admin, proof_type: :income)
-    Current.paper_context = false
+    proof_review = create_rejected_proof_review_without_auto_resubmission(
+      application: @application,
+      admin: @admin,
+      proof_type: :income,
+      rejection_reason: 'Missing documentation'
+    )
 
     mail_delivery = mock('mail_delivery')
     mail_delivery.expects(:deliver_later).returns(true)
@@ -287,11 +299,30 @@ class NotificationServiceTest < ActiveSupport::TestCase
       recipient: @constituent,
       actor: @admin,
       notifiable: @application,
+      metadata: { delivery_path: 'legacy' },
       channel: :email
     )
 
     assert_not_nil notification
     assert_equal 'email', notification.reload.metadata['actual_delivery_channel']
+  end
+
+  test 'typed proof rejected notifications are refused like generic proof rejected' do
+    create(:proof_review, :rejected, application: @application, admin: @admin, proof_type: :income)
+
+    ApplicationNotificationsMailer.expects(:proof_rejected).never
+
+    assert_no_difference 'Notification.count' do
+      notification = NotificationService.create_and_deliver!(
+        type: :income_proof_rejected,
+        recipient: @constituent,
+        actor: @admin,
+        notifiable: @application,
+        channel: :email
+      )
+
+      assert_nil notification
+    end
   end
 
   test 'id proof attached is preference routed' do

--- a/test/services/printed_letter_delivery_integration_test.rb
+++ b/test/services/printed_letter_delivery_integration_test.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PrintedLetterDeliveryIntegrationTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @admin = create(:admin)
+    @constituent = create(:constituent, communication_preference: :letter)
+    @application = create(:application, user: @constituent)
+  end
+
+  teardown do
+    Current.reset
+  end
+
+  test 'sync secure proof request queues PrintQueueItem when recipient prefers letter' do
+    application = create(:application, :in_progress, id_proof_status: :not_reviewed, user: @constituent)
+    ApplicationNotificationsMailer.unstub(:proof_requested)
+
+    result = assert_difference('PrintQueueItem.count', 1) do
+      Applications::RequestProofResubmission.new(
+        application: application,
+        actor: @admin,
+        proof_type: :id
+      ).call
+    end
+
+    assert_predicate result, :success?
+    secure_request_form = result.data.fetch(:secure_request_forms).first
+    assert_predicate secure_request_form, :recipient_channel_letter?
+
+    print_item = PrintQueueItem.last
+    assert_equal application.id, print_item.application_id
+    assert_equal @constituent.id, print_item.constituent_id
+    assert_predicate print_item.pdf_letter, :attached?
+  end
+
+  test 'paper proof rejection auto-issues resubmission and queues rejected letter type' do
+    application = create(:application, :in_progress, income_proof_status: :rejected, user: @constituent)
+    ApplicationNotificationsMailer.unstub(:proof_rejected)
+    Current.paper_context = true
+
+    proof_review = nil
+    assert_difference('PrintQueueItem.count', 1) do
+      proof_review = create(
+        :proof_review,
+        :rejected,
+        application: application,
+        admin: @admin,
+        proof_type: :income,
+        rejection_reason: 'Missing income details'
+      )
+    end
+
+    secure_request_form = SecureRequestForm.where(application: application).order(:created_at).last
+    assert_predicate secure_request_form, :recipient_channel_letter?
+
+    print_item = PrintQueueItem.last
+    assert_equal 'income_proof_rejected', print_item.letter_type
+    assert_equal application.id, print_item.application_id
+    assert_equal proof_review.id, application.proof_reviews.where(proof_type: :income, status: :rejected).pick(:id)
+    assert_predicate print_item.pdf_letter, :attached?
+  end
+
+  test 'admin proof rejection via ProofReviewer queues PrintQueueItem for letter-preference voice users' do
+    application = create(:application, :in_progress, user: @constituent)
+    @constituent.update!(phone_type: :voice)
+    application.income_proof.attach(
+      io: StringIO.new('income proof content'),
+      filename: 'income.pdf',
+      content_type: 'application/pdf'
+    )
+    ApplicationNotificationsMailer.unstub(:proof_rejected)
+
+    assert_difference('PrintQueueItem.count', 1) do
+      Applications::ProofReviewer.new(application, @admin).review(
+        proof_type: :income,
+        status: :rejected,
+        rejection_reason: 'Document is not acceptable'
+      )
+    end
+
+    print_item = PrintQueueItem.last
+    assert_equal 'income_proof_rejected', print_item.letter_type
+    assert_equal application.id, print_item.application_id
+    assert_predicate print_item.pdf_letter, :attached?
+  end
+
+  test 'email communication preference routes secure proof request to email not SMS or print' do
+    @constituent.update!(communication_preference: :email, phone_type: :text)
+    application = create(:application, :in_progress, income_proof_status: :not_reviewed, user: @constituent)
+    ApplicationNotificationsMailer.unstub(:proof_requested)
+    SmsService.expects(:send_message).never
+
+    assert_no_difference('PrintQueueItem.count') do
+      result = Applications::RequestProofResubmission.new(
+        application: application,
+        actor: @admin,
+        proof_type: :income
+      ).call
+
+      assert_predicate result, :success?
+      secure_request_form = result.data.fetch(:secure_request_forms).first
+      assert_predicate secure_request_form, :recipient_channel_email?
+    end
+  end
+
+  test 'paper proof rejection uses communication preference letter over text phone type' do
+    @constituent.update!(communication_preference: :letter, phone_type: :text)
+    application = create(:application, :in_progress, income_proof_status: :rejected, user: @constituent)
+    application.income_proof.purge if application.income_proof.attached?
+    ApplicationNotificationsMailer.unstub(:proof_rejected)
+    SmsService.expects(:send_message).never
+    Current.paper_context = true
+
+    assert_difference('PrintQueueItem.count', 1) do
+      create(
+        :proof_review,
+        :rejected,
+        application: application,
+        admin: @admin,
+        proof_type: :income,
+        rejection_reason: 'Missing income details'
+      )
+    end
+
+    secure_request_form = SecureRequestForm.where(application: application).order(:created_at).last
+    assert_predicate secure_request_form, :recipient_channel_letter?
+
+    print_item = PrintQueueItem.last
+    assert_equal 'income_proof_rejected', print_item.letter_type
+  ensure
+    Current.reset
+  end
+
+  test 'sync provider info request queues PrintQueueItem when recipient prefers letter' do
+    ApplicationNotificationsMailer.unstub(:provider_info_requested)
+
+    result = assert_difference('PrintQueueItem.count', 1) do
+      Applications::RequestProviderInfo.new(application: @application, actor: @admin).call
+    end
+
+    assert_predicate result, :success?
+    secure_request_form = result.data.fetch(:secure_request_forms).first
+    assert_predicate secure_request_form, :recipient_channel_letter?
+
+    print_item = PrintQueueItem.last
+    assert_equal 'provider_info_requested', print_item.letter_type
+    assert_equal @application.id, print_item.application_id
+    assert_equal @constituent.id, print_item.constituent_id
+    assert_predicate print_item.pdf_letter, :attached?
+  end
+
+  test 'async account_created notification queues PrintQueueItem after mailer job runs' do
+    ApplicationNotificationsMailer.unstub(:account_created)
+
+    assert_difference('PrintQueueItem.count', 1) do
+      perform_enqueued_jobs(only: ActionMailer::MailDeliveryJob) do
+        NotificationService.create_and_deliver!(
+          type: :account_created,
+          recipient: @constituent,
+          actor: @admin,
+          notifiable: @constituent,
+          channel: :email
+        )
+      end
+    end
+
+    print_item = PrintQueueItem.last
+    assert_equal 'account_created', print_item.letter_type
+    assert_equal @constituent.id, print_item.constituent_id
+    assert_predicate print_item.pdf_letter, :attached?
+  end
+
+  test 'async direct registration confirmation mailer queues PrintQueueItem after job runs' do
+    ApplicationNotificationsMailer.unstub(:registration_confirmation)
+
+    assert_difference('PrintQueueItem.count', 1) do
+      perform_enqueued_jobs(only: ActionMailer::MailDeliveryJob) do
+        ApplicationNotificationsMailer.registration_confirmation(@constituent).deliver_later
+      end
+    end
+
+    print_item = PrintQueueItem.last
+    assert_equal 'registration_confirmation', print_item.letter_type
+    assert_equal @constituent.id, print_item.constituent_id
+    assert_predicate print_item.pdf_letter, :attached?
+  end
+
+  test 'async proof received notification queues PrintQueueItem after mailer job runs' do
+    ApplicationNotificationsMailer.unstub(:proof_received)
+
+    assert_difference('PrintQueueItem.count', 1) do
+      perform_enqueued_jobs(only: ActionMailer::MailDeliveryJob) do
+        NotificationService.create_and_deliver!(
+          type: :id_proof_attached,
+          recipient: @constituent,
+          actor: @constituent,
+          notifiable: @application,
+          metadata: { proof_type: 'id' },
+          channel: :email
+        )
+      end
+    end
+
+    print_item = PrintQueueItem.last
+    assert_equal @application.id, print_item.application_id
+    assert_equal @constituent.id, print_item.constituent_id
+    assert_predicate print_item.pdf_letter, :attached?
+  end
+end

--- a/test/services/proof_attachment_service_test.rb
+++ b/test/services/proof_attachment_service_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class ProofAttachmentServiceTest < ActiveSupport::TestCase
   include ActionDispatch::TestProcess
+  include ProofResubmissionTestHelper
 
   setup do
     # Disconnect any lingering database connections and set up Active Storage
@@ -137,15 +138,17 @@ class ProofAttachmentServiceTest < ActiveSupport::TestCase
     # Clear events before the test
     Event.delete_all
 
-    result = ProofAttachmentService.reject_proof_without_attachment(
-      application: @application,
-      proof_type: 'income',
-      admin: @admin,
-      submission_method: :paper,
-      reason: 'invalid_document',
-      notes: 'Document does not meet requirements',
-      metadata: { ip_address: '127.0.0.1' }
-    )
+    result = without_auto_resubmission do
+      ProofAttachmentService.reject_proof_without_attachment(
+        application: @application,
+        proof_type: 'income',
+        admin: @admin,
+        submission_method: :paper,
+        reason: 'invalid_document',
+        notes: 'Document does not meet requirements',
+        metadata: { ip_address: '127.0.0.1' }
+      )
+    end
 
     assert result[:success], 'Expected reject_proof_without_attachment to succeed'
     assert_not_nil result[:duration_ms], 'Expected duration to be tracked'
@@ -157,15 +160,17 @@ class ProofAttachmentServiceTest < ActiveSupport::TestCase
     assert_equal 'rejected', proof_review.status
     assert_equal 'invalid_document', proof_review.rejection_reason
 
-    # Verify audit event was created
-    event = Event.where(action: 'income_proof_rejected').order(:created_at).last
-    assert_not_nil event, 'Expected an income_proof_rejected audit event'
-    assert_equal 'income_proof_rejected', event.action
+    # The canonical audit event is the generic `proof_rejected` written by ProofReview;
+    # no typed `income_proof_rejected` event should be emitted by ProofAttachmentService.
+    assert_empty Event.where(action: 'income_proof_rejected'), 'Did not expect a typed income_proof_rejected event'
+
+    event = Event.where(action: 'proof_rejected').order(:created_at).last
+    assert_not_nil event, 'Expected a generic proof_rejected audit event'
     assert_equal @application.id, event.auditable_id
     assert_equal 'Application', event.auditable_type
     assert_equal @admin.id, event.user_id
     assert_equal 'income', event.metadata['proof_type']
-    assert_equal 'invalid_document', event.metadata['rejection_reason']
+    assert_equal 'paper', event.metadata['submission_method']
   end
 
   test 'metrics recording handles exceptions gracefully' do

--- a/test/support/proof_rejection_notification_assertions.rb
+++ b/test/support/proof_rejection_notification_assertions.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ProofRejectionNotificationAssertions
+  ORPHAN_PROOF_REJECTION_NOTIFICATION_TYPES = %w[
+    proof_rejected
+    id_proof_rejected
+    income_proof_rejected
+    residency_proof_rejected
+  ].freeze
+
+  def assert_no_orphan_proof_rejection_notification_delivery
+    NotificationService.expects(:create_and_deliver!).with do |params|
+      ORPHAN_PROOF_REJECTION_NOTIFICATION_TYPES.include?(params[:type].to_s)
+    end.never
+  end
+end

--- a/test/support/proof_resubmission_test_helper.rb
+++ b/test/support/proof_resubmission_test_helper.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ProofResubmissionTestHelper
+  # Suppresses ProofReview after_commit resubmission delivery for the duration of the block.
+  # Use when tests need a rejected review as setup state without issuing a real secure request.
+  def without_auto_resubmission
+    noop = mock('suppressed-resubmission')
+    noop.stubs(:call).returns(BaseService::Result.new(success: true, message: 'suppressed', data: {}))
+    Applications::RequestProofResubmission.stubs(:new).returns(noop)
+    yield
+  ensure
+    Applications::RequestProofResubmission.unstub(:new)
+  end
+
+  def create_rejected_proof_review_without_auto_resubmission(**attributes)
+    without_auto_resubmission do
+      create(:proof_review, status: :rejected, **attributes)
+    end
+  end
+end


### PR DESCRIPTION
Straightens out proof rejection delivery by making secure proof resubmission requests the single delivery path for income, residency, and ID proof rejections

Secure proof request routing now follows communication preference consistently:

- Letter preference queues printed letters
- Email preference sends email
- SMS requires an explicit channel override

Removed duplicate/competing proof rejection notification paths from paper intake and no-attachment rejection handling

- Suppress `account_created` notices for equipment-scope paper applications as equipment-scope users should use secure temporary form links for proof/cert uploads instead of receiving misleading account-login notices