### PR TITLE
Drop income required flag in favor of vouchers_enabled

### DIFF
--- a/app/controllers/admin/paper_applications_controller.rb
+++ b/app/controllers/admin/paper_applications_controller.rb
@@ -165,7 +165,7 @@ module Admin
     helper_method :fpl_thresholds_json, :fpl_modifier_value
 
     def fpl_thresholds_json
-      return '{}' unless FeatureFlag.enabled?(:income_proof_required)
+      return '{}' unless FeatureFlag.income_proof_required?
 
       thresholds = (1..8).to_h do |size|
         result = IncomeThresholdCalculationService.call(size)
@@ -179,7 +179,7 @@ module Admin
     end
 
     def fpl_modifier_value
-      return 0 unless FeatureFlag.enabled?(:income_proof_required)
+      return 0 unless FeatureFlag.income_proof_required?
 
       result = IncomeThresholdCalculationService.call(1)
       if result.success?
@@ -190,7 +190,7 @@ module Admin
     end
 
     def reject_for_income
-      unless FeatureFlag.enabled?(:income_proof_required)
+      unless FeatureFlag.income_proof_required?
         redirect_to new_admin_paper_application_path, alert: 'Income rejection is not available when income collection is disabled.'
         return
       end
@@ -225,7 +225,7 @@ module Admin
     end
 
     def send_rejection_notification
-      unless FeatureFlag.enabled?(:income_proof_required)
+      unless FeatureFlag.income_proof_required?
         redirect_to admin_applications_path, alert: 'Income rejection is not available when income collection is disabled.'
         return
       end

--- a/app/controllers/constituent_portal/applications_controller.rb
+++ b/app/controllers/constituent_portal/applications_controller.rb
@@ -193,7 +193,7 @@ module ConstituentPortal
     helper_method :fpl_thresholds_json, :fpl_modifier_value
 
     def fpl_thresholds_json
-      return '{}' unless FeatureFlag.enabled?(:income_proof_required)
+      return '{}' unless FeatureFlag.income_proof_required?
 
       thresholds = (1..8).to_h do |size|
         result = IncomeThresholdCalculationService.call(size)
@@ -207,7 +207,7 @@ module ConstituentPortal
     end
 
     def fpl_modifier_value
-      return 0 unless FeatureFlag.enabled?(:income_proof_required)
+      return 0 unless FeatureFlag.income_proof_required?
 
       result = IncomeThresholdCalculationService.call(1)
       if result.success?

--- a/app/forms/application_form.rb
+++ b/app/forms/application_form.rb
@@ -285,7 +285,7 @@ class ApplicationForm
     if application&.persisted?
       application.income_proof_required?
     else
-      FeatureFlag.enabled?(:income_proof_required)
+      FeatureFlag.income_proof_required?
     end
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -602,7 +602,7 @@ class Application < ApplicationRecord
     if persisted?
       income_proof_required?
     else
-      FeatureFlag.enabled?(:income_proof_required)
+      FeatureFlag.income_proof_required?
     end
   end
 
@@ -746,7 +746,7 @@ class Application < ApplicationRecord
 
   def stamp_workflow_defaults!
     self.fulfillment_type = FeatureFlag.enabled?(:vouchers_enabled) ? :voucher : :equipment
-    self.income_proof_required = FeatureFlag.enabled?(:income_proof_required)
+    self.income_proof_required = FeatureFlag.income_proof_required?
   end
 
   def scrub_income_fields

--- a/app/models/concerns/proof_manageable.rb
+++ b/app/models/concerns/proof_manageable.rb
@@ -191,7 +191,7 @@ module ProofManageable
 
     # Check for attachment changes using Rails' built-in detection
     if respond_to?(:attachment_changes) && attachment_changes.present?
-      return (FeatureFlag.enabled?(:income_proof_required) && attachment_changes['income_proof'].present?) ||
+      return (FeatureFlag.income_proof_required? && attachment_changes['income_proof'].present?) ||
              attachment_changes['residency_proof'].present? ||
              attachment_changes['id_proof'].present?
     end
@@ -203,7 +203,7 @@ module ProofManageable
   def set_needs_review_timestamp
     return if @setting_review_timestamp
     return if Current.proof_attachment_service_context?
