### PR TITLE
Allow sign-in by email or phone for existing users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -117,7 +117,7 @@ class ApplicationController < ActionController::Base
     if session_record
       redirect_to after_sign_in_path_for(user), notice: t('controllers.application.sign_in.signin_pass')
     else
-      redirect_to sign_in_path(email_hint: user.email), alert: t('alerts.session_fail')
+      redirect_to sign_in_path, alert: t('alerts.session_fail')
     end
   end
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -55,9 +55,8 @@ module Authentication
   def find_production_session
     return if cookies.signed[:session_token].blank?
 
-    # Only include the user without eager loading role_capabilities
-    Session.includes(:user)
-           .find_by(session_token: cookies.signed[:session_token])
+    # Load session without eager loading user; association is loaded on demand when needed.
+    Session.find_by(session_token: cookies.signed[:session_token])
   end
 
   def find_test_session
@@ -99,13 +98,13 @@ module Authentication
   def find_signed_cookie_session
     return if cookies.signed[:session_token].blank?
 
-    Session.includes(:user).find_by(session_token: cookies.signed[:session_token])
+    Session.find_by(session_token: cookies.signed[:session_token])
   end
 
   def find_unsigned_cookie_session
     return if cookies[:session_token].blank?
 
-    Session.includes(:user).find_by(session_token: cookies[:session_token])
+    Session.find_by(session_token: cookies[:session_token])
   end
 
   # Redirects unauthenticated users to the sign-in page with an alert message

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -91,14 +91,23 @@ class PasswordsController < ApplicationController
   end
 
   def find_user_for_account_access
-    contact = account_access_contact
-    email_user = User.find_by_email(contact)
-    return [email_user, :email] if email_user.present?
+    contact = account_access_contact.to_s.strip.presence
+    return [nil, nil] if contact.blank?
+
+    if User.login_identifier_looks_like_email?(contact)
+      return [nil, nil] unless User.login_identifier_valid_email?(contact)
+
+      email_user = User.find_by_email(contact)
+      return [nil, nil] if email_user.blank? || User.system_generated_email?(email_user.email)
+
+      return [email_user, :email]
+    end
 
     phone_user = User.find_by_phone(contact)
-    return [phone_user, :sms] if phone_user.present?
+    return [nil, nil] if phone_user.blank? || User.placeholder_phone?(phone_user.phone)
+    return [nil, nil] unless phone_user.phone_type.to_s == 'text'
 
-    [nil, nil]
+    [phone_user, :sms]
   end
 
   def account_access_contact

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,16 +16,16 @@ class SessionsController < ApplicationController
   end
 
   def create
-    user = User.find_by_email(params[:email])
+    user = User.find_by_login_identifier(login_contact_param)
 
     if user&.account_locked?
-      @errors = { email: invalid_credentials_message }
+      @errors = { contact: invalid_credentials_message }
       return render_form_errors
     end
 
     unless user&.authenticate(params[:password])
       user&.record_failed_login!
-      @errors = { email: invalid_credentials_message }
+      @errors = { contact: invalid_credentials_message }
       return render_form_errors
     end
 
@@ -36,19 +36,15 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    # Clean up any temporary 2FA state without marking the session verified.
     TwoFactorAuth.abort_authentication(session)
 
-    # Find and destroy the current session if it exists
     if current_user&.sessions
       session_to_destroy = current_user.sessions.find_by(session_token: cookies.signed[:session_token])
       session_to_destroy&.destroy
     end
 
-    # Always clear the session cookie
     cookies.delete(:session_token)
 
-    # Handle different response formats appropriately
     respond_to do |format|
       format.html { redirect_to sign_in_path, notice: 'Signed out successfully' }
       format.turbo_stream { redirect_to sign_in_path, notice: 'Signed out successfully' }
@@ -57,22 +53,19 @@ class SessionsController < ApplicationController
 
   private
 
+  def login_contact_param
+    params[:contact].presence || params[:email].presence
+  end
+
   def render_form_errors
     respond_to do |format|
       format.turbo_stream do
         render turbo_stream: turbo_stream.replace('sign_in_form', partial: 'sessions/form')
       end
       format.html do
-        redirect_to sign_in_path(email_hint: params[:email]), alert: invalid_credentials_message
+        redirect_to sign_in_path, alert: invalid_credentials_message
       end
     end
-  end
-
-  def handle_invalid_credentials
-    # Add user feedback for failed login attempts if User model supports it
-    # user = User.find_by_email(params[:email])
-    # user&.track_failed_attempt!(request.remote_ip) if user # Assuming track_failed_attempt! exists
-    redirect_to sign_in_path(email_hint: params[:email]), alert: invalid_credentials_message
   end
 
   def invalid_credentials_message
@@ -80,10 +73,9 @@ class SessionsController < ApplicationController
   end
 
   def setup_two_factor_session(user)
-    cookies.delete(:session_token) # Ensure no old session interferes
-    TwoFactorAuth.clear_challenge(session) # Clear any stale challenge
+    cookies.delete(:session_token)
+    TwoFactorAuth.clear_challenge(session)
     TwoFactorAuth.store_temp_user_id(session, user.id)
