### PR TITLE
Simplify recipients help text

### DIFF
--- a/app/views/admin/applications/_secure_request_forms.html.erb
+++ b/app/views/admin/applications/_secure_request_forms.html.erb
@@ -18,12 +18,6 @@
 <% elsif @provider_info_recipient_options.present? %>
   <%= form_with url: admin_application_secure_request_forms_path(@application), method: :post, local: true, data: { turbo: false }, class: "mb-6 space-y-4" do |form| %>
     <fieldset>
-      <legend class="text-sm font-medium text-gray-900 mb-2">
-        <%= t('admin.applications.secure_request_forms.panel.recipients') %>
-      </legend>
-      <p class="text-xs text-gray-600 mb-3">
-        <%= t('admin.applications.secure_request_forms.panel.recipient_help') %>
-      </p>
 
       <div class="space-y-3">
         <% @provider_info_recipient_options.each do |option| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -395,7 +395,7 @@ en:
           title: "Secure provider information requests"
           description: "Send a secure link for entering certifying professional contact information."
           recipients: "Recipients"
-          recipient_help: "Managing guardian, dependent/applicant, and recorded guardians are authorized application relationships. The default follows the dependent's effective email path; other recorded guardians receive secure links only when explicitly selected. Alternate contacts are informational only and do not receive secure links."
+          recipient_help: "Select who will receive the secure link."
           default_channel: "Default channel: %{channel}"
           email_override: "Send secure online link by email instead"
           submit: "Send secure request"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -394,8 +394,6 @@ en:
         panel:
           title: "Secure provider information requests"
           description: "Send a secure link for entering certifying professional contact information."
-          recipients: "Recipients"
-          recipient_help: "Select who will receive the secure link."
           default_channel: "Default channel: %{channel}"
           email_override: "Send secure online link by email instead"
           submit: "Send secure request"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -168,7 +168,7 @@ es:
           title: "Solicitudes seguras de información del proveedor"
           description: "Envíe un enlace seguro para ingresar información de contacto del profesional certificador."
           recipients: "Destinatarios"
-          recipient_help: "El tutor principal, la persona dependiente/solicitante y los tutores registrados son relaciones autorizadas de la solicitud. El valor predeterminado sigue la ruta de correo efectiva de la persona dependiente; otros tutores registrados reciben enlaces seguros solo cuando se seleccionan explícitamente. Los contactos alternativos son solo informativos y no reciben enlaces seguros."
+          recipient_help: "Seleccione quién recibirá el enlace seguro."
           default_channel: "Canal predeterminado: %{channel}"
           email_override: "Enviar enlace seguro en línea por correo electrónico"
           submit: "Enviar solicitud segura"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -167,8 +167,6 @@ es:
         panel:
           title: "Solicitudes seguras de información del proveedor"
           description: "Envíe un enlace seguro para ingresar información de contacto del profesional certificador."
-          recipients: "Destinatarios"
-          recipient_help: "Seleccione quién recibirá el enlace seguro."
           default_channel: "Canal predeterminado: %{channel}"
           email_override: "Enviar enlace seguro en línea por correo electrónico"
           submit: "Enviar solicitud segura"

--- a/test/controllers/admin/secure_request_forms_test.rb
+++ b/test/controllers/admin/secure_request_forms_test.rb
@@ -77,7 +77,7 @@ module Admin
       assert_response :success
       assert_select "input[name='recipient_ids[]'][value='#{dependent.id}'][checked]"
       assert_select "input[name='recipient_ids[]'][value='#{guardian.id}'][checked]", count: 0
-      assert_match(/authorized application relationships/, response.body)
+      assert_match(/receive the secure link/, response.body)
     end
 
     test 'show page defaults provider info recipient checkbox from resolver for guardian email path' do

--- a/test/controllers/admin/secure_request_forms_test.rb
+++ b/test/controllers/admin/secure_request_forms_test.rb
@@ -77,7 +77,6 @@ module Admin
       assert_response :success
       assert_select "input[name='recipient_ids[]'][value='#{dependent.id}'][checked]"
       assert_select "input[name='recipient_ids[]'][value='#{guardian.id}'][checked]", count: 0
-      assert_match(/receive the secure link/, response.body)
     end
 
     test 'show page defaults provider info recipient checkbox from resolver for guardian email path' do


### PR DESCRIPTION
- This help text was confusing and over-explained. Simplified
- Separate note: This seems to only be for medical information requests--do we not select recipients for secure upload forms? Do we know that admins would know to select or would it be easier to assume recipient?