-    return unless (FeatureFlag.enabled?(:income_proof_required) && income_proof.attached?) || residency_proof.attached? || id_proof.attached?
+    return unless (FeatureFlag.income_proof_required? && income_proof.attached?) || residency_proof.attached? || id_proof.attached?
 
     @setting_review_timestamp = true
 

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -17,5 +17,11 @@ class FeatureFlag < ApplicationRecord
     def disable!(feature_name)
       find_or_initialize_by(name: feature_name.to_s).update!(enabled: false)
     end
+
+    # Income proof requirement is derived from the single `vouchers_enabled`
+    # flag. Income is required only when the voucher workflow is disabled.
+    def income_proof_required?
+      !enabled?(:vouchers_enabled)
+    end
   end
 end

--- a/app/services/applications/paper_application_service.rb
+++ b/app/services/applications/paper_application_service.rb
@@ -434,7 +434,7 @@ module Applications
 
     def validate_income_threshold(application_attrs)
       return true if @skip_income_validation
-      return true unless FeatureFlag.enabled?(:income_proof_required)
+      return true unless FeatureFlag.income_proof_required?
       return true unless income_proof_action_requires_income_validation?
 
       household_size = application_attrs[:household_size]
@@ -479,7 +479,7 @@ module Applications
       residency_action = params[:residency_proof_action]
 
       # Only consider income action when income collection is enabled
-      if FeatureFlag.enabled?(:income_proof_required)
+      if FeatureFlag.income_proof_required?
         return :awaiting_proof if income_action.in?(%w[none reject]) || residency_action.in?(%w[none reject])
       elsif residency_action.in?(%w[none reject])
         return :awaiting_proof

--- a/app/views/admin/paper_applications/new.html.erb
+++ b/app/views/admin/paper_applications/new.html.erb
@@ -72,7 +72,7 @@
       "applicant-type-adult-picker-outlet": "[data-controller='adult-picker']"
     }
     paper_form_data[:"applicant-type-adult-picker-outlet"] = "[data-controller='adult-picker']"
-    if FeatureFlag.enabled?(:income_proof_required)
+    if FeatureFlag.income_proof_required?
       paper_form_data[:"income-validation-fpl-thresholds-value"] = fpl_thresholds_json
       paper_form_data[:"income-validation-modifier-value"] = fpl_modifier_value
     else
@@ -774,7 +774,7 @@
           </div>
 
           <div class="p-6 space-y-8">
-            <% if FeatureFlag.enabled?(:income_proof_required) %>
+            <% if FeatureFlag.income_proof_required? %>
             <%# Income Proof Section %>
             <div data-controller="document-proof-handler" data-document-proof-handler-type-value="income">
               <h3 class="text-base font-semibold text-gray-900 mb-4 flex items-center gap-2">
@@ -1213,7 +1213,7 @@
           <%= link_to "Cancel", admin_applications_path,
               class: "inline-flex justify-center items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
 
-          <% if FeatureFlag.enabled?(:income_proof_required) %>
+          <% if FeatureFlag.income_proof_required? %>
           <%= button_tag type: "button",
               id: "rejection-button",
               class: "hidden inline-flex justify-center items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500",
@@ -1236,7 +1236,7 @@
     <% end %>
   </div>
 
-<% if FeatureFlag.enabled?(:income_proof_required) %>
+<% if FeatureFlag.income_proof_required? %>
 <%# ============================================================ %>
 <%# Rejection Modal %>
 <%# ============================================================ %>

--- a/app/views/constituent_portal/applications/new.html.erb
+++ b/app/views/constituent_portal/applications/new.html.erb
@@ -23,7 +23,7 @@
         autosave_edit_form_url_value: constituent_portal_application_path(':id'),
         autosave_edit_autosave_url_value: autosave_field_constituent_portal_application_path(':id')
       }
-        if FeatureFlag.enabled?(:income_proof_required)
+        if FeatureFlag.income_proof_required?
           new_app_form_data[:controller] = "income-validation #{new_app_form_data[:controller]}"
           new_app_form_data[:"income-validation-fpl-thresholds-value"] = fpl_thresholds_json
           new_app_form_data[:"income-validation-modifier-value"] = fpl_modifier_value