-    # Only store return path if it's not the sign-in page or root path
     return_path = session[:return_to]
     return_path = nil if return_path&.include?('sign_in') || return_path == '/'
     TwoFactorAuth.store_return_path(session, return_path)
@@ -135,7 +127,7 @@ class SessionsController < ApplicationController
                   notice: TwoFactor::SmsLoginChallenge::DUPLICATE_SEND_MESSAGE
     else
       TwoFactorAuth.abort_authentication(session)
-      redirect_to sign_in_path(email_hint: user.email),
+      redirect_to sign_in_path,
                   alert: 'Could not send verification code. Please try again.'
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,6 +78,45 @@ class User < ApplicationRecord
     nil
   end
 
+  def self.login_identifier_looks_like_email?(contact)
+    contact.to_s.strip.include?('@')
+  end
+
+  def self.login_identifier_valid_email?(contact)
+    normalized = contact.to_s.strip
+    normalized.match?(URI::MailTo::EMAIL_REGEXP)
+  end
+
+  def self.find_by_login_identifier(contact)
+    normalized = contact.to_s.strip.presence
+    return nil if normalized.blank?
+
+    if login_identifier_looks_like_email?(normalized)
+      return nil unless login_identifier_valid_email?(normalized)
+
+      user = find_by_email(normalized)
+      return nil if user.blank? || system_generated_email?(user.email)
+
+      return user
+    end
+
+    phone_user = find_by_phone(normalized)
+    return nil if phone_user.blank?
+    return nil if placeholder_phone?(phone_user.phone)
+
+    phone_user
+  end
+
+  def self.placeholder_phone?(phone)
+    synthetic_dependent_phone?(phone)
+  end
+
+  def self.system_generated_email?(email)
+    return false if email.blank?
+
+    normalize_email(email).to_s.end_with?('@system.matvulcan.local')
+  end
+
   def self.exists_with_email?(email_value, excluding_id: nil)
     normalized_email = normalize_email(email_value)
     return false if normalized_email.blank?

--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -1,5 +1,4 @@
 <div id="sign_in_form">
-  <%# Error Summary Block - from main page for better accessibility %>
   <% if @errors&.any? %>
     <div id="signin-error-summary"
          role="alert"
@@ -22,25 +21,25 @@
                 aria: { labelledby: "signin-heading" },
                 data: { controller: "visibility" } do |form| %>
 
-  <div class="space-y-1" role="group" aria-labelledby="email-input-label">
-    <%= form.label :email, "Email Address",
-        for: "email-input",
-        id: "email-input-label",
+  <div class="space-y-1" role="group" aria-labelledby="contact-input-label">
+    <%= form.label :contact, t("sessions.form.contact_label"),
+        for: "contact-input",
+        id: "contact-input-label",
         class: "block text-sm font-medium text-gray-700" %>
-    <%= form.email_field :email,
-        id: "email-input",
+    <%= form.text_field :contact,
+        id: "contact-input",
         class: "mt-1 block w-full px-4 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm",
-        value: params[:email_hint] || "",
+        value: params[:email_hint].presence || "",
         required: true,
-        autocomplete: "email",
+        autocomplete: "username",
         autofocus: true,
         "aria-required": "true",
-        "aria-invalid": (@errors&.include?(:email) ? "true" : "false"),
-        "aria-describedby": (["email-hint", (@errors&.include?(:email) ? "email-error" : nil)].compact.join(" ")) %>
-    <p id="email-hint" class="text-xs text-gray-500">Enter the email address associated with your account</p>
-    <% if @errors&.include?(:email) %>
-      <p id="email-error" class="mt-1 text-sm text-red-600">
-        <%= @errors[:email] %>
+        "aria-invalid": (@errors&.include?(:contact) ? "true" : "false"),
+        "aria-describedby": (["contact-hint", (@errors&.include?(:contact) ? "contact-error" : nil)].compact.join(" ")) %>
+    <p id="contact-hint" class="text-xs text-gray-500"><%= t("sessions.form.contact_hint") %></p>
+    <% if @errors&.include?(:contact) %>
+      <p id="contact-error" class="mt-1 text-sm text-red-600">
+        <%= @errors[:contact] %>
       </p>
     <% end %>
   </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,8 +1,8 @@
-<main class="min-h-screen flex items-center justify-center bg-gray-100 px-4 py-12">
-  <section class="bg-white p-6 sm:p-8 rounded-lg shadow-md w-full max-w-md" aria-labelledby="signin-heading">
+<div class="min-h-screen w-full flex items-center justify-center bg-gray-100 px-4 py-12">
+  <section class="bg-white p-6 sm:p-8 rounded-lg shadow-md w-full max-w-md min-w-0" aria-labelledby="signin-heading">
     <h1 id="signin-heading" class="text-2xl font-semibold mb-6 text-center text-gray-900">Sign In</h1>
 
     <%# Render the unified sign-in form partial %>
     <%= render "sessions/form" %>
   </section>
