### PR TITLE
Fix guardian dependent contact updates and paper intake failure handling

### DIFF
--- a/app/controllers/constituent_portal/dependents_controller.rb
+++ b/app/controllers/constituent_portal/dependents_controller.rb
@@ -34,7 +34,7 @@ module ConstituentPortal
 
     # POST /constituent_portal/dependents
     def create
-      dependent_attrs = dependent_attributes_with_guardian_contact_fallback
+      dependent_attrs = dependent_attributes_with_contact_strategies
 
       # Using UserServiceIntegration concern for consistent user creation
       # Portal always creates NEW users for dependents (skip_user_lookup: true)
@@ -74,8 +74,7 @@ module ConstituentPortal
 
     # PATCH/PUT /constituent_portal/dependents/:id
     def update
-      params_to_update = dependent_user_params
-      configure_uniqueness_validation(params_to_update)
+      params_to_update = dependent_attributes_with_contact_strategies
 
       if @dependent.update(params_to_update)
         redirect_after_successful_update
@@ -141,27 +140,60 @@ module ConstituentPortal
       Current.user = current_user
     end
 
-    def dependent_attributes_with_guardian_contact_fallback
+    def dependent_attributes_with_contact_strategies
       attrs = dependent_user_params.to_h
+      strategies = dependent_contact_strategy_params(attrs)
+      return attrs if strategies.values_at(:email_strategy, :phone_strategy).all?(&:nil?)
 
       Applications::GuardianDependentManagementService
-        .new(dependent_contact_strategy_params)
+        .new(strategies)
         .apply_contact_strategies_for(current_user, attrs)
     end
 
-    def dependent_contact_strategy_params
+    def dependent_contact_strategy_params(attrs)
       {
-        email_strategy: guardian_contact_strategy(:use_guardian_email, dependent_user_params[:email]),
-        phone_strategy: guardian_contact_strategy(:use_guardian_phone, dependent_user_params[:phone]),
+        email_strategy: contact_strategy_for(:email, :use_guardian_email, attrs),
+        phone_strategy: contact_strategy_for(:phone, :use_guardian_phone, attrs),
         address_strategy: 'dependent'
       }
     end
 
+    def contact_strategy_for(field, checkbox_param, attrs)
+      submitted = attrs.key?(field) || attrs.key?(field.to_s)
+      value = attrs[field] || attrs[field.to_s]
+
+      # Update only rewrites contact when the field was submitted; omitted keys preserve stored values.
+      if action_name == 'update'
+        return nil unless submitted
+      elsif !submitted
+        return guardian_contact_strategy(checkbox_param, nil)
+      end
+
+      guardian_contact_strategy(checkbox_param, value)
+    end
+
     def guardian_contact_strategy(param_name, dependent_value)
       return 'guardian' if ActiveModel::Type::Boolean.new.cast(params[param_name])
+      # Submitted blank contact on create/update applies guardian strategy and regenerates primary contact.
       return 'guardian' if dependent_value.blank?
+      return 'guardian' if matches_guardian_contact?(param_name, dependent_value)
 
       'dependent'
+    end
+
+    def matches_guardian_contact?(param_name, dependent_value)
+      case param_name
+      when :use_guardian_email
+        User.normalize_email(dependent_value) == User.normalize_email(current_user.email)
+      when :use_guardian_phone
+        normalized_phone_digits(dependent_value) == normalized_phone_digits(current_user.phone)
+      else
+        false
+      end
+    end
+
+    def normalized_phone_digits(phone)
+      phone.to_s.gsub(/\D/, '')
     end
 
     # Get recent profile changes for a user
@@ -191,18 +223,6 @@ module ConstituentPortal
 
       flash.now[:alert] = "Failed to create dependent: #{error_messages.join(', ')}"
       render :new, status: :unprocessable_content
-    end
-
-    def configure_uniqueness_validation(params_to_update)
-      should_skip_validation = should_skip_uniqueness_validation?(params_to_update)
-      @dependent.skip_contact_uniqueness_validation = true if should_skip_validation
-    end
-
-    def should_skip_uniqueness_validation?(params_to_update)
-      params_to_update[:email] == current_user.email ||
-        params_to_update[:phone] == current_user.phone ||
-        @dependent.email == current_user.email ||
-        @dependent.phone == current_user.phone
     end
 
     def redirect_after_successful_update

--- a/app/services/applications/guardian_dependent_management_service.rb
+++ b/app/services/applications/guardian_dependent_management_service.rb
@@ -88,6 +88,8 @@ module Applications
     end
 
     def apply_email_strategy(data)
+      return if params[:email_strategy].nil?
+
       case params[:email_strategy]
       when 'guardian'
         if @guardian_user&.email.present?
@@ -118,6 +120,8 @@ module Applications
     end
 
     def apply_phone_strategy(data)
+      return if params[:phone_strategy].nil?
+
       case params[:phone_strategy]
       when 'guardian'
         data[:dependent_phone] = @guardian_user.phone
@@ -171,7 +175,7 @@ module Applications
 
     def failure(message)
       add_error?(message)
-      Result.new(success: false, errors: @errors)
+      Result.new(success: false, message: message, data: { errors: @errors })
     end
   end
 end

--- a/docs/development/guardian_relationship_system.md
+++ b/docs/development/guardian_relationship_system.md
@@ -1,19 +1,102 @@
 # Guardian Relationship System
 