@@ -229,7 +229,7 @@
         <fieldset class="space-y-6 p-4 bg-gray-50 rounded">
           <legend class="text-lg font-medium text-gray-900">Required Documentation</legend>
 
-          <% if FeatureFlag.enabled?(:income_proof_required) %>
+          <% if FeatureFlag.income_proof_required? %>
           <!-- Income Verification Subsection -->
           <div class="space-y-4">
             <h3 class="text-base font-medium text-gray-900">Income Verification</h3>

--- a/db/migrate/20260622150000_drop_income_proof_required_feature_flag.rb
+++ b/db/migrate/20260622150000_drop_income_proof_required_feature_flag.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Removes the obsolete `income_proof_required` feature flag. Income proof
+# requirement is now derived from the single `vouchers_enabled` flag (income is
+# required only when vouchers are disabled), so the standalone flag is no longer
+# read anywhere in the application.
+class DropIncomeProofRequiredFeatureFlag < ActiveRecord::Migration[8.0]
+  def up
+    FeatureFlag.where(name: 'income_proof_required').delete_all
+  end
+
+  def down
+    FeatureFlag.find_or_create_by!(name: 'income_proof_required') do |f|
+      f.enabled = true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_04_172500) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_22_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -787,16 +787,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_172500) do
     t.index ["w9_rejections_count"], name: "index_users_on_w9_rejections_count", where: "((type)::text = 'Vendor'::text)"
     t.index ["w9_status"], name: "index_users_on_w9_status", where: "((type)::text = 'Vendor'::text)"
     t.index ["webauthn_id"], name: "index_users_on_webauthn_id", unique: true
-  end
-
-  create_table "user_email_search_tokens", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.string "token_digest", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
-    t.index ["token_digest"], name: "index_user_email_search_tokens_on_token_digest"
-    t.index ["user_id", "token_digest"], name: "index_user_email_search_tokens_on_user_id_and_token_digest", unique: true
-    t.index ["user_id"], name: "index_user_email_search_tokens_on_user_id"
   end
 
   create_table "vendor_secure_request_forms", force: :cascade do |t|

--- a/db/seeds/feature_flags.rb
+++ b/db/seeds/feature_flags.rb
@@ -3,9 +3,11 @@
 def seed_feature_flags
   puts 'Seeding feature flags...'
 
+  # `vouchers_enabled` is the single switch for the voucher fulfillment workflow.
+  # Income proof requirement is derived from it: income is NOT required when
+  # vouchers are enabled, and required when they are disabled.
   feature_flags = {
-    'vouchers_enabled' => false,
-    'income_proof_required' => true
+    'vouchers_enabled' => false
   }
 
   feature_flags.each do |name, enabled|

--- a/test/controllers/admin/paper_applications_controller_test.rb
+++ b/test/controllers/admin/paper_applications_controller_test.rb
@@ -978,7 +978,7 @@ module Admin
     end
 
     test 'reject_for_income is gated when income collection is disabled' do
