### PR TITLE
Improve system test screenshots

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ gem 'aws-sdk-s3', '~> 1.217'
 gem 'bcrypt', '~> 3.1.22'
 # reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '~> 1.23', require: false
+# PNG parsing for system test screenshot blank-artifact detection
+gem 'chunky_png', '~> 1.4'
 # bundle and process CSS [https://github.com/rails/cssbundling-rails]
 gem 'cssbundling-rails', '~> 1.4', '>= 1.4.3'
 # DocuSeal API integration for digital document signing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,6 +518,7 @@ DEPENDENCIES
   bullet
   byebug (~> 13.0)
   capybara (~> 3.40)
+  chunky_png (~> 1.4)
   cssbundling-rails (~> 1.4, >= 1.4.3)
   cuprite (~> 0.17)
   database_cleaner-active_record

--- a/bin/run-test
+++ b/bin/run-test
@@ -10,7 +10,8 @@ echo "=============================================="
 # Set up special environment variables for debugging
 export DEBUG_AUTH=true
 export WEBDRIVER_TIMEOUT=15
-export CAPYBARA_SCREENSHOTS=true
+export RAILS_SYSTEM_TESTING_SCREENSHOT="${RAILS_SYSTEM_TESTING_SCREENSHOT:-simple}"
+export RAILS_SYSTEM_TESTING_SCREENSHOT_HTML="${RAILS_SYSTEM_TESTING_SCREENSHOT_HTML:-1}"
 
 # Display installed Chrome version (for informational purposes)
 chrome_version=$(google-chrome --version 2>/dev/null || chrome --version 2>/dev/null || echo "Unknown Chrome version")

--- a/docs/development/testing_and_debugging_guide.md
+++ b/docs/development/testing_and_debugging_guide.md
@@ -104,7 +104,13 @@ safe_fill_in('Field Label', with: 'value')  # Clears field before filling
 # Debugging
 assert_notification(text, type: nil)
 take_screenshot