-Explicit `GuardianRelationship` records replace the old boolean flags, allowing each guardian to manage many dependents and vice-versa while preserving data integrity.
+How MAT Vulcan records guardian/dependent relationships and connects them to dependent applications.
 
 ---
 
-## 1 · Data Model
+## 1 · High-Level Flow
 
-| Table | Key Columns | Notes |
-|-------|-------------|-------|
-| **guardian_relationships** | `guardian_id`, `dependent_id`, `relationship_type` | Unique index on `[guardian_id, dependent_id]`. |
-| **applications** | `user_id`, `managing_guardian_id` | `user_id` = applicant; `managing_guardian_id` set only for dependents. |
-| **users** (associations) | see below | |
+```text
+Portal dependent management
+  ConstituentPortal::DependentsController
+  -> UserServiceIntegration
+  -> Applications::UserCreationService
+  -> Applications::GuardianDependentManagementService
+  -> GuardianRelationship
+
+Portal dependent application
+  ConstituentPortal::ApplicationsController
+  -> ApplicationForm
+  -> Applications::ApplicationCreator
+  -> Application(user: dependent, managing_guardian: current_user)
+
+Admin paper application
+  Admin::PaperApplicationsController
+  -> Applications::PaperApplicationService
+  -> Applications::GuardianDependentManagementService / Applications::UserCreationService
+  -> GuardianRelationship
+  -> Application(user: dependent, managing_guardian: guardian)
+```
+
+A `GuardianRelationship` records that one user can act for another user. An `Application` records the actual applicant in `user_id`; dependent applications also store the responsible guardian in `managing_guardian_id`.
+
+---
+
+## 2 · Main Entry Points
+
+### 2.1 Constituent Portal Dependents
+
+`ConstituentPortal::DependentsController` is mounted with `resources :dependents`. The controller currently implements `new`, `create`, `show`, `edit`, `update`, and `destroy`.
+
+| Action | Current behavior |
+|--------|------------------|
+| `new` / `create` | Creates a new dependent user with `skip_user_lookup: true`, requires at least one disability, applies contact strategies via `Applications::GuardianDependentManagementService` (blank dependent contact or `use_guardian_email` / `use_guardian_phone` checkboxes fall back to guardian strategy), then creates `GuardianRelationship`. |
+| `show` / `edit` | Loads only dependents returned by `User.editable_by_guardian(current_user)` and displays the current user's relationship plus recent profile-change events. |
+| `update` | Updates permitted dependent profile fields. When `email` or `phone` is explicitly submitted, the controller applies the same contact strategies as `create`; omitted contact keys are left unchanged so partial PATCHes do not rewrite existing contact. Submitted contact matching the guardian's email/phone uses guardian strategy (generated primary contact plus real contact in `dependent_email` / `dependent_phone`). `Current.user` is set to the guardian, so `UserProfile` logs `profile_updated_by_guardian` for profile-field changes. |
+| `destroy` | Destroys the current guardian's `GuardianRelationship`. It does not destroy the dependent user. |
+
+### 2.2 Constituent Portal Applications
+
+`ConstituentPortal::ApplicationsController` builds dependent applications through `ApplicationForm` and persists them with `Applications::ApplicationCreator`.
+
+For dependent applications:
+
+1. The form carries the dependent `user_id`.
+2. `ApplicationForm#for_dependent?` checks that `user_id` differs from `current_user.id`.
+3. `ApplicationForm#validate_guardian_relationship` verifies a `GuardianRelationship` for `current_user` and the dependent.
+4. `Applications::ApplicationCreator` sets the application user to the dependent and `managing_guardian_id` to the guardian.
+
+### 2.3 Admin Paper Applications
+
+`Admin::PaperApplicationsController` normalizes paper form params and calls `Applications::PaperApplicationService`.
+
+`Applications::PaperApplicationService` handles:
+
+- existing self applicants
+- new self applicants
+- existing guardian plus existing dependent
+- existing guardian plus new dependent
+- new guardian plus new dependent
+
+For dependent paper applications, the service creates or verifies the `GuardianRelationship`, sets `@guardian_user_for_app`, and saves the paper `Application` with `managing_guardian`.
+
+Paper create/update paths wrap the main work in `Current.paper_context = true`, and nested proof/application operations also set it where needed.
+
+### 2.4 Admin Relationship Views
+
+Admin user and application pages display guardian/dependent relationships through `Admin::UsersController`, `Application#managing_guardian`, and the `GuardianRelationship` associations.
+
+Only relationship removal is currently routed for `Admin::GuardianRelationshipsController`:
+
+```text
+DELETE /admin/guardian_relationships/:id -> admin/guardian_relationships#destroy
+```
+
+The controller has `new` and `create` methods, but `config/routes.rb` does not currently route them.
+
+---
+
+## 3 · Data Model
+
+| Table | Key columns | Current behavior |
+|-------|-------------|------------------|
+| `guardian_relationships` | `guardian_id`, `dependent_id`, `relationship_type` | Requires both users and a relationship type. Unique index on `[guardian_id, dependent_id]`. |
+| `applications` | `user_id`, `managing_guardian_id` | `user_id` is the applicant. `managing_guardian_id` is nullable and present for dependent applications. |
+| `users` | `dependent_email`, `dependent_phone` | Encrypted optional contact fields for dependents. Primary `email` and `phone` remain unique. |
+
+Associations live in `app/models/concerns/user_guardianship.rb`:
 
 ```ruby
-# Implemented in UserGuardianship concern (app/models/concerns/user_guardianship.rb)
 has_many :guardian_relationships_as_guardian,
          class_name: 'GuardianRelationship',
          foreign_key: 'guardian_id',
@@ -35,186 +118,102 @@ has_many :managed_applications,
          dependent: :nullify
 ```
 