-      FeatureFlag.find_by!(name: 'income_proof_required').update!(enabled: false)
+      FeatureFlag.enable!(:vouchers_enabled)
 
       post reject_for_income_admin_paper_applications_path, headers: default_headers, params: {
         first_name: 'John', last_name: 'Doe', email: 'john@example.com'
@@ -989,7 +989,7 @@ module Admin
     end
 
     test 'send_rejection_notification is gated when income collection is disabled' do
-      FeatureFlag.find_by!(name: 'income_proof_required').update!(enabled: false)
+      FeatureFlag.enable!(:vouchers_enabled)
 
       post send_rejection_notification_admin_paper_applications_path, headers: default_headers, params: {
         first_name: 'John', last_name: 'Doe', email: 'john@example.com',

--- a/test/models/application_workflow_predicates_test.rb
+++ b/test/models/application_workflow_predicates_test.rb
@@ -5,7 +5,6 @@ require 'test_helper'
 class ApplicationWorkflowPredicatesTest < ActiveSupport::TestCase
   def setup
     setup_paper_application_context
-    @income_flag = FeatureFlag.find_or_create_by!(name: 'income_proof_required') { |f| f.enabled = true }
     @vouchers_flag = FeatureFlag.find_or_create_by!(name: 'vouchers_enabled') { |f| f.enabled = false }
   end
 
@@ -13,7 +12,6 @@ class ApplicationWorkflowPredicatesTest < ActiveSupport::TestCase
 
   test 'stamp_workflow_defaults! sets equipment when vouchers_enabled is off' do
     @vouchers_flag.update!(enabled: false)
-    @income_flag.update!(enabled: true)
     app = create(:application, :in_progress)
     assert app.fulfillment_type_equipment?
     assert app.income_proof_required?
@@ -21,7 +19,6 @@ class ApplicationWorkflowPredicatesTest < ActiveSupport::TestCase
 
   test 'stamp_workflow_defaults! sets voucher when vouchers_enabled is on' do
     @vouchers_flag.update!(enabled: true)
-    @income_flag.update!(enabled: false)
     app = create(:application, :in_progress)
     assert app.fulfillment_type_voucher?
     assert_not app.income_proof_required?
@@ -29,8 +26,7 @@ class ApplicationWorkflowPredicatesTest < ActiveSupport::TestCase
 
   test 'stamp_workflow_defaults! is unconditional and overrides any pre-set values' do
     @vouchers_flag.update!(enabled: true)
-    @income_flag.update!(enabled: true)
-    app = Application.new(fulfillment_type: :equipment, income_proof_required: false)
+    app = Application.new(fulfillment_type: :equipment, income_proof_required: true)
     app.assign_attributes(
       user: create(:constituent, :with_disabilities),
       status: :in_progress,
@@ -43,27 +39,27 @@ class ApplicationWorkflowPredicatesTest < ActiveSupport::TestCase
     )
     app.save!
     assert app.fulfillment_type_voucher?, "Expected voucher, got #{app.fulfillment_type}"
-    assert app.income_proof_required?, 'Expected income_proof_required to be true'
+    assert_not app.income_proof_required?, 'Expected income_proof_required stamped false when vouchers enabled'
   end
 
   # --- scrub_income_fields ---
 
   test 'scrub_income_fields nils out income data on new record when income is off' do
-    @income_flag.update!(enabled: false)
+    @vouchers_flag.update!(enabled: true)
     app = create(:application, :in_progress)
     assert_nil app.annual_income
     assert_nil app.household_size
   end
 
   test 'scrub_income_fields preserves income data when income is on' do
-    @income_flag.update!(enabled: true)
+    @vouchers_flag.update!(enabled: false)
     app = create(:application, :in_progress)
     assert_not_nil app.annual_income
     assert_not_nil app.household_size
   end
 
   test 'scrub_income_fields works on draft status updates' do
-    @income_flag.update!(enabled: true)
+    @vouchers_flag.update!(enabled: false)
     app = create(:application, :draft)
     assert_not_nil app.household_size
 
@@ -78,7 +74,7 @@ class ApplicationWorkflowPredicatesTest < ActiveSupport::TestCase
   # --- income_collection_enabled? ---
 
   test 'income_collection_enabled? returns income_proof_required for persisted records' do
-    @income_flag.update!(enabled: true)
+    @vouchers_flag.update!(enabled: false)
     app = create(:application, :in_progress)
     assert app.income_collection_enabled?
 
@@ -88,11 +84,11 @@ class ApplicationWorkflowPredicatesTest < ActiveSupport::TestCase
   end
 
   test 'income_collection_enabled? checks feature flag for new records' do
-    @income_flag.update!(enabled: true)
+    @vouchers_flag.update!(enabled: false)
     app = Application.new
     assert app.income_collection_enabled?
 
-    @income_flag.update!(enabled: false)
+    @vouchers_flag.update!(enabled: true)
     assert_not app.income_collection_enabled?
   end
 

--- a/test/models/voucher_transition_behavior_test.rb
+++ b/test/models/voucher_transition_behavior_test.rb
@@ -10,7 +10,6 @@ class VoucherTransitionBehaviorTest < ActiveSupport::TestCase
     clear_enqueued_jobs
     clear_performed_jobs
     setup_paper_application_context
-    @income_flag = FeatureFlag.find_or_create_by!(name: 'income_proof_required') { |f| f.enabled = true }
     @vouchers_flag = FeatureFlag.find_or_create_by!(name: 'vouchers_enabled') { |f| f.enabled = false }
   end
 
@@ -94,7 +93,7 @@ class VoucherTransitionBehaviorTest < ActiveSupport::TestCase
   # --- ApplicationForm: conditional income validation ---
 
   test 'ApplicationForm validates annual_income on submission when income required' do
-    @income_flag.update!(enabled: true)
+    @vouchers_flag.update!(enabled: false)
     user = create(:constituent, :with_disabilities)
 
     form = ApplicationForm.new(
@@ -112,7 +111,7 @@ class VoucherTransitionBehaviorTest < ActiveSupport::TestCase
   end
 
   test 'ApplicationForm skips annual_income validation when income not required' do
-    @income_flag.update!(enabled: false)
+    @vouchers_flag.update!(enabled: true)
     user = create(:constituent, :with_disabilities)
 
     form = ApplicationForm.new(
@@ -129,7 +128,7 @@ class VoucherTransitionBehaviorTest < ActiveSupport::TestCase
   end
 
   test 'ApplicationForm uses persisted application income_proof_required for drafts' do
-    @income_flag.update!(enabled: true)
+    @vouchers_flag.update!(enabled: false)
     user = create(:constituent, :with_disabilities)
     app = create(:application, :draft, user: user)
     assert app.income_proof_required?
@@ -154,7 +153,7 @@ class VoucherTransitionBehaviorTest < ActiveSupport::TestCase
   # --- PaperApplicationService: income threshold skip ---
 
   test 'PaperApplicationService skips income threshold validation when flag is off' do
-    @income_flag.update!(enabled: false)
+    @vouchers_flag.update!(enabled: true)
     admin = create(:admin)
     setup_fpl_policies
 
@@ -187,7 +186,7 @@ class VoucherTransitionBehaviorTest < ActiveSupport::TestCase
   end
 
   test 'PaperApplicationService determine_initial_status ignores income when flag off' do
-    @income_flag.update!(enabled: false)
+    @vouchers_flag.update!(enabled: true)
     admin = create(:admin)
     setup_fpl_policies
 
@@ -240,7 +239,7 @@ class VoucherTransitionBehaviorTest < ActiveSupport::TestCase
   # --- PaperApplicationService: income proof processing skip ---
 
   test 'PaperApplicationService does not process income proof when flag is off' do
-    @income_flag.update!(enabled: false)
+    @vouchers_flag.update!(enabled: true)
     admin = create(:admin)
     setup_fpl_policies
 

--- a/test/support/paper_application_context_helpers.rb
+++ b/test/support/paper_application_context_helpers.rb
@@ -14,9 +14,8 @@ module PaperApplicationContextHelpers
     # Also set the application skip flag that's used in ApplicationSystemTestCase
     Application.skip_wait_period_validation = true
 
-    # Ensure workflow feature flags exist with legacy defaults so that
+    # Ensure the single workflow feature flag exists with its default so that
     # stamp_workflow_defaults! and scrub_income_fields behave correctly.
-    FeatureFlag.find_or_create_by!(name: 'income_proof_required') { |f| f.enabled = true }
     FeatureFlag.find_or_create_by!(name: 'vouchers_enabled') { |f| f.enabled = false }
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -230,9 +230,8 @@ module ActiveSupport
       setup do
         DatabaseCleaner.strategy = :transaction
         DatabaseCleaner.start
-        # Ensure workflow feature flags exist with legacy defaults so that
+        # Ensure the single workflow feature flag exists with its default so that
         # stamp_workflow_defaults! and scrub_income_fields behave correctly.
-        FeatureFlag.find_or_create_by!(name: 'income_proof_required') { |f| f.enabled = true }
         FeatureFlag.find_or_create_by!(name: 'vouchers_enabled') { |f| f.enabled = false }
       end
 


### PR DESCRIPTION
- Because income requirements will be linked to vouchers being enabled, this allows them to be turned off when vouchers are enabled.
- Consideration: Is there any chance income requirements would be dropped _without_ vouchers being enabled?