-</main>
+</div>

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -10,7 +10,7 @@ Rails.application.config.filter_parameters += [
   :password, :password_confirmation, :current_password, :password_digest,
 
   # PII fields (plaintext) - User model
-  :email, :phone, :ssn_last4, :date_of_birth,
+  :email, :phone, :contact, :ssn_last4, :date_of_birth,
   :physical_address_1, :physical_address_2, :city, :state, :zip_code,
 
   # SMS credential specific field

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,10 @@ en:
     toggle:
       show: "Show password"
       hide: "Hide password"
+  sessions:
+    form:
+      contact_label: "Email Address or Phone Number"
+      contact_hint: "Enter the email address or phone number associated with your account"
   activerecord:
     errors:
       models:
@@ -692,7 +696,7 @@ en:
           not_active: "This secure W9 upload link is not active."
   controllers:
     sessions:
-      invalid_credentials: "Invalid email or password"
+      invalid_credentials: "Invalid email, phone number, or password"
     application:
       check_password_change_required:
         password_security_change: "For security reasons, you must change your password before continuing."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -6,6 +6,10 @@ es:
     toggle:
       show: "Mostrar contraseña"
       hide: "Ocultar contraseña"
+  sessions:
+    form:
+      contact_label: "Correo electrónico o número de teléfono"
+      contact_hint: "Ingrese el correo electrónico o número de teléfono asociado con su cuenta"
   activerecord:
     errors:
       models:
@@ -747,7 +751,7 @@ es:
       contact_info: "Envíe un correo electrónico a %{email} o llame al %{phone}."
   controllers:
     sessions:
-      invalid_credentials: "Correo electrónico o contraseña inválidos"
+      invalid_credentials: "Correo electrónico, número de teléfono o contraseña inválidos"
     application:
       check_password_change_required:
         password_security_change: "Por razones de seguridad, debe cambiar su contraseña antes de continuar."

--- a/docs/development/user_management_features.md
+++ b/docs/development/user_management_features.md
@@ -48,9 +48,10 @@ Email and phone are stored with deterministic Rails encryption so exact lookups 
 - matching email or phone renders the signup page with an account-access prompt instead of creating another user
 - matching email can offer an account-access link by email
 - matching text-capable phone can offer an account-access link by SMS
+- `PasswordsController#create` applies the same text-capable rule: account-access SMS is sent only when the matched user's `phone_type` is `text`
 - conflicting matches, where email and phone belong to different users, show a support-contact prompt
 
-`UserProfile` also validates unique email and phone through `User.exists_with_email?` and `User.exists_with_phone?`. The database has unique indexes on `users.email` and non-null `users.phone`.
+`UserProfile` also validates unique email and phone through `User.exists_with_email?` and `User.exists_with_phone?`. The database has unique indexes on `users.email` and on non-null `users.phone` values.
 
 Blank phone numbers are allowed. Non-blank phones must normalize to a 10-digit US number when the phone changes.
 

--- a/docs/security/authentication_system.md
+++ b/docs/security/authentication_system.md
@@ -10,13 +10,16 @@ Password sign-in starts in `SessionsController#create`.
 
 The controller:
 
-- looks up users through `User.find_by_email`, which normalizes email and works with encrypted email storage
+- looks up users through `User.find_by_login_identifier`, which accepts email or phone, normalizes input, rejects malformed `@` input, synthetic dependent emails, and placeholder phones, and works with encrypted email storage
+- does not change portal registration rules; signup still requires both email and phone in the public UI
 - checks account lock state before password authentication
 - records failed password attempts
 - signs the user in immediately when no second factor is enabled
 - starts the MFA flow when the user has any second factor
 
 User password/session behavior lives in `UserAuthentication`.
+
+Account access (the “Forgot password?” / send reset link flow) lives in `PasswordsController#create`. It uses parallel contact lookup logic in `find_user_for_account_access` with the same malformed-`@`, synthetic-email, placeholder-phone, and text-capable SMS rules as sign-in, but it does not call `User.find_by_login_identifier` directly. WebAuthn recovery in `AccountRecoveryController` is still email-only.
 
 Current account-lock behavior:
 
@@ -200,6 +203,7 @@ When changing authentication:
 - Use `TwoFactorAuth` session keys instead of inventing new session state.
 - Do not count unverified SMS credentials as enabled.
 - Do not store SMS codes in our database.
-- Do not bypass `User.find_by_email` for login lookup.
+- Use `User.find_by_login_identifier` for password sign-in lookup instead of calling `User.find_by_email` or `User.find_by_phone` directly.
+- Keep account-access lookup aligned with the same contact guards even if it remains in `PasswordsController#find_user_for_account_access` for now.
 - Do not add role-based MFA exceptions without updating tests.
 - Be careful with direct column writes in auth bookkeeping; the existing uses are narrow and documented in code.

--- a/docs/security/pii_encryption.md
+++ b/docs/security/pii_encryption.md
@@ -67,10 +67,17 @@ Use the helper methods on `User` for contact lookup:
 
 - `User.find_by_email(value)`
 - `User.find_by_phone(value)`
+- `User.find_by_login_identifier(value)` — password sign-in lookup in `SessionsController`; treats any `@` input as email-shaped, rejects malformed email strings without falling back to phone, and blocks synthetic dependent contacts
 - `User.exists_with_email?(value, excluding_id: nil)`
 - `User.exists_with_phone?(value, excluding_id: nil)`
 
-These helpers normalize email and phone values before querying and rescue lookup failures with a warning. They are used by login, registration, password/account recovery, and paper intake paths.
+These helpers normalize email and phone values before querying and rescue lookup failures with a warning.
+
+Current adoption by path:
+
+- `User.find_by_login_identifier` — `SessionsController` sign-in only
+- `User.find_by_email` / `User.find_by_phone` — registration duplicate checks, paper intake, WebAuthn recovery, and other existing lookup paths
+- `PasswordsController#find_user_for_account_access` — parallel account-access lookup with equivalent guards, but not yet routed through `find_by_login_identifier`
 
 Direct Rails equality queries on deterministic encrypted fields can work, but new code should use the helpers where contact lookup or uniqueness is the point. That keeps normalization and failure behavior consistent.
 
@@ -101,7 +108,7 @@ Sensitive request parameters are filtered in `config/initializers/filter_paramet
 Currently filtered categories include:
 
 - password fields
-- user contact and address fields
+- user contact and address fields, including unified auth `contact`
 - date of birth and SSN fields
 - SMS phone number params
 - medical provider contact fields

--- a/test/config/filter_parameter_logging_test.rb
+++ b/test/config/filter_parameter_logging_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class FilterParameterLoggingTest < ActiveSupport::TestCase
+  test 'filters contact and password parameters from logs' do
+    filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+    filtered = filter.filter(
+      'contact' => '410-555-0198',
+      'password' => 'password123',
+      'controller' => 'sessions',
+      'action' => 'create'
+    )
+
+    assert_equal '[FILTERED]', filtered['contact']
+    assert_equal '[FILTERED]', filtered['password']
+    assert_equal 'sessions', filtered['controller']
+    assert_equal 'create', filtered['action']
+  end
+end

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -70,6 +70,8 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_should_send_account_access_sms_for_existing_phone
+    @user.update!(phone_type: 'text')
+
     SmsService.expects(:send_message)
               .with(@user.phone,
                     regexp_matches(%r{MAT account access link to set your password: https?://\S+ This link expires in 20 minutes\.}))
@@ -85,6 +87,8 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_should_return_generic_confirmation_when_sms_delivery_fails
+    @user.update!(phone_type: 'text')
+
     SmsService.expects(:send_message).raises(StandardError, 'invalid number')
 
     assert_difference -> { Event.where(action: 'account_access_instructions_delivery_failed', user: @user).count }, 1 do
@@ -97,6 +101,8 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_should_rate_limit_repeated_account_access_sms_requests
+    @user.update!(phone_type: 'text')
+
     old_cache = Rails.cache
     Rails.cache = ActiveSupport::Cache::MemoryStore.new
 
@@ -244,6 +250,161 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     # Verify password was not changed
     @user.reload
     assert_equal @original_password_digest, @user.password_digest
+  end
+
+
+  def test_system_email_does_not_fall_through_to_phone_for_account_access
+    sign_out if respond_to?(:sign_out)
+
+    user = create(:constituent,
+                  email: "dep.#{SecureRandom.hex(3)}@system.matvulcan.local",
+                  phone: '410-555-0166',
+                  password: 'password123',
+                  password_confirmation: 'password123')
+
+    SmsService.expects(:send_message).never
+
+    assert_no_enqueued_emails do
+      post password_path, params: { contact: user.email }
+    end
+
+    assert_redirected_to sign_in_path
+    assert_equal account_access_confirmation_message, flash[:notice]
+  end
+
+  def test_placeholder_phone_does_not_receive_account_access_sms
+    sign_out if respond_to?(:sign_out)
+
+    user = create(:constituent,
+                  phone: '000-000-4321',
+                  email: "real.#{SecureRandom.hex(3)}@example.com",
+                  password: 'password123',
+                  password_confirmation: 'password123')
+
+    SmsService.expects(:send_message).never
+
+    assert_no_enqueued_emails do
+      post password_path, params: { contact: user.phone }
+    end
+
+    assert_redirected_to sign_in_path
+  end
+
+  def test_guardian_generated_synthetic_phone_does_not_receive_account_access_sms
+    sign_out if respond_to?(:sign_out)
+
+    user = create(:constituent,
+                  phone: '000-345-6789',
+                  email: "real.#{SecureRandom.hex(3)}@example.com",
+                  password: 'password123',
+                  password_confirmation: 'password123')
+
+    SmsService.expects(:send_message).never
+
+    assert_no_enqueued_emails do
+      post password_path, params: { contact: '0003456789' }
+    end
+
+    assert_redirected_to sign_in_path
+  end
+
+  def test_account_access_accepts_email_with_surrounding_whitespace
+    sign_out if respond_to?(:sign_out)
+
+    assert_enqueued_emails 1 do
+      post password_path, params: { contact: "  #{@user.email}  " }
+    end
+
+    assert_redirected_to sign_in_path
+    assert_equal account_access_confirmation_message, flash[:notice]
+  end
+
+  def test_voice_phone_does_not_receive_account_access_sms
+    sign_out if respond_to?(:sign_out)
+
+    user = create(:constituent,
+                  phone: '410-555-0144',
+                  phone_type: 'voice',
+                  email: "voice.#{SecureRandom.hex(3)}@example.com",
+                  password: 'password123',
+                  password_confirmation: 'password123')
+
+    SmsService.expects(:send_message).never
+
+    assert_no_enqueued_emails do
+      post password_path, params: { contact: user.phone }
+    end
+
+    assert_redirected_to sign_in_path
+    assert_equal account_access_confirmation_message, flash[:notice]
+  end
+
+  def test_malformed_email_shaped_account_access_does_not_fall_through_to_phone
+    sign_out if respond_to?(:sign_out)
+
+    phone = '410-555-0164'
+    Current.paper_context = true
+    user = nil
+    begin
+      user = Users::Constituent.create!(
+        first_name: 'Phone', last_name: 'OnlyMalformedAccess',
+        phone: phone,
+        phone_type: 'text',
+        communication_preference: :letter,
+        physical_address_1: '123 Main St', city: 'Baltimore', state: 'MD', zip_code: '21201',
+        date_of_birth: Date.new(1950, 1, 1),
+        password: 'password123', password_confirmation: 'password123',
+        hearing_disability: true
+      )
+    ensure
+      Current.reset
+    end
+
+    SmsService.expects(:send_message).never
+
+    assert_no_enqueued_emails do
+      post password_path, params: { contact: '4105550164@' }
+    end
+
+    assert_redirected_to sign_in_path
+    assert_equal account_access_confirmation_message, flash[:notice]
+    assert_equal user, User.find_by_phone(phone)
+  end
+
+  def test_email_shaped_account_access_does_not_fall_through_to_phone
+    sign_out if respond_to?(:sign_out)
+
+    phone = '410-555-0165'
+    Current.paper_context = true
+    user = nil
+    begin
+      user = Users::Constituent.create!(
+        first_name: 'Phone', last_name: 'OnlyAccess',
+        phone: phone,
+        phone_type: 'voice',
+        communication_preference: :letter,
+        physical_address_1: '123 Main St', city: 'Baltimore', state: 'MD', zip_code: '21201',
+        date_of_birth: Date.new(1950, 1, 1),
+        password: 'password123', password_confirmation: 'password123',
+        hearing_disability: true
+      )
+    ensure
+      Current.reset
+    end
+
+    SmsService.expects(:send_message).never
+
+    assert_no_enqueued_emails do
+      post password_path, params: { contact: '4105550165@example.com' }
+    end
+
+    assert_redirected_to sign_in_path
+    assert_equal account_access_confirmation_message, flash[:notice]
+    assert_equal user, User.find_by_phone(phone)
+  end
+
+  def account_access_confirmation_message
+    'If the information you entered matches an account, we sent account access instructions to the contact information on record.'
   end
 
   private

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -24,7 +24,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       email: @admin.email,
       password: 'wrongpassword'
     }
-    assert_redirected_to sign_in_path(email_hint: @admin.email)
+    assert_redirected_to sign_in_path
     follow_redirect!
     assert_match I18n.t('controllers.sessions.invalid_credentials'), flash[:alert]
   end
@@ -36,7 +36,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       post sign_in_path, params: { email: user.email, password: 'wrongpassword' }
     end
 
-    assert_redirected_to sign_in_path(email_hint: user.email)
+    assert_redirected_to sign_in_path
   end
 
   def test_repeated_failed_logins_lock_account
@@ -57,7 +57,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       post sign_in_path, params: { email: user.email, password: 'password123' }
     end
 
-    assert_redirected_to sign_in_path(email_hint: user.email)
+    assert_redirected_to sign_in_path
   end
 
   def test_should_sign_in_constituent_without_mfa
@@ -91,5 +91,168 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to verify_method_two_factor_authentication_path(type: 'sms')
     assert_equal TwoFactor::SmsLoginChallenge::DUPLICATE_SEND_MESSAGE, flash[:notice]
     assert_equal user.id, session[TwoFactorAuth::SESSION_KEYS[:temp_user_id]]
+  end
+
+  def test_should_sign_in_constituent_by_phone
+    user = create(:constituent)
+
+    post sign_in_path, params: { contact: user.phone, password: 'password123' }
+
+    assert_redirected_to constituent_portal_dashboard_path
+  end
+
+  def test_should_sign_in_with_normalized_phone
+    user = create(:constituent, phone: '410-555-0100')
+
+    post sign_in_path, params: { contact: '4105550100', password: 'password123' }
+
+    assert_redirected_to constituent_portal_dashboard_path
+  end
+
+  def test_backward_compat_email_param_still_works
+    user = create(:constituent)
+
+    post sign_in_path, params: { email: user.email, password: 'password123' }
+
+    assert_redirected_to constituent_portal_dashboard_path
+  end
+
+  def test_paper_no_email_user_signs_in_with_phone
+    user = nil
+    Current.paper_context = true
+    begin
+      user = Users::Constituent.create!(
+        first_name: 'Paper', last_name: 'NoEmail',
+        phone: '410-555-0188',
+        phone_type: 'voice',
+        communication_preference: :letter,
+        physical_address_1: '123 Main St', city: 'Baltimore', state: 'MD', zip_code: '21201',
+        date_of_birth: Date.new(1950, 1, 1),
+        password: 'password123', password_confirmation: 'password123',
+        hearing_disability: true
+      )
+    ensure
+      Current.reset
+    end
+
+    post sign_in_path, params: { contact: user.phone, password: 'password123' }
+
+    assert_redirected_to constituent_portal_dashboard_path
+  end
+
+  def test_paper_no_email_user_signs_in_with_phone_then_sms_2fa
+    user = nil
+    Current.paper_context = true
+    begin
+      user = Users::Constituent.create!(
+        first_name: 'Paper', last_name: 'Sms2fa',
+        phone: '410-555-0189',
+        phone_type: 'voice',
+        communication_preference: :letter,
+        physical_address_1: '123 Main St', city: 'Baltimore', state: 'MD', zip_code: '21201',
+        date_of_birth: Date.new(1950, 1, 1),
+        password: 'password123', password_confirmation: 'password123',
+        hearing_disability: true
+      )
+    ensure
+      Current.reset
+    end
+
+    user.sms_credentials.create!(
+      phone_number: '555-321-9876',
+      last_sent_at: Time.current,
+      verified_at: Time.current
+    )
+
+    SessionsController.any_instance.stubs(:ensure_sms_challenge_for_user).returns(:sending)
+
+    post sign_in_path, params: { contact: user.phone, password: 'password123' }
+
+    assert_redirected_to verify_method_two_factor_authentication_path(type: 'sms')
+    assert_equal user.id, session[TwoFactorAuth::SESSION_KEYS[:temp_user_id]]
+  end
+
+  def test_failed_login_by_phone_increments_failed_attempts
+    user = create(:constituent)
+
+    assert_difference -> { user.reload.failed_attempts.to_i }, 1 do
+      post sign_in_path, params: { contact: user.phone, password: 'wrongpassword' }
+    end
+
+    assert_redirected_to sign_in_path
+  end
+
+  def test_locked_account_cannot_sign_in_by_phone
+    user = create(:constituent, failed_attempts: UserAuthentication::MAX_LOGIN_ATTEMPTS, locked_at: Time.current)
+
+    assert_no_difference('Session.count') do
+      post sign_in_path, params: { contact: user.phone, password: 'password123' }
+    end
+
+    assert_redirected_to sign_in_path
+  end
+
+  def test_placeholder_phone_cannot_sign_in
+    user = create(:constituent, phone: '000-000-5678', email: "dep.#{SecureRandom.hex(3)}@system.matvulcan.local")
+
+    post sign_in_path, params: { contact: user.phone, password: 'password123' }
+
+    assert_redirected_to sign_in_path
+    follow_redirect!
+    assert_match I18n.t('controllers.sessions.invalid_credentials'), flash[:alert]
+  end
+
+  def test_guardian_generated_synthetic_phone_cannot_sign_in
+    user = create(:constituent, phone: '000-234-5678', email: "dep.#{SecureRandom.hex(3)}@system.matvulcan.local")
+
+    post sign_in_path, params: { contact: '0002345678', password: 'password123' }
+
+    assert_redirected_to sign_in_path
+    follow_redirect!
+    assert_match I18n.t('controllers.sessions.invalid_credentials'), flash[:alert]
+  end
+
+  def test_system_email_cannot_sign_in
+    user = create(:constituent, email: "dep.#{SecureRandom.hex(3)}@system.matvulcan.local", phone: '410-555-0177')
+
+    post sign_in_path, params: { contact: user.email, password: 'password123' }
+
+    assert_redirected_to sign_in_path
+  end
+
+  def test_malformed_email_shaped_identifier_cannot_sign_in
+    phone = '410-555-0143'
+    user = nil
+    Current.paper_context = true
+    begin
+      user = Users::Constituent.create!(
+        first_name: 'Phone', last_name: 'MalformedSignIn',
+        phone: phone,
+        phone_type: 'voice',
+        communication_preference: :letter,
+        physical_address_1: '123 Main St', city: 'Baltimore', state: 'MD', zip_code: '21201',
+        date_of_birth: Date.new(1950, 1, 1),
+        password: 'password123', password_confirmation: 'password123',
+        hearing_disability: true
+      )
+    ensure
+      Current.reset
+    end
+
+    post sign_in_path, params: { contact: '4105550143@', password: 'password123' }
+
+    assert_redirected_to sign_in_path
+    follow_redirect!
+    assert_match I18n.t('controllers.sessions.invalid_credentials'), flash[:alert]
+    assert_equal user, User.find_by_phone(phone)
+  end
+
+  def test_failed_login_redirect_has_no_contact_in_url
+    user = create(:constituent)
+
+    post sign_in_path, params: { contact: user.phone, password: 'wrongpassword' }
+
+    assert_redirected_to sign_in_path
+    assert_nil URI(response.redirect_url).query
   end
 end

--- a/test/models/user_login_identifier_test.rb
+++ b/test/models/user_login_identifier_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UserLoginIdentifierTest < ActiveSupport::TestCase
+  test 'find_by_login_identifier matches email' do
+    user = create(:constituent, email: "login.email.#{SecureRandom.hex(3)}@example.com")
+
+    assert_equal user, User.find_by_login_identifier(user.email)
+  end
+
+  test 'find_by_login_identifier matches normalized phone' do
+    user = create(:constituent, phone: '410-555-0198')
+
+    assert_equal user, User.find_by_login_identifier('4105550198')
+    assert_equal user, User.find_by_login_identifier(user.phone)
+  end
+
+  test 'email_shaped_identifier_does_not_fall_back_to_phone' do
+    phone = '410-555-0197'
+    user = nil
+    Current.paper_context = true
+    begin
+      user = Users::Constituent.create!(
+        first_name: 'Phone', last_name: 'Only',
+        phone: phone,
+        phone_type: 'voice',
+        communication_preference: :letter,
+        physical_address_1: '123 Main St', city: 'Baltimore', state: 'MD', zip_code: '21201',
+        date_of_birth: Date.new(1950, 1, 1),
+        password: 'password123', password_confirmation: 'password123',
+        hearing_disability: true
+      )
+    ensure
+      Current.reset
+    end
+
+    assert_nil user.email
+    assert_nil User.find_by_login_identifier('4105550197@example.com')
+    assert_equal user, User.find_by_login_identifier(phone)
+  end
+
+  test 'login_identifier_looks_like_email? treats any at sign as email shaped' do
+    assert User.login_identifier_looks_like_email?('  user@example.com  ')
+    assert User.login_identifier_looks_like_email?('4105550197@')
+  end
+
+  test 'login_identifier_valid_email? requires a valid email shape' do
+    assert User.login_identifier_valid_email?('  user@example.com  ')
+    assert_not User.login_identifier_valid_email?('4105550197@')
+  end
+
+  test 'malformed email shaped identifier does not fall back to phone' do
+    phone = '410-555-0195'
+    user = nil
+    Current.paper_context = true
+    begin
+      user = Users::Constituent.create!(
+        first_name: 'Phone', last_name: 'OnlyMalformed',
+        phone: phone,
+        phone_type: 'voice',
+        communication_preference: :letter,
+        physical_address_1: '123 Main St', city: 'Baltimore', state: 'MD', zip_code: '21201',
+        date_of_birth: Date.new(1950, 1, 1),
+        password: 'password123', password_confirmation: 'password123',
+        hearing_disability: true
+      )
+    ensure
+      Current.reset
+    end
+
+    assert_nil user.email
+    assert_nil User.find_by_login_identifier('4105550195@')
+    assert_equal user, User.find_by_login_identifier(phone)
+  end
+
+  test 'find_by_login_identifier rejects placeholder phone' do
+    user = create(:constituent, phone: '000-000-1234',
+                               email: "placeholder.#{SecureRandom.hex(3)}@example.com")
+
+    assert User.placeholder_phone?(user.phone)
+    assert_nil User.find_by_login_identifier(user.phone)
+  end
+
+  test 'find_by_login_identifier rejects guardian generated synthetic phone' do
+    user = create(:constituent, phone: '000-123-4567',
+                               email: "synthetic.#{SecureRandom.hex(3)}@example.com")
+
+    assert User.synthetic_dependent_phone?(user.phone)
+    assert User.placeholder_phone?(user.phone)
+    assert_nil User.find_by_login_identifier(user.phone)
+    assert_nil User.find_by_login_identifier('0001234567')
+  end
+
+  test 'find_by_login_identifier rejects system generated email' do
+    user = create(:constituent,
+                  email: "dependent.#{SecureRandom.hex(3)}@system.matvulcan.local",
+                  phone: '410-555-0196')
+
+    assert User.system_generated_email?(user.email)
+    assert_nil User.find_by_login_identifier(user.email)
+  end
+
+  test 'placeholder_phone? handles nil and blank' do
+    assert_not User.placeholder_phone?(nil)
+    assert_not User.placeholder_phone?('')
+  end
+
+  test 'system_generated_email? handles nil and blank' do
+    assert_not User.system_generated_email?(nil)
+    assert_not User.system_generated_email?('')
+  end
+end

--- a/test/support/system_test_authentication.rb
+++ b/test/support/system_test_authentication.rb
@@ -96,7 +96,7 @@ module SystemTestAuthentication
     assert_selector('form[action="/sign_in"]', wait: 10)
 
     within('form[action="/sign_in"]') do
-      fill_in 'email-input', with: user.email
+      fill_in 'contact-input', with: user.email
       fill_in 'password-input', with: 'password123'
       click_button 'Sign In'
     end
@@ -117,7 +117,7 @@ module SystemTestAuthentication
         # Success: 2FA sign-in has reached the expected verification step.
       elsif dashboard_path_reached?(user, wait: 8)
         # Success! Continue to dashboard verification below
-      elsif page.has_text?('Invalid email or password', wait: 2)
+      elsif page.has_text?(I18n.t('controllers.sessions.invalid_credentials'), wait: 2)
         # Clear authentication failure
         take_screenshot
         raise "❌ Sign-in failed for #{user.email} - invalid credentials detected."
@@ -183,7 +183,7 @@ module SystemTestAuthentication
     wait_for_stimulus_controller('visibility')
 
     within('form[action="/sign_in"]') do
-      fill_in 'email-input', with: user.email
+      fill_in 'contact-input', with: user.email
       fill_in 'password-input', with: 'password123'
       click_button 'Sign In'
     end

--- a/test/system/two_factor_authentication_flow_test.rb
+++ b/test/system/two_factor_authentication_flow_test.rb
@@ -483,7 +483,7 @@ class TwoFactorAuthenticationFlowTest < ApplicationSystemTestCase
     # Sign in - capture a screenshot of the page after sign-in
     # to help diagnose what options are actually visible
     visit sign_in_path
-    find_by_id('email-input').send_keys(@user.email)
+    find_by_id('contact-input').send_keys(@user.email)
     find_by_id('password-input').send_keys('password123')
     click_button 'Sign In'
 
@@ -512,7 +512,7 @@ class TwoFactorAuthenticationFlowTest < ApplicationSystemTestCase
 
     # Sign in to trigger 2FA flow
     visit sign_in_path
-    find_by_id('email-input').send_keys(@user.email)
+    find_by_id('contact-input').send_keys(@user.email)
     find_by_id('password-input').send_keys('password123')
     click_button 'Sign In'
 

--- a/test/system/webauthn_recovery_flow_test.rb
+++ b/test/system/webauthn_recovery_flow_test.rb
@@ -16,12 +16,12 @@ class WebauthnRecoveryFlowTest < ApplicationSystemTestCase
   test 'recovery link appears on webauthn authentication page' do
     # Start sign in process (first password step)
     visit sign_in_path
-    fill_in 'email', with: @user.email
-    fill_in 'password', with: 'password123'
+    fill_in 'contact-input', with: @user.email
+    fill_in 'password-input', with: 'password123'
     click_button 'Sign In'
 
     # Should be on WebAuthn page now
-    assert_text 'Use your registered security key to complete sign-in.'
+    assert_text 'Use your device (fingerprint or face) or a physical security key to complete sign-in.'
 
     # Check for recovery link
     assert_link "I've lost my security key"
@@ -125,8 +125,8 @@ class WebauthnRecoveryFlowTest < ApplicationSystemTestCase
 
     # User should now be able to sign in without WebAuthn
     visit sign_in_path
-    fill_in 'email', with: @user.email
-    fill_in 'password', with: 'password123'
+    fill_in 'contact-input', with: @user.email
+    fill_in 'password-input', with: 'password123'
     click_button 'Sign In'
 
     # Should be logged in without 2FA prompt

--- a/test/system/webauthn_sign_in_test.rb
+++ b/test/system/webauthn_sign_in_test.rb
@@ -101,7 +101,7 @@ class WebauthnSignInTest < ApplicationSystemTestCase
     wait_for_network_idle
 
     within('form[action="/sign_in"]') do
-      fill_in 'email-input', with: user.email
+      fill_in 'contact-input', with: user.email
       fill_in 'password-input', with: 'password123'
       click_button 'Sign In'
     end
@@ -114,7 +114,7 @@ class WebauthnSignInTest < ApplicationSystemTestCase
 
     # Verify the WebAuthn verification page displays correctly
     assert_text 'Device or Security Key Verification'
-    assert_text 'Use your registered security key to complete sign-in'
+    assert_text 'Use your device (fingerprint or face) or a physical security key to complete sign-in.'
 
     # Test stops here - we don't try to complete actual WebAuthn verification
     # That would require real hardware tokens or platform authenticators


### PR DESCRIPTION
Previously only email login was allowed. This PR adds phone as an option. 

Add User.find_by_login_identifier and a unified contact sign-in field while blocking fake dependent emails (created when guardians are the preferred contact in a guardian-dependent relationship) and placeholder phones from sign-in and account-access lookup. 

Account-access SMS stays limited to text-capable phones and malformed @ input no longer falls back to phone. 

Filter :contact from request logs, tighten auth/PII docs, and update tests and sign-in UI for the contact field.