+`Application#ensure_managing_guardian_set` is a safety callback. If an application is assigned to a dependent with an existing relationship and no `managing_guardian_id`, it sets `managing_guardian_id` from an existing `GuardianRelationship`.
+
 ---
 
-## 2 · Dependent Contact Strategy
+## 4 · Contact Handling
 
-| Field | Purpose |
-|-------|---------|
-| `dependent_email` | Encrypted, optional e-mail for dependent |
-| `dependent_phone` | Encrypted, optional phone |
+Dependent contact handling separates the unique login/contact columns from effective recipient information.
 
-**Own contact info**
+| Field or parameter | Current behavior |
+|--------------------|------------------|
+| `users.email` | Primary email. Deterministically encrypted and unique. |
+| `users.phone` | Primary phone. Deterministically encrypted and unique when present. |
+| `users.dependent_email` | Optional encrypted dependent contact email. Used by `effective_email` before guardian fallback. |
+| `users.dependent_phone` | Optional encrypted dependent contact phone. Used by `effective_phone` before guardian fallback. |
+| `email_strategy` / `phone_strategy` / `address_strategy` | Runtime params used by portal and paper flows. They are not persisted strategy columns. |
+
+Guardian-contact sharing uses dependent fields plus generated primary values when needed:
 
 ```ruby
 dependent = User.create!(
-  email:            'child@example.com',
-  phone:            '555-0001',
-  dependent_email:  'child@example.com',
-  dependent_phone:  '555-0001'
+  email: 'dependent-abc123@system.matvulcan.local',
+  phone: '000-000-1234',
+  dependent_email: 'guardian@example.com',
+  dependent_phone: '555-0002'
 )
 ```
 
-**Shared contact info**
+There is no validation bypass flag for shared contact. `User` always validates primary `email` and `phone` uniqueness; guardian sharing is handled by `Applications::GuardianDependentManagementService` contact strategies, not by skipping uniqueness checks.
 
-```ruby
-dependent = User.create!(
-  email:            'dependent-abc123@system.local', # system-generated unique
-  phone:            '000-000-1234',
-  dependent_email:  'guardian@example.com',
-  dependent_phone:  '555-0002'
-)
-```
+Contact helper methods live in `UserGuardianship`:
 
-Helper methods (implemented in `UserGuardianship` concern):
+| Method | Current behavior |
+|--------|------------------|
+| `effective_email` | Uses `dependent_email` for dependents when present, then falls back to `guardian_for_contact.email`; otherwise uses `email`. |
+| `effective_phone` | Uses `dependent_phone` for dependents when present, then falls back to `guardian_for_contact.phone`; otherwise uses `phone`. |
+| `effective_phone_type` | Uses the guardian phone type when the effective phone matches the guardian phone; otherwise uses the dependent phone type. |
+| `effective_communication_preference` | Uses the guardian preference for dependents with a contact guardian. |
+| `effective_locale` | Uses the guardian locale when a dependent's effective email is the guardian email; otherwise uses the user's locale. |
+| `guardian_for_contact` | Returns the first loaded or queryable guardian relationship's guardian user. |
 
-```ruby
-dependent.effective_email  # prefers dependent_email, falls back to guardian's email
-dependent.effective_phone  # prefers dependent_phone, falls back to guardian's phone
-dependent.effective_phone_type  # handles phone type logic for dependents
-dependent.effective_communication_preference  # uses guardian's preference if dependent
-dependent.guardian_for_contact  # returns primary guardian for contact purposes
+`has_own_contact_info?` and `uses_guardian_contact_info?` are not implemented.
 
-# Note: has_own_contact_info? and uses_guardian_contact_info? methods
-# are mentioned in docs but not currently implemented in the codebase
-```
-
-*Avoids uniqueness violations and supports real-world family setups.*
+See also [email uniqueness for dependents](../features/email_uniqueness_for_dependents.md).
 
 ---
 
-## 3 · Key Methods & Scopes
+## 5 · Key Methods and Scopes
 