+take_screenshot('meaningful-step', html: true)
 ```
+
+System screenshots are saved under `tmp/capybara` with a JSON sidecar next to each PNG. The sidecar includes browser URL,
+title, readiness details, meaningful page anchors, blank/solid-color analysis, and `artifact_usable_for_llm_qa`.
+Use named screenshots for LLM QA checkpoints. `bin/run-test` enables Rails HTML companions with
+`RAILS_SYSTEM_TESTING_SCREENSHOT_HTML=1`.
 
 ## 5. Common Issues & Solutions
 ### Authentication Issues
@@ -372,7 +378,7 @@ end
 1. Run tests in isolation
 2. Enable verbose mode (`VERBOSE_TESTS=1`)
 3. Use visual browser (`HEADLESS=false`)
-4. Add screenshots before assertions
+4. Add named screenshots before assertions
 5. Verify authentication state
 6. Check browser dev tools for JS errors
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/OneClassPerFile -- system test base co-locates helper modules by design.
+
 require 'test_helper'
+require 'json'
 require 'socket'
 require 'capybara/cuprite'
+begin
+  require 'chunky_png'
+rescue LoadError
+  # Blank screenshot detection is skipped when the PNG parser is unavailable.
+end
 begin
   require 'selenium/webdriver'
 rescue LoadError
@@ -452,22 +460,53 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     Application.skip_wait_period_validation = original_value
   end
 
-  # Override Rails' take_screenshot to provide logging and handle optional name parameter
-  def take_screenshot(_name = nil)
+  # Keep Rails 8 keyword support while preserving the repo's named screenshot calls.
+  def take_screenshot(name = nil, html: false, screenshot: nil)
     return nil unless page&.driver
 
-    # Use Rails' built-in screenshot functionality (ignores name parameter)
-    path = super()
-    puts "📸 Screenshot saved: #{path}" if path
+    @screenshot_artifact_label = name.presence
+    wait_for_meaningful_page_content(timeout: 3) if respond_to?(:wait_for_meaningful_page_content)
+
+    super(html: html, screenshot: screenshot)
+    path = image_path
+    write_screenshot_sidecar(path, label: @screenshot_artifact_label, html_saved: screenshot_html_enabled?(html))
+    puts screenshot_log_message(path)
     path
   rescue StandardError => e
     puts "Failed to take screenshot: #{e.message}"
     nil
+  ensure
+    @screenshot_artifact_label = nil
+  end
+
+  def take_failed_screenshot
+    return unless failed? && supports_screenshot? && Capybara::Session.instance_created?
+
+    unless browser_page_visited?
+      puts "Skipping failure screenshot for #{self.class.name}##{name}: no browser page was visited"
+      return
+    end
+
+    super
+  end
+
+  def capture_browser_recovery_diagnostics(reason, error: nil)
+    return if @capturing_browser_recovery_diagnostics
+
+    @capturing_browser_recovery_diagnostics = true
+    detail = error ? "#{reason}: #{error.class} - #{error.message}" : reason
+    puts "Capturing browser diagnostics before recovery: #{detail}" if ENV['VERBOSE_TESTS'] || ENV['DEBUG_BROWSER']
+    take_screenshot("recovery-#{reason}", html: true)
+  rescue StandardError => e
+    puts "Failed to capture browser recovery diagnostics: #{e.message}" if ENV['VERBOSE_TESTS'] || ENV['DEBUG_BROWSER']
+  ensure
+    @capturing_browser_recovery_diagnostics = false
   end
 
   # Helper to manually restart browser when tests detect issues
   def restart_browser!
     puts '🔄 Manually restarting browser...'
+    capture_browser_recovery_diagnostics('manual_restart')
     hard_restart
   end
 
@@ -552,6 +591,156 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   private
+
+  # These methods intentionally extend Rails' private ScreenshotHelper internals
+  # so labels, sidecars, and Rails' own html:/screenshot: options share one artifact name.
+  def image_name
+    label = @screenshot_artifact_label
+    return super if label.blank?
+
+    sanitized_label = label.to_s.gsub(/[^\w]+/, '-').gsub(/^-|-$/, '').presence
+    "#{unique}_#{sanitized_label || method_name.gsub(/[^\w]+/, '-')}"[0...225]
+  end
+
+  def screenshot_html_enabled?(html_argument)
+    html_argument || ENV['RAILS_SYSTEM_TESTING_SCREENSHOT_HTML'] == '1'
+  end
+
+  def screenshot_sidecar_path
+    "#{absolute_path}.json"
+  end
+
+  def write_screenshot_sidecar(path, label:, html_saved:)
+    state = screenshot_browser_state
+    blank_analysis = analyze_screenshot_blankness(path)
+    unusable_reasons = screenshot_unusable_reasons(state, blank_analysis)
+
+    File.write(
+      screenshot_sidecar_path,
+      JSON.pretty_generate(
+        generated_at: Time.current.iso8601,
+        test_class: self.class.name,
+        test_name: name,
+        label: label,
+        artifact_usable_for_llm_qa: unusable_reasons.empty?,
+        unusable_reasons: unusable_reasons,
+        screenshot_path: path,
+        html_path: html_saved ? html_path : nil,
+        browser_state: state,
+        viewport_analysis: blank_analysis
+      )
+    )
+  rescue StandardError => e
+    puts "Failed to write screenshot sidecar: #{e.message}" if ENV['VERBOSE_TESTS'] || ENV['DEBUG_BROWSER']
+  end
+
+  def screenshot_log_message(path)
+    sidecar = screenshot_sidecar_path
+    return "Screenshot saved: #{path} (sidecar: #{sidecar})" unless File.exist?(sidecar)
+
+    sidecar_json = JSON.parse(File.read(sidecar))
+    return "Screenshot saved: #{path} (sidecar: #{sidecar})" if sidecar_json['artifact_usable_for_llm_qa']
+
+    reasons = Array(sidecar_json['unusable_reasons']).join(', ')
+    "Screenshot saved but marked QA-unusable: #{path} (#{reasons}; sidecar: #{sidecar})"
+  rescue StandardError
+    "Screenshot saved: #{path}"
+  end
+
+  def screenshot_browser_state
+    page.evaluate_script(<<~JS, meaningful_page_content_selector)
+      (function(selector) {
+        var meaningfulMatches = [];
+        try {
+          meaningfulMatches = Array.prototype.slice.call(document.querySelectorAll(selector)).map(function(element) {
+            return {
+              tag: element.tagName.toLowerCase(),
+              id: element.id || null,
+              testid: element.getAttribute("data-testid"),
+              text: (element.innerText || element.textContent || "").trim().slice(0, 120)
+            };
+          }).slice(0, 10);
+        } catch (error) {}
+
+        return {
+          url: window.location.href,
+          path: window.location.pathname,
+          title: document.title,
+          ready_state: document.readyState,
+          has_body: !!document.body,
+          body_text_length: document.body ? (document.body.innerText || "").trim().length : 0,
+          meaningful_selector: selector,
+          meaningful_match_count: meaningfulMatches.length,
+          meaningful_matches: meaningfulMatches
+        };
+      })(arguments[0]);
+    JS
+  rescue StandardError => e
+    {
+      url: safe_current_browser_url,
+      path: nil,
+      title: nil,
+      ready_state: nil,
+      has_body: false,
+      body_text_length: 0,
+      meaningful_selector: meaningful_page_content_selector,
+      meaningful_match_count: 0,
+      meaningful_matches: [],
+      error: "#{e.class}: #{e.message}"
+    }
+  end
+
+  def screenshot_unusable_reasons(state, blank_analysis)
+    reasons = []
+    reasons << 'about_blank_url' if state[:url] == 'about:blank' || state['url'] == 'about:blank'
+    reasons << 'no_meaningful_content_anchor' if (state[:meaningful_match_count] || state['meaningful_match_count']).to_i.zero?
+    reasons << 'empty_body_text' if (state[:body_text_length] || state['body_text_length']).to_i.zero?
+    reasons << 'solid_color_viewport' if blank_analysis[:solid_color] || blank_analysis['solid_color']
+    reasons
+  end
+
+  def analyze_screenshot_blankness(path)
+    return { solid_color: nil, reason: 'image_missing' } if path.blank? || !File.exist?(path)
+    return { solid_color: nil, reason: 'chunky_png_unavailable' } unless defined?(ChunkyPNG)
+
+    image = ChunkyPNG::Image.from_file(path)
+    colors = sampled_png_colors(image)
+
+    {
+      solid_color: colors.size <= 2,
+      sampled_color_count: colors.size,
+      width: image.width,
+      height: image.height
+    }
+  rescue StandardError => e
+    { solid_color: nil, reason: "#{e.class}: #{e.message}" }
+  end
+
+  def sampled_png_colors(image)
+    x_step = [(image.width / 32.0).ceil, 1].max
+    y_step = [(image.height / 32.0).ceil, 1].max
+    colors = {}
+
+    (0...image.height).step(y_step) do |y|
+      (0...image.width).step(x_step) do |x|
+        colors[image[x, y]] = true
+        return colors if colors.size > 2
+      end
+    end
+
+    colors
+  end
+
+  def browser_page_visited?
+    url = safe_current_browser_url
+    url.present? && url != 'about:blank'
+  end
+
+  def safe_current_browser_url
+    page.current_url
+  rescue StandardError
+    nil
+  end
 
   # ============================================================================
   # CHROME PROCESS MANAGEMENT
@@ -722,8 +911,10 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     end
   end
 
-  def force_browser_restart(_reason)
+  def force_browser_restart(reason)
     # Minimal reset; do not kill external Chrome processes
+    capture_browser_recovery_diagnostics(reason)
     capybara_session_cleanup
   end
 end
+# rubocop:enable Style/OneClassPerFile

--- a/test/support/system_test_helpers.rb
+++ b/test/support/system_test_helpers.rb
@@ -6,6 +6,27 @@
 AuditEvent = Event unless defined?(AuditEvent)
 
 module SystemTestHelpers
+  def meaningful_page_content_selector
+    'main, [role="main"], h1, [data-testid], form[action], header nav'
+  end
+
+  # Wait for content that is useful in a screenshot, not just a non-empty DOM shell.
+  def wait_for_meaningful_page_content(timeout: 5, selector: meaningful_page_content_selector)
+    return false unless page&.driver
+    return false if page.current_url == 'about:blank'
+
+    wait_for_turbo(timeout: [timeout, 1].min)
+    page.has_selector?(selector, wait: timeout)
+  rescue StandardError
+    false
+  end
+
+  def capture_before_browser_recovery(reason, error = nil)
+    return unless respond_to?(:capture_browser_recovery_diagnostics, true)
+
+    capture_browser_recovery_diagnostics(reason, error: error)
+  end
+
   # Waits for Turbo and DOM to be stable.
   # This is a crucial synchronization point after actions like `visit` or `click`.
   def wait_for_page_stable(timeout: 10)
@@ -14,6 +35,7 @@ module SystemTestHelpers
     # Use Capybara's native wait mechanism - assert_selector already waits
     # Do NOT wrap in using_wait_time (causes double-waiting anti-pattern)
     assert_selector 'body', wait: timeout
+    wait_for_meaningful_page_content(timeout: [timeout, 3].min)
     true
   rescue Ferrum::NodeNotFoundError, Ferrum::DeadBrowserError => e
     puts "Warning: wait_for_page_stable failed due to browser corruption: #{e.message}"
@@ -45,7 +67,6 @@ module SystemTestHelpers
 
   # Waits for browser to be ready after session reset
   # Uses Capybara's native waiting instead of arbitrary sleeps
-  # rubocop:disable Naming/PredicateMethod -- this is a wait helper, not a predicate
   def wait_for_browser_ready(timeout: 2)
     deadline = Time.current + timeout
     while Time.current < deadline
@@ -60,7 +81,6 @@ module SystemTestHelpers
     end
     false
   end
-  # rubocop:enable Naming/PredicateMethod
 
   # Ensures Stimulus is loaded and ready before proceeding with tests
   # Uses Capybara's built-in waiting instead of manual retry loops
@@ -110,7 +130,6 @@ module SystemTestHelpers
   end
 
   # Wait for FPL data to load - compatibility for income validation
-  # rubocop:disable Naming/PredicateMethod -- this is a wait helper, not a predicate
   def wait_for_fpl_data_to_load(timeout: Capybara.default_max_wait_time)
     controller_selector = "[data-controller*='income-validation']"
     controller_present = page.has_selector?(controller_selector, wait: timeout)
@@ -127,7 +146,6 @@ module SystemTestHelpers
     assert thresholds_loaded, 'FPL thresholds never populated on income validation controller'
     true
   end
-  # rubocop:enable Naming/PredicateMethod
 
   # Wait for JavaScript animations to complete
   # Note: _timeout parameter kept for compatibility but not currently used
@@ -235,10 +253,15 @@ module SystemTestHelpers
   def wait_until_dom_stable(timeout: Capybara.default_max_wait_time)
     # Check readyState in a single call - browsers complete this quickly
     ready = page.evaluate_script('document.readyState === "complete"')
-    return true if ready
+    if ready
+      wait_for_meaningful_page_content(timeout: [timeout, 3].min)
+      return true
+    end
 
     # If not ready, use has_selector to wait for body (implies DOM is usable)
-    page.has_selector?('body', wait: timeout)
+    body_present = page.has_selector?('body', wait: timeout)
+    wait_for_meaningful_page_content(timeout: [timeout, 3].min) if body_present
+    body_present
   rescue Ferrum::NodeNotFoundError, Ferrum::DeadBrowserError => e
     puts "Warning: DOM stability check failed: #{e.message}" if ENV['VERBOSE_TESTS']
     false
@@ -635,6 +658,7 @@ module SystemTestHelpers
         puts "Navigation retry #{retries}/#{max_retries}: #{e.message}" if ENV['VERBOSE_TESTS']
 
         # Reset browser state
+        capture_before_browser_recovery('visit_admin_application_with_retry', e)
         Capybara.reset_sessions!
 
         # Wait for browser to be ready using idiomatic Capybara approach

--- a/test/system/browser_test.rb
+++ b/test/system/browser_test.rb
@@ -8,9 +8,34 @@ class BrowserTest < ApplicationSystemTestCase
     visit root_path
 
     # Take a screenshot to verify the browser is running
-    take_screenshot
+    screenshot_path = take_screenshot('browser-home', html: true)
+    sidecar = screenshot_sidecar_for(screenshot_path)
+
+    assert_equal 'browser-home', sidecar.fetch('label')
+    assert_equal true, sidecar.fetch('artifact_usable_for_llm_qa')
+    assert_empty sidecar.fetch('unusable_reasons')
+    assert_path_exists sidecar.fetch('screenshot_path')
+    assert_path_exists sidecar.fetch('html_path')
 
     # If we got this far, Chrome for Testing is working!
     assert true, 'Chrome for Testing is configured correctly'
+  end
+
+  test 'blank browser screenshots are marked unusable for LLM QA' do
+    visit 'about:blank'
+
+    screenshot_path = take_screenshot('about-blank-check')
+    sidecar = screenshot_sidecar_for(screenshot_path)
+
+    assert_equal 'about-blank-check', sidecar.fetch('label')
+    assert_equal false, sidecar.fetch('artifact_usable_for_llm_qa')
+    assert_includes sidecar.fetch('unusable_reasons'), 'about_blank_url'
+    assert_includes sidecar.fetch('unusable_reasons'), 'empty_body_text'
+  end
+
+  private
+
+  def screenshot_sidecar_for(screenshot_path)
+    JSON.parse(File.read(screenshot_path.sub(/\.png\z/, '.json')))
   end
 end

--- a/test/system/vendor_portal/invoices_test.rb
+++ b/test/system/vendor_portal/invoices_test.rb
@@ -94,6 +94,7 @@ module VendorPortal
           puts "Network error during visit, retry #{retries}/#{max_retries}: #{e.message}" if ENV['VERBOSE_TESTS']
 
           # Reset session and try again
+          capture_before_browser_recovery('vendor_invoice_visit_with_retry', e) if respond_to?(:capture_before_browser_recovery)
           Capybara.reset_sessions!
           # Re-authenticate since we reset the session
           begin


### PR DESCRIPTION
- Preserve screenshot labels and keyword forwarding for easier finding while debugging
- Save HTML/JSON screenshot companions with blank-artifact detection so we don't waste time on blank screenshots
- Capture recovery diagnostics
- Expand tests