-| Model | Method | Purpose |
-|-------|--------|---------|
-| **User** | `guardian?`, `dependent?` | Quick role checks (implemented in UserGuardianship) |
-|  | `dependent_applications` | All apps for dependents (implemented in UserGuardianship) |
-|  | `relationship_types_for_dependent(user)` | Returns relationship strings (implemented in UserGuardianship) |
-|  | `effective_email`, `effective_phone` | Contact info with guardian fallback |
-|  | `guardian_for_contact` | Primary guardian for contact purposes |
-| **Application** | `for_dependent?` | Returns true if managing_guardian_id present |
-|  | `guardian_relationship_type` | Returns relationship_type from GuardianRelationship |
-|  | `ensure_managing_guardian_set` | Callback for safety (before_save and before_create) |
+| Model | Method or scope | Current behavior |
+|-------|-----------------|------------------|
+| `User` | `guardian?`, `dependent?` | Checks whether relationship associations exist. |
+| `User` | `with_dependents`, `with_guardians` | Finds users with guardian/dependent relationships. |
+| `User` | `editable_by_guardian(guardian)`, `accessible_by_guardian(guardian)` | Returns dependents for a guardian; `accessible_by_guardian` aliases `editable_by_guardian`. |
+| `User` | `editable_by_guardian?`, `accessible_by_guardian?`, `viewable_by_guardian?` | Checks whether the supplied guardian is related to this dependent. |
+| `User` | `dependent_applications` | Returns applications for this user's dependents. |
+| `User` | `relationship_types_for_dependent(user)` | Returns relationship type strings for a dependent. |
+| `Application` | `for_dependent?` | True when `managing_guardian_id` is present. |
+| `Application` | `guardian_relationship_type` | Looks up the relationship type for `managing_guardian_id` and `user_id`. |
+| `Application` | `managed_by(guardian)` | Applications whose `managing_guardian_id` is the guardian. |
+| `Application` | `for_dependents_of(guardian)` | Applications for any dependent related to the guardian. |
+| `Application` | `related_to_guardian(guardian)` | Broad viewing scope: managed applications plus applications for related dependents. |
+| `Application` | `editable_by(user)`, `accessible_by(user)` | Strict ownership scope: self applications with no guardian, or applications managed by the user. |
+| `Application` | `editable_by?`, `accessible_by?`, `viewable_by?` | Instance-level versions of the strict ownership check. |
 
-```ruby
-# Application scopes (implemented in app/models/application.rb)
-scope :managed_by, lambda { |guardian_user|
-  where(managing_guardian_id: guardian_user.id)
-}
-
-scope :for_dependents_of, lambda { |guardian_user|
-  if guardian_user
-    joins('INNER JOIN guardian_relationships ON applications.user_id = guardian_relationships.dependent_id')
-      .where(guardian_relationships: { guardian_id: guardian_user.id })
-  else
-    none
-  end
-}
-
-scope :related_to_guardian, lambda { |guardian_user|
-  managed_by(guardian_user).or(for_dependents_of(guardian_user))
-}
-
-# User scopes (implemented in UserGuardianship concern)
-scope :with_dependents, -> { joins(:guardian_relationships_as_guardian).distinct }
-scope :with_guardians, -> { joins(:guardian_relationships_as_dependent).distinct }
-```
+Important distinction: `related_to_guardian` is broader than edit access and is documented in the model as view-only.
 
 ---
 
-## 4 · User Flows
+## 6 · Testing Notes
 
-### 4.1 · Web-Created Dependent (Constituent Portal)
-
-1. Guardian uses `ConstituentPortal::DependentsController#create`
-2. Uses `UserServiceIntegration` concern for consistent user creation
-3. Flow: `create_user_with_service(params, is_managing_adult: false)` → handles password, disability validation
-4. Then: `create_guardian_relationship_with_service(guardian, dependent, relationship_type)` → creates GuardianRelationship
-5. Application creation happens separately when dependent applies
-
-### 4.2 · Admin Paper Application
-
-Handled by `Applications::PaperApplicationService` with `GuardianDependentManagementService`:
+Factory patterns:
 
 ```ruby
-Current.paper_context = true
-begin
-  # PaperApplicationService.process_guardian_dependent calls:
-  # GuardianDependentManagementService.process_guardian_scenario
-  # - Sets up guardian (existing or new)
-  # - Creates dependent with contact strategies
-  # - Creates GuardianRelationship
-  # - Creates Application with managing_guardian_id set
-ensure
-  Current.paper_context = nil
-end
+create(:guardian_relationship)
+create(:guardian_relationship, :legal_guardian)
+create(:guardian_relationship, :caretaker)
+
+create(:constituent, :with_dependents)
+create(:constituent, :with_guardian)
 ```
 
-Supports both new & existing guardians. Uses contact strategies (email_strategy, phone_strategy, address_strategy) to handle dependent contact information.
+Use `GuardianRelationship` before creating dependent applications unless the service under test is responsible for creating the relationship.
 
----
+For paper-flow tests, `Applications::PaperApplicationService` sets `Current.paper_context` itself. Tests that call lower-level proof, model, or service paths directly should set `Current.paper_context` or use the paper context helpers as the surrounding tests do.
 
-## 5 · Database Constraints
+Useful coverage:
 
-* Unique composite index on `(guardian_id, dependent_id)` (implemented in GuardianRelationship model)
-* FK constraints on both IDs with proper inverse_of associations
-* `managing_guardian_id` nullable in applications table
-* Proper dependent: :destroy and dependent: :nullify for data integrity
+- `test/controllers/constituent_portal/dependents_controller_test.rb`
+- `test/controllers/constituent_portal/applications_controller_test.rb`
+- `test/services/applications/guardian_dependent_management_service_test.rb`
+- `test/services/applications/dependent_email_handling_test.rb`
+- `test/system/admin_guardian_management_test.rb`
+- `test/services/applications/paper_application_service_test.rb`
 
-## 6 · Service Integration
+Related docs:
 
-### UserServiceIntegration Concern
-
-Controllers use `UserServiceIntegration` concern for consistent user and relationship creation:
-
-```ruby
-# Used in ConstituentPortal::DependentsController and Admin::GuardianRelationshipsController
-create_user_with_service(user_params, is_managing_adult: false)
-create_guardian_relationship_with_service(guardian, dependent, relationship_type)
-```
-
-### GuardianDependentManagementService
-
-Handles complex guardian/dependent scenarios in paper applications:
-
-```ruby
-# Contact strategies determine how dependent contact info is handled
-service = GuardianDependentManagementService.new(params)
-service.process_guardian_scenario(guardian_id, new_guardian_attrs, applicant_data, relationship_type)
-```
-
----
-
-## 7 · Testing Patterns
-
-```ruby
-# Factory patterns (test/factories/guardian_relationships.rb)
-create(:guardian_relationship)                    # Basic relationship
-create(:guardian_relationship, :legal_guardian)   # Specific relationship type
-create(:guardian_relationship, :dependent_shares_contact)  # Shared contact info
-
-# User factory traits
-create(:constituent, :with_dependents)           # Guardian with dependents
-create(:constituent, :with_guardians)            # Dependent with guardians
-```
-
-*Always*:
-
-1. Build `GuardianRelationship` before dependent apps
-2. Set `Current.paper_context = true` in paper-flow tests
-3. Assert both `user_id` and `managing_guardian_id`
-4. Use appropriate factory traits for different contact scenarios
-
-Example:
-
-```ruby
-test 'dependent app sets guardian' do
-  service = PaperApplicationService.new(params:, admin: @admin)
-  assert_difference ['GuardianRelationship.count', 'Application.count'] do
-    assert service.create
-  end
-  app = service.application
-  assert app.for_dependent?
-  assert_equal service.guardian_user_for_app.id, app.managing_guardian_id
-end
-```
+- [Paper application architecture](paper_application_architecture.md)
+- [Application workflow guide](../features/application_workflow_guide.md)
+- [Email uniqueness for dependents](../features/email_uniqueness_for_dependents.md)

--- a/docs/features/email_uniqueness_for_dependents.md
+++ b/docs/features/email_uniqueness_for_dependents.md
@@ -1,122 +1,80 @@
 # Dependent Contact Information Handling
 
-This document outlines how the system handles dependent contact information (email and phone) to maintain database integrity and avoid uniqueness constraint violations.
+This document describes how MAT Vulcan stores and resolves contact information for dependents without violating unique email and phone constraints.
 
-## Context
+## High-Level Flow
 
-To support cases where dependents share contact information with their guardians, the system must accommodate non-unique emails and phone numbers without violating database constraints. The architecture is designed to clearly distinguish between a dependent's own contact information and shared guardian information.
+1. A guardian or admin enters dependent contact information.
+2. The controller decides the contact strategy for email and phone. On portal create and paper intake, that can come from checkboxes or direct strategy params. On portal edit, the form has no checkboxes — the app infers the strategy from what was submitted (blank contact, contact matching the guardian, or the dependent's own contact).
+3. `Applications::GuardianDependentManagementService` applies those strategies before creating a new dependent, or before updating one when email or phone was submitted. If a contact field was not submitted, the service leaves that field alone.
+4. `Applications::UserCreationService` creates or reuses the constituent record, depending on the entry point.
+5. `GuardianRelationship` connects the guardian and dependent.
+6. Mailers, notification builders, secure request resolution, and admin lookup endpoints use effective contact helpers or `dependent_email` fallback when choosing recipients.
 
-## Architecture
+## Main Entry Points
 
-The system uses dedicated contact fields for dependents to provide a flexible and robust solution.
+| Area | Path | Current behavior |
+|------|------|------------------|
+| Portal dependent creation and update | `app/controllers/constituent_portal/dependents_controller.rb` | On `create`, strategy comes from `use_guardian_email` / `use_guardian_phone` checkboxes; blank contact also uses guardian strategy. Portal-created dependents always use `skip_user_lookup: true`. On `update`, strategies run only when email or phone was submitted — a name-only PATCH leaves stored contact alone. Submitted contact that matches the guardian's email or phone also uses guardian strategy (generated primary contact plus real contact in `dependent_email` / `dependent_phone`). |
+| Admin paper intake | `app/controllers/admin/paper_applications_controller.rb` | `create` permits direct strategy params and guardian-contact checkboxes, then passes normalized params to the paper application service. For an existing dependent, the service updates submitted contact fields directly from `dependent_email` and `dependent_phone` aliases instead of reapplying strategy params. |
+| Strategy application | `app/services/applications/guardian_dependent_management_service.rb` | Applies email, phone, and address strategies when creating a dependent or when a portal update submits contact fields. When a strategy is `nil` for a field, that field is not rewritten. |
+| User creation | `app/services/applications/user_creation_service.rb` | Creates constituent records and, unless `skip_user_lookup` is true, may reuse an existing user by primary email or phone. System email addresses are not used for lookup. |
+| Model behavior | `app/models/concerns/user_profile.rb`, `app/models/concerns/user_guardianship.rb` | Encrypts and validates dependent contact fields, then resolves effective contact values through guardian relationships. |
+| Mail delivery | `app/mailers/application_mailer.rb`, `app/services/notifications/parameter_normalization_service.rb` | Uses `effective_email` and `effective_communication_preference` when available. Letter delivery for dependents is addressed to `guardian_for_contact`. |
+| Lookup and secure requests | `app/controllers/admin/paper_applications_controller.rb`, `app/models/concerns/user_email_search.rb`, `app/services/applications/secure_request_recipient_resolver.rb` | Admin recipient preference lookup checks primary email first, then `dependent_email`. User email search indexes both `email` and `dependent_email`; dependents without their own `dependent_email` can be found through linked guardian email tokens. Secure request defaults use the managing guardian when the dependent's effective email matches that guardian. |
 
-**Approach**: Dependents have separate `dependent_email` and `dependent_phone` fields. This allows them to either have their own unique contact information or share their guardian's contact information without causing database conflicts.
+## Key Concepts
 
-## Implementation Details
+| Concept | Meaning |
+|---------|---------|
+| Primary contact fields | `users.email` and `users.phone`. These remain unique and are still required by user creation. |
+| Dependent contact fields | `users.dependent_email` and `users.dependent_phone`. Encrypted fields for the dependent's real contact. They are searchable but are not held to the same uniqueness rules as primary `email` and `phone`. |
+| Guardian strategy | Stores guardian contact in the dependent contact field and assigns a generated unique primary contact value to avoid uniqueness conflicts. |
+| Dependent strategy | Uses the dependent's submitted contact as both the primary contact and dependent contact field. If the submitted contact is blank, the strategy service falls back to guardian contact. |
+| Managing guardian | The guardian responsible for a dependent application. See `docs/development/guardian_relationship_system.md`. |
 
-### 1. Database Schema
+> Important distinction: contact strategies are request-time params. The app does not currently persist `email_strategy` or `phone_strategy` columns on users or guardian relationships. There is also no flag to skip uniqueness validation — shared contact is handled by storing the real address in `dependent_email` / `dependent_phone` and generating unique primary values when needed.
 
-The `users` table includes dedicated contact fields for dependents to avoid uniqueness conflicts:
+## Current Behavior
 
-- `dependent_email` (string): An optional, indexed field for the dependent's own email. If blank, communications default to the guardian's email.
-- `dependent_phone` (string): An optional, indexed field for the dependent's own phone number.
+### Email
 
-**Key Design Points:**
-- Avoids uniqueness constraint violations on the primary `email` and `phone` columns.
-- Provides a clear separation between a primary user's contact info and a dependent's.
-- Ensures database integrity and query performance with indexes.
-- Allows for flexible contact information handling.
+- With `email_strategy: "guardian"`, the dependent gets a generated primary email like `dependent-{uuid}@system.matvulcan.local`, and `dependent_email` is set to the guardian's email when the guardian has one.
+- With `email_strategy: "dependent"`, the submitted dependent email is normalized into both `email` and `dependent_email`.
+- If `email_strategy` is omitted (`nil`), the service leaves email fields unchanged. This is how partial portal updates avoid rewriting contact.
+- Invalid strategy values, or a blank email under the dependent strategy, fall back to guardian strategy.
+- On portal `update`, a submitted blank email also uses guardian strategy and generates a new primary email. Omitted email (not in the request) is left alone.
+- Portal `update` also uses guardian strategy when the submitted email matches the guardian's email (after normalization).
+- `UserGuardianship#effective_email` returns `dependent_email` for dependents when present. If it is blank and a guardian relationship exists, it falls back to `guardian_for_contact.email`. Otherwise it returns the user's primary `email`.
 
-### 2. Model Logic
+### Phone
 
-The `User` model includes logic to manage dependent-specific contact information through the `UserProfile` and `UserGuardianship` concerns:
+- With `phone_strategy: "guardian"`, the dependent gets a generated primary phone like `000-000-1234`, and `dependent_phone` is set to the guardian's phone.
+- With `phone_strategy: "dependent"`, the submitted dependent phone is normalized into both `phone` and `dependent_phone`.
+- If `phone_strategy` is omitted (`nil`), the service leaves phone fields unchanged.
+- Invalid strategy values, or a blank phone under the dependent strategy, fall back to guardian strategy.
+- On portal `update`, a submitted blank phone also uses guardian strategy and generates a new primary phone. Omitted phone (not in the request) is left alone.
+- Portal `update` also uses guardian strategy when the submitted phone matches the guardian's phone (after normalization).
+- `UserGuardianship#effective_phone` returns `dependent_phone` for dependents when present. If it is blank and a guardian relationship exists, it falls back to `guardian_for_contact.phone`. Otherwise it returns the user's primary `phone`.
+- `UserGuardianship#effective_phone_type` returns the guardian's phone type when the dependent is using the guardian's phone, including when `dependent_phone` normalizes to the guardian's phone. Otherwise it returns the dependent user's `phone_type`.
 
-- **Encryption**: The `dependent_email` and `dependent_phone` fields are encrypted using `encrypts` (implemented in `UserProfile` concern).
-- **Validation**: The model validates the format of `dependent_email` and `dependent_phone` (implemented in `UserProfile` concern).
-- **Helper Methods** (implemented in `UserGuardianship` concern):
-  - `effective_email`: Returns the dependent's own email if present, otherwise falls back to the guardian's email via `guardian_for_contact`.
-  - `effective_phone`: Returns the dependent's own phone if present, otherwise falls back to the guardian's phone via `guardian_for_contact`.
-  - `effective_phone_type`: Handles phone type logic for dependents.
-  - `effective_communication_preference`: Uses guardian's preference if user is a dependent.
-  - `guardian_for_contact`: Returns the primary guardian for contact purposes.
+### Communication Preference And Locale
 
-**Note**: The `has_own_contact_info?` and `uses_guardian_contact_info?` methods mentioned in earlier documentation are not currently implemented in the codebase.
+- `effective_communication_preference` returns the guardian's communication preference for dependents with a contact guardian.
+- `effective_locale` returns the guardian's locale only when a dependent's effective email is the guardian's email. Otherwise it returns the dependent user's locale.
+- `ApplicationMailer#letter_recipient_for` sends printed letters for dependents to `guardian_for_contact` when one exists.
 
-The implementation provides a clear and secure way to handle different contact scenarios for dependents.
+## Verified Test Coverage
 
-### 3. Paper Application Service
+| Test | Coverage |
+|------|----------|
+| `test/services/applications/dependent_email_handling_test.rb` | Paper application service behavior for guardian email, dependent email, and guardian phone type resolution. |
+| `test/services/applications/guardian_dependent_management_service_test.rb` | Failure result handling for missing guardian information, invalid guardian IDs, and missing relationship type. |
+| `test/controllers/admin/paper_applications_controller_test.rb` | Admin paper application creation for dependents with new or existing guardians, own email, guardian email, locale persistence, and recipient lookup by `dependent_email`. |
+| `test/controllers/constituent_portal/dependents_controller_test.rb` | Portal dependent creation, guardian email fallback, validation failures, forced creation of a new dependent user, contact-sharing update, and partial-update contact preservation. |
 
-The paper application service (via `GuardianDependentManagementService`) uses contact strategy parameters (`email_strategy`, `phone_strategy`, `address_strategy`) to determine how to handle a dependent's contact information. This approach avoids complex checkbox logic and validation bypasses.
+## Related Docs
 
-- **Strategy-Based Logic**: The service checks the strategy parameters in `apply_contact_strategies` method:
-  - If the strategy is `'guardian'`, the dependent is assigned the guardian's contact information, and a system-generated unique primary email/phone is created to satisfy database constraints (e.g., `dependent-{uuid}@system.matvulcan.local`).
-  - If the strategy is `'dependent'`, the service uses the provided dependent-specific contact information.
-  - If the strategy is not specified, it defaults to guardian strategy with fallback logic.
-- **Address Strategy**: Also handles address information copying from guardian to dependent.
-- **Maintainability**: This design results in cleaner, more maintainable code with clear fallback logic and proper error handling.
-
-### 4. Testing
-
-The test suite covers the contact strategy implementation through factory patterns and service tests:
-
-- **Factory Traits** (`test/factories/guardian_relationships.rb`):
-  - `:dependent_shares_contact` - Sets dependent to use guardian's contact info
-  - Various phone type traits (`:dependent_with_voice_phone`, `:dependent_with_videophone`, etc.)
-
-- **Service Testing** - Tests cover:
-  - Scenarios for a dependent having their own email and phone (`email_strategy: 'dependent'`)
-  - Scenarios for a dependent sharing a guardian's email (`email_strategy: 'guardian'`)
-  - Mixed scenarios (e.g., own email, guardian's phone)
-  - Address strategy handling
-  - Proper encryption and validation of dependent contact fields
-  - Fallback logic for when dependent contact information is left blank
-  - System-generated unique emails for constraint avoidance
-
-## Usage Patterns
-
-### Scenario 1: Dependent has their own contact information
-```ruby
-dependent = User.create!(
-  first_name: "Child",
-  email: "child@example.com",
-  phone: "555-0001",
-  dependent_email: "child@example.com",  # Same as primary email
-  dependent_phone: "555-0001"            # Same as primary phone
-)
-
-dependent.effective_email  # => "child@example.com"
-dependent.effective_phone  # => "555-0001"
-# Note: has_own_contact_info? method not currently implemented
-```
-
-### Scenario 2: Dependent shares guardian's contact information
-```ruby
-dependent = User.create!(
-  first_name: "Child",
-  email: "dependent-abc123@system.matvulcan.local",  # System-generated
-  phone: "000-000-1234",                             # System-generated
-  dependent_email: "guardian@example.com",           # Guardian's email
-  dependent_phone: "555-0002"                        # Guardian's phone
-)
-
-dependent.effective_email  # => "guardian@example.com"
-dependent.effective_phone  # => "555-0002"
-# Note: uses_guardian_contact_info? method not currently implemented
-```
-
-## Current Implementation Status
-
-The system currently implements:
-- ✅ Encrypted `dependent_email` and `dependent_phone` fields
-- ✅ Contact strategy handling in `GuardianDependentManagementService`
-- ✅ `effective_email`, `effective_phone`, `effective_phone_type`, `effective_communication_preference` methods
-- ✅ Factory patterns for testing different contact scenarios
-- ✅ Proper uniqueness constraint handling with system-generated fallback emails
-
-## Future Enhancements
-
-- Implement missing helper methods: `has_own_contact_info?` and `uses_guardian_contact_info?`
-- Update frontend forms to properly handle dependent contact field selection
-- Add an admin interface for managing dependent contact preferences
-- Consider extending this pattern to other contact fields (e.g., emergency contacts)
-- Improve contact strategy UI in paper application forms
+- `docs/development/guardian_relationship_system.md`
+- `docs/development/paper_application_architecture.md`
+- `docs/features/application_workflow_guide.md`

--- a/test/controllers/constituent_portal/dependents_controller_test.rb
+++ b/test/controllers/constituent_portal/dependents_controller_test.rb
@@ -252,6 +252,68 @@ module ConstituentPortal
       assert_equal 'updated.dependent@example.com', changes['email']['new']
     end
 
+    test 'should update dependent when submitted contact matches guardian contact' do
+      patch constituent_portal_dependent_path(@dependent), params: {
+        dependent: {
+          first_name: 'Shared Contact',
+          email: @guardian.email,
+          phone: @guardian.phone
+        }
+      }
+
+      assert_redirected_to constituent_portal_dashboard_path
+      assert_equal 'Dependent was successfully updated.', flash[:notice]
+
+      @dependent.reload
+      assert_equal 'Shared Contact', @dependent.first_name
+      assert_match(/\Adependent-.*@system\.matvulcan\.local\z/, @dependent.email)
+      assert_equal @guardian.email, @dependent.dependent_email
+      assert_equal @guardian.phone, @dependent.dependent_phone
+    end
+
+    test 'should preserve contact fields on partial update without submitted email or phone' do
+      original_email = @dependent.email
+      original_phone = @dependent.phone
+      original_dependent_email = @dependent.dependent_email
+      original_dependent_phone = @dependent.dependent_phone
+
+      patch constituent_portal_dependent_path(@dependent), params: {
+        dependent: {
+          first_name: 'Test Update'
+        }
+      }
+
+      assert_redirected_to constituent_portal_dashboard_path
+      assert_equal 'Dependent was successfully updated.', flash[:notice]
+
+      @dependent.reload
+      assert_equal 'Test Update', @dependent.first_name
+      assert_equal original_email, @dependent.email
+      assert_equal original_phone, @dependent.phone
+      assert_equal original_dependent_email, @dependent.dependent_email
+      assert_equal original_dependent_phone, @dependent.dependent_phone
+    end
+
+    test 'should preserve phone on partial update when only email is submitted' do
+      original_phone = @dependent.phone
+      original_dependent_phone = @dependent.dependent_phone
+      new_email = 'only.email.updated@example.com'
+
+      patch constituent_portal_dependent_path(@dependent), params: {
+        dependent: {
+          email: new_email
+        }
+      }
+
+      assert_redirected_to constituent_portal_dashboard_path
+
+      @dependent.reload
+      assert_equal new_email, @dependent.email
+      assert_equal new_email, @dependent.dependent_email
+      assert_equal original_phone, @dependent.phone
+      assert_equal original_dependent_phone, @dependent.dependent_phone
+    end
+
     test 'should set Current.user before update' do
       # Verify Current.user is set during the request
       DependentsController.any_instance.expects(:set_current_user).once

--- a/test/services/applications/guardian_dependent_management_service_test.rb
+++ b/test/services/applications/guardian_dependent_management_service_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Applications
+  class GuardianDependentManagementServiceTest < ActiveSupport::TestCase
+    setup do
+      @guardian = create(:constituent, email: 'guardian@example.com', phone: '410-555-0100')
+    end
+
+    test 'process_guardian_scenario returns failure result when guardian information is missing' do
+      service = GuardianDependentManagementService.new(
+        email_strategy: 'guardian',
+        phone_strategy: 'guardian',
+        address_strategy: 'dependent'
+      )
+
+      result = service.process_guardian_scenario(
+        nil,
+        {},
+        { first_name: 'Child', last_name: 'User', date_of_birth: '2015-01-01', hearing_disability: true },
+        'Parent'
+      )
+
+      assert_not result.success?
+      assert_equal 'Failed to setup guardian', result.message
+      assert_includes result.data[:errors], 'Guardian information missing'
+      assert_includes service.errors, 'Guardian information missing'
+    end
+
+    test 'process_guardian_scenario returns failure result when guardian id is invalid' do
+      service = GuardianDependentManagementService.new(
+        email_strategy: 'guardian',
+        phone_strategy: 'guardian',
+        address_strategy: 'dependent'
+      )
+
+      result = service.process_guardian_scenario(
+        -1,
+        {},
+        { first_name: 'Child', last_name: 'User', date_of_birth: '2015-01-01', hearing_disability: true },
+        'Parent'
+      )
+
+      assert_not result.success?
+      assert_equal 'Failed to setup guardian', result.message
+      assert_includes result.data[:errors], 'Guardian not found'
+    end
+
+    test 'process_guardian_scenario returns failure result when relationship type is missing' do
+      service = GuardianDependentManagementService.new(
+        email_strategy: 'guardian',
+        phone_strategy: 'guardian',
+        address_strategy: 'dependent'
+      )
+
+      result = service.process_guardian_scenario(
+        @guardian.id,
+        {},
+        { first_name: 'Child', last_name: 'User', date_of_birth: '2015-01-01', hearing_disability: true },
+        nil
+      )
+
+      assert_not result.success?
+      assert_equal 'Failed to create relationship', result.message
+      assert(result.data[:errors].any? { |error| error.include?('Relationship type required') })
+    end
+  end
+end


### PR DESCRIPTION
Updated guardian_relationship_system.md and email_uniqueness_for_dependents which led to the discovery of two serious bugs, which are fixed in this PR:

- fixed bug that would cause any guardian updating a dependent record sharing the guardian's email/phone to hit a NoMethodError
- fixed a bug that would cause paper intake failures to 500 and lose validation feedback (this may explain why Alejandro was seeing info disappear after hitting submit)

- updated tests for better coverage
- both docs are updated to reflect our recent work 