### PR TITLE
Align portal registration, sign-in, account access, and WebAuthn recovery

### DIFF
--- a/app/controllers/account_recovery_controller.rb
+++ b/app/controllers/account_recovery_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'openssl'
+
 class AccountRecoveryController < ApplicationController
   RECOVERY_REQUEST_RATE_LIMIT = 5
   RECOVERY_REQUEST_RATE_LIMIT_WINDOW = 1.hour
@@ -11,9 +13,19 @@ class AccountRecoveryController < ApplicationController
   end
 
   def create
-    @user = User.find_by_login_identifier(account_recovery_contact)
+    contact = account_recovery_contact
+    contact_rate_limited = recovery_contact_rate_limited?(contact)
+    @user = User.find_by_login_identifier(contact)
 
-    submit_recovery_request(@user) if @user.present?
+    if @user.present?
+      if contact_rate_limited
+        log_recovery_attempt(@user, 'rate_limited', reason: 'submitted_contact_ip')
+      else
+        submit_recovery_request(@user)
+      end
+    elsif contact_rate_limited
+      log_unmatched_recovery_rate_limit(contact)
+    end
 
     # We don't want to reveal if an email exists in our system
     # So we show the confirmation page regardless
@@ -31,7 +43,10 @@ class AccountRecoveryController < ApplicationController
   end
 
   def submit_recovery_request(user)
-    return if recovery_submission_rate_limited?(user)
+    if recovery_submission_rate_limited?(user)
+      log_recovery_attempt(user, 'rate_limited', reason: 'user_ip')
+      return
+    end
 
     user.with_lock do
       return if user.recovery_requests.pending.exists?
@@ -48,8 +63,23 @@ class AccountRecoveryController < ApplicationController
     # Concurrent duplicate pending — treat as coalesced (partial unique index)
     nil
   rescue StandardError => e
+    log_recovery_attempt(user, 'failed', error_class: e.class.name)
     Rails.logger.error "Failed to submit recovery request for user #{user.id}: #{e.message}"
     nil
+  end
+
+  def recovery_contact_rate_limited?(contact)
+    count = Rails.cache.increment(recovery_contact_rate_limit_key(contact), 1,
+                                  expires_in: RECOVERY_REQUEST_RATE_LIMIT_WINDOW)
+
+    count.to_i > RECOVERY_REQUEST_RATE_LIMIT
+  end
+
+  def recovery_contact_rate_limit_key(contact)
+    hashed_scope = Digest::SHA256.hexdigest(
+      [submitted_recovery_contact_digest(contact), request_ip_digest].join(':')
+    )
+    "security_key_recovery_contact:#{hashed_scope}"
   end
 
   def recovery_submission_rate_limited?(user)
@@ -62,6 +92,58 @@ class AccountRecoveryController < ApplicationController
   def recovery_submission_rate_limit_key(user)
     hashed_scope = Digest::SHA256.hexdigest("#{user.id}:#{request.remote_ip}")
     "security_key_recovery:#{hashed_scope}"
+  end
+
+  def log_recovery_attempt(user, status, metadata = {})
+    AuditEventService.log(
+      action: "security_key_recovery_request_#{status}",
+      actor: user,
+      auditable: user,
+      metadata: recovery_audit_metadata.merge(metadata)
+    )
+  rescue StandardError => e
+    Rails.logger.warn("Unable to audit security key recovery #{status} for user #{user.id}: #{e.message}")
+  end
+
+  def log_unmatched_recovery_rate_limit(contact)
+    system_user = User.system_user
+    AuditEventService.log(
+      action: 'security_key_recovery_unmatched_rate_limited',
+      actor: system_user,
+      auditable: system_user,
+      metadata: recovery_audit_metadata.merge(
+        submitted_contact_digest: submitted_recovery_contact_digest(contact)
+      )
+    )
+  rescue StandardError => e
+    Rails.logger.warn("Unable to audit unmatched security key recovery rate limit: #{e.message}")
+  end
+
+  def recovery_audit_metadata
+    {
+      ip_address: request.remote_ip,
+      request_id: request.request_id
+    }
+  end
+
+  def submitted_recovery_contact_digest(contact)
+    OpenSSL::HMAC.hexdigest('SHA256', recovery_contact_digest_secret, normalized_recovery_contact(contact))
+  end
+
+  def normalized_recovery_contact(contact)
+    normalized = contact.to_s.strip
+    return 'blank' if normalized.blank?
+    return User.normalize_email(normalized) if User.login_identifier_looks_like_email?(normalized)
+
+    User.normalize_phone(normalized).to_s
+  end
+
+  def recovery_contact_digest_secret
+    Rails.application.key_generator.generate_key('account-recovery-submitted-contact', 32)
+  end
+
+  def request_ip_digest
+    Digest::SHA256.hexdigest(request.remote_ip.to_s)
   end
 
   def notify_admins_of_recovery_request!(recovery_request)

--- a/app/controllers/account_recovery_controller.rb
+++ b/app/controllers/account_recovery_controller.rb
@@ -8,8 +8,7 @@ class AccountRecoveryController < ApplicationController
   end
 
   def create
-    # Find user by email
-    @user = User.find_by_email(params[:email])
+    @user = User.find_by_login_identifier(account_recovery_contact)
 
     if @user.present?
       # Create a recovery request record
@@ -29,6 +28,10 @@ class AccountRecoveryController < ApplicationController
   end
 
   private
+
+  def account_recovery_contact
+    params[:contact].presence
+  end
 
   def create_recovery_request(user)
     # Record the recovery request in the database
@@ -52,7 +55,7 @@ class AccountRecoveryController < ApplicationController
         notifiable: recovery_request,
         metadata: {
           recovery_request_id: recovery_request.id,
-          requester_email: recovery_request.user.email
+          requester_identifier: recovery_request.user.mfa_account_name
         },
         deliver: false
       )

--- a/app/controllers/account_recovery_controller.rb
+++ b/app/controllers/account_recovery_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class AccountRecoveryController < ApplicationController
+  RECOVERY_REQUEST_RATE_LIMIT = 5
+  RECOVERY_REQUEST_RATE_LIMIT_WINDOW = 1.hour
+
   skip_before_action :authenticate_user!, only: %i[new create confirmation]
 
   def new
@@ -10,13 +13,7 @@ class AccountRecoveryController < ApplicationController
   def create
     @user = User.find_by_login_identifier(account_recovery_contact)
 
-    if @user.present?
-      # Create a recovery request record
-      recovery_request = create_recovery_request(@user)
-
-      # Notify administrators of the recovery request
-      notify_admins_of_recovery_request(recovery_request)
-    end
+    submit_recovery_request(@user) if @user.present?
 
     # We don't want to reveal if an email exists in our system
     # So we show the confirmation page regardless
@@ -33,34 +30,65 @@ class AccountRecoveryController < ApplicationController
     params[:contact].presence
   end
 
-  def create_recovery_request(user)
-    # Record the recovery request in the database
-    RecoveryRequest.create!(
-      user: user,
-      status: 'pending',
-      details: params[:details],
-      ip_address: request.remote_ip,
-      user_agent: request.user_agent
-    )
+  def submit_recovery_request(user)
+    return if recovery_submission_rate_limited?(user)
 
-    # Return the recovery request object
+    user.with_lock do
+      return if user.recovery_requests.pending.exists?
+
+      recovery_request = user.recovery_requests.create!(
+        status: 'pending',
+        details: params[:details],
+        ip_address: request.remote_ip,
+        user_agent: request.user_agent
+      )
+      notify_admins_of_recovery_request!(recovery_request)
+    end
+  rescue ActiveRecord::RecordNotUnique
+    # Concurrent duplicate pending — treat as coalesced (partial unique index)
+    nil
+  rescue StandardError => e
+    Rails.logger.error "Failed to submit recovery request for user #{user.id}: #{e.message}"
+    nil
   end
 
-  def notify_admins_of_recovery_request(recovery_request)
+  def recovery_submission_rate_limited?(user)
+    count = Rails.cache.increment(recovery_submission_rate_limit_key(user), 1,
+                                  expires_in: RECOVERY_REQUEST_RATE_LIMIT_WINDOW)
+
+    count.to_i > RECOVERY_REQUEST_RATE_LIMIT
+  end
+
+  def recovery_submission_rate_limit_key(user)
+    hashed_scope = Digest::SHA256.hexdigest("#{user.id}:#{request.remote_ip}")
+    "security_key_recovery:#{hashed_scope}"
+  end
+
+  def notify_admins_of_recovery_request!(recovery_request)
+    admin_count = 0
+    notifications_created = 0
+
     User.admins.find_each do |admin|
-      NotificationService.create_and_deliver!(
-        type: 'security_key_recovery_requested',
-        recipient: admin,
-        actor: recovery_request.user,
-        notifiable: recovery_request,
-        metadata: {
-          recovery_request_id: recovery_request.id,
-          requester_identifier: recovery_request.user.mfa_account_name
-        },
-        deliver: false
-      )
+      admin_count += 1
+      notification = NotificationService.build
+                                        .type('security_key_recovery_requested')
+                                        .recipient(admin)
+                                        .actor(recovery_request.user)
+                                        .notifiable(recovery_request)
+                                        .metadata(
+                                          recovery_request_id: recovery_request.id,
+                                          requester_identifier: recovery_request.user.mfa_account_name
+                                        )
+                                        .channel(:email)
+                                        .deliver(false)
+                                        .create_and_deliver!
+
+      raise 'Failed to create admin notification for recovery request' unless notification.respond_to?(:persisted?) && notification.persisted?
+
+      notifications_created += 1
     end
-  rescue StandardError => e
-    Rails.logger.error "Failed to notify admins of recovery request #{recovery_request.id}: #{e.message}"
+
+    raise 'No admin recipients configured for recovery notification' if admin_count.zero?
+    raise 'Failed to create admin notifications for recovery request' if notifications_created.zero?
   end
 end

--- a/app/controllers/admin/recovery_requests_controller.rb
+++ b/app/controllers/admin/recovery_requests_controller.rb
@@ -15,22 +15,12 @@ module Admin
     end
 
     def approve
-      # Transaction to ensure user's credentials are deleted if and only if the status is updated
-      ActiveRecord::Base.transaction do
-        # Delete all the user's WebAuthn credentials
-        @recovery_request.user.webauthn_credentials.destroy_all
-
-        # Update the recovery request status
-        @recovery_request.update!(
-          status: 'approved',
-          resolved_at: Time.current,
-          resolved_by_id: current_user.id
-        )
-
-        # Notify the user
-        notify_user_of_approval
+      unless approve_pending_request
+        redirect_to admin_recovery_request_path(@recovery_request), alert: t('.not_pending')
+        return
       end
 
+      notify_user_of_approval
       redirect_to admin_recovery_requests_path, notice: t('.recovery_approved')
     end
 
@@ -44,6 +34,24 @@ module Admin
       return if current_user.admin?
 
       redirect_to root_path, alert: t('alerts.unauthorized_page')
+    end
+
+    def approve_pending_request
+      approved = false
+
+      @recovery_request.with_lock do
+        if @recovery_request.pending?
+          @recovery_request.user.webauthn_credentials.destroy_all
+          @recovery_request.update!(
+            status: 'approved',
+            resolved_at: Time.current,
+            resolved_by_id: current_user.id
+          )
+          approved = true
+        end
+      end
+
+      approved
     end
 
     def notify_user_of_approval

--- a/app/controllers/concerns/paper_quick_create_portal_markers.rb
+++ b/app/controllers/concerns/paper_quick_create_portal_markers.rb
@@ -7,7 +7,7 @@ module PaperQuickCreatePortalMarkers
   SESSION_KEY = 'paper_quick_created_portal_users'
 
   def store_quick_created_portal_user_marker!(user)
-    return unless user&.email_backed_portal_account?
+    return unless user&.email_backed_public_portal_account?
 
     prune_stale_quick_created_portal_user_markers!
     session[SESSION_KEY] ||= {}

--- a/app/controllers/concerns/paper_quick_create_portal_markers.rb
+++ b/app/controllers/concerns/paper_quick_create_portal_markers.rb
@@ -7,7 +7,7 @@ module PaperQuickCreatePortalMarkers
   SESSION_KEY = 'paper_quick_created_portal_users'
 
   def store_quick_created_portal_user_marker!(user)
-    return unless user&.portal_access_eligible?
+    return unless user&.email_backed_portal_account?
 
     prune_stale_quick_created_portal_user_markers!
     session[SESSION_KEY] ||= {}

--- a/app/controllers/concerns/two_factor_verification.rb
+++ b/app/controllers/concerns/two_factor_verification.rb
@@ -252,7 +252,7 @@ module TwoFactorVerification # rubocop:disable Metrics/ModuleLength
   # Generate QR code with validated secret only
   def generate_totp_qr_code
     # Only use the validated @secret instance variable
-    @totp_uri = ROTP::TOTP.new(@secret, issuer: 'MatVulcan').provisioning_uri(current_user.email)
+    @totp_uri = ROTP::TOTP.new(@secret, issuer: 'MatVulcan').provisioning_uri(current_user.mfa_account_name)
     @qr_code = RQRCode::QRCode.new(@totp_uri).as_svg(
       color: '000',
       shape_rendering: 'crispEdges',
@@ -291,7 +291,7 @@ module TwoFactorVerification # rubocop:disable Metrics/ModuleLength
     WebAuthn::Credential.options_for_create(
       user: {
         id: current_user.webauthn_id,
-        name: current_user.email
+        name: current_user.mfa_account_name
       },
       exclude: current_user.webauthn_credentials.pluck(:external_id),
       authenticator_selection: {
@@ -307,7 +307,7 @@ module TwoFactorVerification # rubocop:disable Metrics/ModuleLength
     WebAuthn::Credential.options_for_create(
       user: {
         id: current_user.webauthn_id,
-        name: current_user.email
+        name: current_user.mfa_account_name
       },
       exclude: current_user.webauthn_credentials.pluck(:external_id)
     )

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -19,7 +19,7 @@ class PasswordsController < ApplicationController
 
   def create
     user, delivery_method = find_user_for_account_access
-    handle_account_access_request(user, delivery_method) if user.present?
+    attempt_account_access_delivery(user, delivery_method)
 
     redirect_to sign_in_path, notice: account_access_confirmation_message
   end
@@ -94,36 +94,29 @@ class PasswordsController < ApplicationController
     contact = account_access_contact.to_s.strip.presence
     return [nil, nil] if contact.blank?
 
-    if User.login_identifier_looks_like_email?(contact)
-      return [nil, nil] unless User.login_identifier_valid_email?(contact)
-
-      email_user = User.find_by_email(contact)
-      return [nil, nil] if email_user.blank?
-      return [nil, nil] unless email_user.real_email?
-
-      return [email_user, :email]
-    end
-
-    phone_user = User.find_by_phone(contact)
-    return [nil, nil] if phone_user.blank?
-    return [nil, nil] unless phone_user.real_phone?
-    return [nil, nil] unless phone_user.sms_capable_phone?
-
-    [phone_user, :sms]
+    User.find_for_account_access(contact)
   end
 
   def account_access_contact
     params[:contact].presence || params[:email].presence || params[:phone].presence
   end
 
+  def attempt_account_access_delivery(user, delivery_method)
+    return false unless user.present? && delivery_method.present?
+
+    handle_account_access_request(user, delivery_method)
+  end
+
   def handle_account_access_request(user, delivery_method)
     if account_access_rate_limited?(user)
       log_account_access_attempt(user, delivery_method, 'rate_limited')
-      return
+      return false
     end
 
-    send_account_access_instructions(user, delivery_method)
+    return false unless send_account_access_instructions(user, delivery_method)
+
     log_account_access_attempt(user, delivery_method, 'sent')
+    true
   end
 
   def account_access_rate_limited?(user)
@@ -158,9 +151,11 @@ class PasswordsController < ApplicationController
     else
       UserMailer.with(user: user).password_reset.deliver_later
     end
+    true
   rescue StandardError => e
     log_account_access_attempt(user, delivery_method, 'delivery_failed')
     Rails.logger.warn("Unable to send account access instructions for user #{user.id}: #{e.class}: #{e.message}")
+    false
   end
 
   def account_access_sms_body(user)
@@ -197,6 +192,12 @@ class PasswordsController < ApplicationController
   end
 
   def account_access_confirmation_message
-    'If the information you entered matches an account, we sent account access instructions to the contact information on record.'
+    "If you need help signing in, contact the MAT Team at #{account_access_support_email}. " \
+      'Portal accounts require an email address on file. If the information you entered matches such an account, ' \
+      'account access instructions may have been sent when email or text-capable phone delivery is available.'
+  end
+
+  def account_access_support_email
+    Policy.get('support_email') || 'mat.program1@maryland.gov'
   end
 end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -147,7 +147,12 @@ class PasswordsController < ApplicationController
 
   def send_account_access_instructions(user, delivery_method)
     if delivery_method == :sms
-      SmsService.send_message(user.phone, account_access_sms_body(user))
+      SmsService.send_message(
+        user.phone,
+        account_access_sms_body(user),
+        sensitive: true,
+        context: { recipient_id: user.id, recipient_channel: 'account_access_sms' }
+      )
     else
       UserMailer.with(user: user).password_reset.deliver_later
     end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -192,9 +192,10 @@ class PasswordsController < ApplicationController
   end
 
   def account_access_confirmation_message
-    "If you need help signing in, contact the MAT Team at #{account_access_support_email}. " \
-      'Portal accounts require an email address on file. If the information you entered matches such an account, ' \
-      'account access instructions may have been sent when email or text-capable phone delivery is available.'
+    I18n.t(
+      'portal_self_service.account_access.confirmation',
+      support_email: account_access_support_email
+    )
   end
 
   def account_access_support_email

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -102,7 +102,12 @@ class PasswordsController < ApplicationController
   end
 
   def attempt_account_access_delivery(user, delivery_method)
-    return false unless user.present? && delivery_method.present?
+    return false if user.blank?
+
+    if delivery_method.blank?
+      log_account_access_attempt(user, :none, 'delivery_unavailable')
+      return false
+    end
 
     handle_account_access_request(user, delivery_method)
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -21,6 +21,7 @@ class RegistrationsController < ApplicationController
   def create
     build_user
     return render_duplicate_account_prompt if duplicate_account_match?
+    return render_non_email_backed_phone_match_prompt if phone_matches_non_email_backed_record?
 
     # Check for potential duplicates based on Name + DOB and flag for admin review
     @user.needs_duplicate_review = true if potential_duplicate_found?(@user)
@@ -69,11 +70,12 @@ class RegistrationsController < ApplicationController
     @user = User.new(registration_params)
     @user.type = 'Users::Constituent'
     @user.force_password_change = false
+    @user.portal_self_registration = true
   end
 
   def duplicate_account_match?
-    email_user = User.find_by_email(registration_params[:email])
-    phone_user = User.find_by_phone(registration_params[:phone])
+    email_user = email_backed_duplicate_for(registration_params[:email])
+    phone_user = phone_duplicate_for_email_backed_account(registration_params[:phone])
 
     if email_user.present? && phone_user.present? && email_user.id != phone_user.id
       @account_access_conflict = true
@@ -86,6 +88,38 @@ class RegistrationsController < ApplicationController
     @account_access_contact = account_access_contact_for(@account_access_user, @account_access_match_type)
     @account_access_available = @account_access_contact.present?
     @account_access_user.present?
+  end
+
+  def email_backed_duplicate_for(email)
+    return nil if email.blank?
+
+    user = User.find_by_email(email)
+    return nil unless user&.real_email?
+
+    user
+  end
+
+  def phone_duplicate_for_email_backed_account(phone)
+    return nil if phone.blank?
+
+    user = User.find_by_phone(phone)
+    return nil unless user&.real_email? && user.real_phone?
+
+    user
+  end
+
+  def phone_matches_non_email_backed_record?
+    phone = registration_params[:phone]
+    return false if phone.blank?
+
+    user = User.find_by_phone(phone)
+    user.present? && !user.real_email?
+  end
+
+  def render_non_email_backed_phone_match_prompt
+    @registration_requires_mat_help = true
+    @support_email = support_email
+    render :new, status: :unprocessable_content
   end
 
   def render_duplicate_account_prompt
@@ -137,9 +171,9 @@ class RegistrationsController < ApplicationController
   end
 
   def account_access_contact_for(user, match_type)
-    return nil unless user
+    return nil unless user&.real_email?
     return user.email if match_type == 'email'
-    return user.phone if user.phone_type.to_s == 'text'
+    return user.phone if user.sms_capable_phone?
 
     @support_email = support_email
     nil

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -72,7 +72,8 @@ class RegistrationsController < ApplicationController
     @user.type = 'Users::Constituent'
     @user.force_password_change = false
     @user.portal_self_registration = true
-    @user.phone_type_submitted = registration_params.key?(:phone_type)
+    @user.phone_type_submitted = registration_params[:phone_type].present?
+    @user.phone_type = nil if @user.phone.present? && !@user.phone_type_submitted
   end
 
   def duplicate_account_match?

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -21,7 +21,6 @@ class RegistrationsController < ApplicationController
   def create
     build_user
     return render_duplicate_account_prompt if duplicate_account_match?
-    return render_non_email_backed_phone_match_prompt if phone_matches_non_email_backed_record?
 
     # Check for potential duplicates based on Name + DOB and flag for admin review
     @user.needs_duplicate_review = true if potential_duplicate_found?(@user)
@@ -106,20 +105,6 @@ class RegistrationsController < ApplicationController
     return nil unless user&.real_email? && user.real_phone?
 
     user
-  end
-
-  def phone_matches_non_email_backed_record?
-    phone = registration_params[:phone]
-    return false if phone.blank?
-
-    user = User.find_by_phone(phone)
-    user.present? && !user.real_email?
-  end
-
-  def render_non_email_backed_phone_match_prompt
-    @registration_requires_mat_help = true
-    @support_email = support_email
-    render :new, status: :unprocessable_content
   end
 
   def render_duplicate_account_prompt

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -10,6 +10,8 @@ class RegistrationsController < ApplicationController
   # GET /sign_up
   def new
     @user = User.new
+    @user.portal_self_registration = true
+    @user.phone_type = :contact_email
   end
 
   # GET /edit_registration
@@ -70,6 +72,7 @@ class RegistrationsController < ApplicationController
     @user.type = 'Users::Constituent'
     @user.force_password_change = false
     @user.portal_self_registration = true
+    @user.phone_type_submitted = registration_params.key?(:phone_type)
   end
 
   def duplicate_account_match?

--- a/app/javascript/controllers/forms/optional_phone_type_controller.js
+++ b/app/javascript/controllers/forms/optional_phone_type_controller.js
@@ -5,15 +5,43 @@ export default class extends Controller {
   static targets = ["phoneInput", "phoneTypeFields"]
 
   connect() {
+    this.element.dataset.optionalPhoneTypeConnected = "true"
+    if (!this.hasPhoneInputTarget || !this.hasPhoneTypeFieldsTarget) return
+
+    this.boundToggle = this.toggle.bind(this)
+    this.phoneInputTarget.addEventListener("input", this.boundToggle)
+    this.phoneInputTarget.addEventListener("change", this.boundToggle)
+    this.phoneInputTarget.addEventListener("blur", this.boundToggle)
+    this.phoneInputTarget.addEventListener("keyup", this.boundToggle)
+
     this.toggle()
+  }
+
+  disconnect() {
+    if (!this.hasPhoneInputTarget || !this.boundToggle) return
+
+    this.phoneInputTarget.removeEventListener("input", this.boundToggle)
+    this.phoneInputTarget.removeEventListener("change", this.boundToggle)
+    this.phoneInputTarget.removeEventListener("blur", this.boundToggle)
+    this.phoneInputTarget.removeEventListener("keyup", this.boundToggle)
   }
 
   toggle() {
     const hasPhone = this.phoneInputTarget.value.trim().length > 0
-    setVisible(this.phoneTypeFieldsTarget, hasPhone, { ariaHidden: !hasPhone })
+    setVisible(this.phoneTypeFieldsTarget, hasPhone, {
+      ariaHidden: !hasPhone,
+      inlineStyleFallback: false
+    })
 
-    this.phoneTypeFieldsTarget.querySelectorAll("input").forEach((input) => {
+    const radios = this.phoneTypeFieldsTarget.querySelectorAll('input[type="radio"]')
+    radios.forEach((input) => {
       input.disabled = !hasPhone
     })
+
+    if (!hasPhone) {
+      radios.forEach((input) => {
+        input.checked = false
+      })
+    }
   }
 }

--- a/app/javascript/controllers/forms/optional_phone_type_controller.js
+++ b/app/javascript/controllers/forms/optional_phone_type_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+import { setVisible } from "../../utils/visibility"
+
+export default class extends Controller {
+  static targets = ["phoneInput", "phoneTypeFields"]
+
+  connect() {
+    this.toggle()
+  }
+
+  toggle() {
+    const hasPhone = this.phoneInputTarget.value.trim().length > 0
+    setVisible(this.phoneTypeFieldsTarget, hasPhone, { ariaHidden: !hasPhone })
+
+    this.phoneTypeFieldsTarget.querySelectorAll("input").forEach((input) => {
+      input.disabled = !hasPhone
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -21,6 +21,7 @@ import ReportsChartController from "./charts/reports_chart_controller"
 import ApplicationFormController from "./forms/application_form_controller"
 import AutosaveController from "./forms/autosave_controller"
 import DeliveryPreferenceController from "./forms/delivery_preference_controller"
+import OptionalPhoneTypeController from "./forms/optional_phone_type_controller"
 import ContactFeedbackController from "./forms/contact_feedback_controller"
 import CurrencyFormatterController from "./forms/currency_formatter_controller"
 import DateRangeController from "./forms/date_range_controller"
@@ -84,6 +85,7 @@ application.register("reports-chart", ReportsChartController)
 application.register("application-form", ApplicationFormController)
 application.register("autosave", AutosaveController)
 application.register("delivery-preference", DeliveryPreferenceController)
+application.register("optional-phone-type", OptionalPhoneTypeController)
 application.register("contact-feedback", ContactFeedbackController)
 application.register("currency-formatter", CurrencyFormatterController)
 application.register("date-range", DateRangeController)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -171,4 +171,29 @@ class ApplicationMailer < ActionMailer::Base
   rescue StandardError
     fallback.to_s
   end
+
+  def log_mail_error(error, user, template_name, variables)
+    AuditEventService.log(
+      actor: user,
+      action: 'email_delivery_error',
+      auditable: user,
+      metadata: {
+        user_agent: Current.user_agent,
+        ip_address: Current.ip_address,
+        error_message: sanitize_secure_error_message(error.message),
+        error_class: error.class.name,
+        template_name: template_name,
+        variables: sanitized_mail_variables(variables),
+        backtrace: sanitize_secure_value(error.backtrace&.first(5))
+      }
+    )
+  end
+
+  def sanitized_mail_variables(variables)
+    redact_sensitive_mail_value(variables.to_h.deep_dup)
+  end
+
+  def redact_sensitive_mail_value(value, key = nil)
+    sanitize_secure_value(value, key)
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -22,20 +22,7 @@ class UserMailer < ApplicationMailer
     Rails.logger.error "Missing EmailTemplate (text format) for #{template_name}: #{e.message}"
     raise "Email template (text format) not found for #{template_name}"
   rescue StandardError => e
-    AuditEventService.log(
-      actor: user,
-      action: 'email_delivery_error',
-      auditable: user,
-      metadata: {
-        user_agent: Current.user_agent,
-        ip_address: Current.ip_address,
-        error_message: e.message,
-        error_class: e.class.name,
-        template_name: template_name,
-        variables: variables,
-        backtrace: e.backtrace&.first(5)
-      }
-    )
+    log_mail_error(e, user, template_name, variables)
     raise e
   end
 
@@ -59,20 +46,7 @@ class UserMailer < ApplicationMailer
     Rails.logger.error "Missing EmailTemplate (text format) for #{template_name}: #{e.message}"
     raise "Email template (text format) not found for #{template_name}"
   rescue StandardError => e
-    AuditEventService.log(
-      actor: user,
-      action: 'email_delivery_error',
-      auditable: user,
-      metadata: {
-        user_agent: Current.user_agent,
-        ip_address: Current.ip_address,
-        error_message: e.message,
-        error_class: e.class.name,
-        template_name: template_name,
-        variables: variables,
-        backtrace: e.backtrace&.first(5)
-      }
-    )
+    log_mail_error(e, user, template_name, variables)
     raise e
   end
 end

--- a/app/mailers/vendor_notifications_mailer.rb
+++ b/app/mailers/vendor_notifications_mailer.rb
@@ -293,31 +293,6 @@ class VendorNotificationsMailer < ApplicationMailer
     mail_with_text_body(mail_options, body.to_s)
   end
 
-  def log_mail_error(error, user, template_name, variables)
-    AuditEventService.log(
-      actor: user,
-      action: 'email_delivery_error',
-      auditable: user,
-      metadata: {
-        user_agent: Current.user_agent,
-        ip_address: Current.ip_address,
-        error_message: sanitize_secure_error_message(error.message),
-        error_class: error.class.name,
-        template_name: template_name,
-        variables: sanitized_mail_variables(variables),
-        backtrace: sanitize_secure_value(error.backtrace&.first(5))
-      }
-    )
-  end
-
-  def sanitized_mail_variables(variables)
-    redact_sensitive_mail_value(variables.to_h.deep_dup)
-  end
-
-  def redact_sensitive_mail_value(value, key = nil)
-    sanitize_secure_value(value, key)
-  end
-
   def render_transactions_html(transactions)
     rows = transactions.map do |t|
       "<tr><td>#{t.processed_at.strftime('%Y-%m-%d')}</td><td>#{t.voucher.code}</td><td>#{number_to_currency(t.amount)}</td></tr>"

--- a/app/models/concerns/user_contact_predicates.rb
+++ b/app/models/concerns/user_contact_predicates.rb
@@ -29,6 +29,22 @@ module UserContactPredicates
     real_email? || real_phone?
   end
 
+  # PR3 public portal self-service: user-facing portal accounts require stored real email.
+  def email_backed_portal_account?
+    real_email?
+  end
+
+  def mfa_account_name
+    return email if real_email?
+
+    return phone if real_phone?
+
+    name = full_name.presence
+    return name if name.present?
+
+    "user-#{id || 'new'}"
+  end
+
   def portal_phone_only_without_email?
     email.blank? && real_phone?
   end

--- a/app/models/concerns/user_contact_predicates.rb
+++ b/app/models/concerns/user_contact_predicates.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 # Canonical contact truth predicates for portal eligibility, auth guards, and display.
+#
+# Three concepts (do not collapse):
+# - Record truth: real_email?, real_phone?, phone_type, portal_access_eligible?, address_only_contact?
+# - Login identity (public portal only): email_backed_public_portal_account? — requires real_email?;
+#   phone-only records may be portal_access_eligible? but are NOT public login-capable
+# - Delivery route: sms_capable_phone? — SMS delivery, not login eligibility
 module UserContactPredicates
   extend ActiveSupport::Concern
 
@@ -25,12 +31,14 @@ module UserContactPredicates
     real_phone? && phone_type == 'text'
   end
 
+  # Paper/admin portal-contact eligibility: real stored contact (email or phone).
+  # Phone-only records qualify here but are not public portal self-service/login-capable.
   def portal_access_eligible?
     real_email? || real_phone?
   end
 
-  # PR3 public portal self-service: user-facing portal accounts require stored real email.
-  def email_backed_portal_account?
+  # Public portal login identity: sign-in, account access, WebAuthn recovery, self-registration.
+  def email_backed_public_portal_account?
     real_email?
   end
 

--- a/app/models/concerns/user_profile.rb
+++ b/app/models/concerns/user_profile.rb
@@ -323,7 +323,7 @@ module UserProfile
 
   def portal_self_registration_phone_type_matches_phone
     return if phone.blank?
-    return if phone_type_submitted
+    return if phone_type_submitted && phone_type.present?
 
     errors.add(:phone_type, :portal_self_registration_phone_type_required)
   end

--- a/app/models/concerns/user_profile.rb
+++ b/app/models/concerns/user_profile.rb
@@ -5,6 +5,8 @@ module UserProfile
   extend ActiveSupport::Concern
 
   included do
+    attr_accessor :phone_type_submitted
+
     # Callbacks
     before_validation :normalize_email_fields
     before_validation :normalize_communication_preference_for_undeliverable_email
@@ -42,6 +44,8 @@ module UserProfile
     validate :validate_address_for_letter_preference
     validate :email_delivery_requires_real_email
     validate :admin_contact_update_must_remain_reachable, on: :update, if: :validate_admin_contact_update?
+    before_validation :normalize_portal_self_registration_phone_type, if: :portal_self_registration?
+    validate :portal_self_registration_phone_type_matches_phone, if: :portal_self_registration?
     validate :portal_self_registration_requires_email_backed_account, if: :portal_self_registration?
 
     # Enums
@@ -311,6 +315,17 @@ module UserProfile
     return if real_email?
 
     errors.add(:base, :portal_self_registration_requires_email)
+  end
+
+  def normalize_portal_self_registration_phone_type
+    self.phone_type = :contact_email if phone.blank?
+  end
+
+  def portal_self_registration_phone_type_matches_phone
+    return if phone.blank?
+    return if phone_type_submitted
+
+    errors.add(:phone_type, :portal_self_registration_phone_type_required)
   end
 
   def portal_registration_support_email

--- a/app/models/concerns/user_profile.rb
+++ b/app/models/concerns/user_profile.rb
@@ -221,9 +221,19 @@ module UserProfile
 
   def phone_must_be_unique
     return if phone.blank?
+    return unless User.exists_with_phone?(phone, excluding_id: id)
 
-    existing = User.exists_with_phone?(phone, excluding_id: id)
-    errors.add(:phone, 'has already been taken') if existing
+    conflicting_user = User.find_by_phone(phone)
+    if portal_self_registration? && conflicting_user.present? && !conflicting_user.real_email?
+      errors.add(
+        :base,
+        :portal_self_registration_unavailable_contact,
+        support_email: portal_registration_support_email
+      )
+      return
+    end
+
+    errors.add(:phone, 'has already been taken')
   rescue StandardError => e
     Rails.logger.warn "Phone uniqueness check failed: #{e.message}"
   end
@@ -300,10 +310,11 @@ module UserProfile
   def portal_self_registration_requires_email_backed_account
     return if real_email?
 
-    errors.add(
-      :base,
-      'A portal account requires an email address. If you do not have email, please contact MAT for assistance with a paper application.'
-    )
+    errors.add(:base, :portal_self_registration_requires_email)
+  end
+
+  def portal_registration_support_email
+    Policy.get('support_email') || 'mat.program1@maryland.gov'
   end
 
   def was_address_only_contact?

--- a/app/models/concerns/user_profile.rb
+++ b/app/models/concerns/user_profile.rb
@@ -42,6 +42,7 @@ module UserProfile
     validate :validate_address_for_letter_preference
     validate :email_delivery_requires_real_email
     validate :admin_contact_update_must_remain_reachable, on: :update, if: :validate_admin_contact_update?
+    validate :portal_self_registration_requires_email_backed_account, if: :portal_self_registration?
 
     # Enums
     enum :status, { inactive: 0, active: 1, suspended: 2 }, default: :active
@@ -237,7 +238,8 @@ module UserProfile
     Current.paper_context && phone.blank?
   end
 
-  # Phone-only portal users store NULL email; password/profile saves must not require email.
+  # Phone-only paper records store NULL email; password/profile saves must not require email.
+  # They are not email-backed portal accounts and cannot use public portal sign-in.
   # Address-only users store NULL email/phone and remain editable outside paper context.
   def email_optional?
     paper_context_no_email? ||
@@ -289,6 +291,19 @@ module UserProfile
     return if was_address_only_contact?
 
     errors.add(:base, 'Cannot clear all contact information outside paper intake.')
+  end
+
+  def portal_self_registration?
+    portal_self_registration == true
+  end
+
+  def portal_self_registration_requires_email_backed_account
+    return if real_email?
+
+    errors.add(
+      :base,
+      'A portal account requires an email address. If you do not have email, please contact MAT for assistance with a paper application.'
+    )
   end
 
   def was_address_only_contact?

--- a/app/models/recovery_request.rb
+++ b/app/models/recovery_request.rb
@@ -4,12 +4,18 @@ class RecoveryRequest < ApplicationRecord
   belongs_to :user
   belongs_to :resolved_by, class_name: 'User', optional: true
 
+  scope :pending, -> { where(status: 'pending') }
+
   validates :status, presence: true
   validates :ip_address, presence: true
   validates :user_agent, presence: true
 
   # Default values
   after_initialize :set_default_values, if: :new_record?
+
+  def pending?
+    status.to_s == 'pending'
+  end
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,6 +89,8 @@ class User < ApplicationRecord
     normalized.match?(URI::MailTo::EMAIL_REGEXP)
   end
 
+  # Public portal login/recovery lookup only (email-backed accounts; phone alternate when real_phone?).
+  # Do not use for paper/admin contact matching or delivery routing — use find_for_account_access for delivery.
   def self.find_by_login_identifier(contact)
     normalized = contact.to_s.strip.presence
     return nil if normalized.blank?
@@ -177,6 +179,7 @@ class User < ApplicationRecord
            dependent: :destroy,
            inverse_of: :recipient
   has_many :applications, inverse_of: :user, dependent: :nullify
+  has_many :recovery_requests, dependent: :destroy
   has_many :income_verified_applications,
            class_name: 'Application',
            foreign_key: :income_verified_by_id,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -179,7 +179,7 @@ class User < ApplicationRecord
            dependent: :destroy,
            inverse_of: :recipient
   has_many :applications, inverse_of: :user, dependent: :nullify
-  has_many :recovery_requests, dependent: :destroy
+  has_many :recovery_requests, dependent: :restrict_with_exception
   has_many :income_verified_applications,
            class_name: 'Application',
            foreign_key: :income_verified_by_id,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
 
   # Ensure duplicate review flag is accessible
   attr_accessor :needs_duplicate_review unless column_names.include?('needs_duplicate_review')
+  attr_accessor :portal_self_registration
 
   # Class methods
   def self.normalize_email(email_value)
@@ -104,10 +105,32 @@ class User < ApplicationRecord
 
     phone_user = find_by_phone(normalized)
     return nil if phone_user.blank?
+    return nil unless phone_user.real_email?
     return nil unless phone_user.real_phone?
 
     phone_user
   end
+
+  def self.find_for_account_access(contact)
+    user = find_by_login_identifier(contact)
+    return [nil, nil] unless user&.real_email?
+
+    [user, account_access_delivery_method_for(user, contact)]
+  end
+
+  def self.account_access_delivery_method_for(user, contact)
+    normalized = contact.to_s.strip.presence
+    return nil if normalized.blank?
+
+    if login_identifier_looks_like_email?(normalized)
+      return :email if user.real_email?
+    elsif user.sms_capable_phone?
+      return :sms
+    end
+
+    nil
+  end
+  private_class_method :account_access_delivery_method_for
 
   def self.placeholder_phone?(phone)
     synthetic_dependent_phone?(phone)

--- a/app/services/applications/guardian_dependent_management_service.rb
+++ b/app/services/applications/guardian_dependent_management_service.rb
@@ -13,7 +13,7 @@ module Applications
       @params = params.with_indifferent_access
       @guardian_user = nil
       @dependent_user = nil
-      @portal_eligible_created_user_ids = []
+      @email_backed_portal_created_user_ids = []
       @errors = []
     end
 
@@ -29,7 +29,7 @@ module Applications
       success(
         guardian: @guardian_user,
         dependent: @dependent_user,
-        portal_eligible_created_user_ids: @portal_eligible_created_user_ids
+        email_backed_portal_created_user_ids: @email_backed_portal_created_user_ids
       )
     end
 
@@ -79,7 +79,7 @@ module Applications
         return false unless result.success?
 
         @guardian_user = result.data[:user]
-        track_portal_eligible_created_user_id(result.data[:portal_eligible_created_user_id])
+        track_email_backed_portal_created_user_id(result.data[:email_backed_portal_created_user_id])
       else
         return add_error?('Guardian information missing')
       end
@@ -91,7 +91,7 @@ module Applications
       return false unless result.success?
 
       @dependent_user = result.data[:user]
-      track_portal_eligible_created_user_id(result.data[:portal_eligible_created_user_id])
+      track_email_backed_portal_created_user_id(result.data[:email_backed_portal_created_user_id])
       true
     end
 
@@ -204,8 +204,8 @@ module Applications
       attrs.present? && attrs.values.any?(&:present?)
     end
 
-    def track_portal_eligible_created_user_id(user_id)
-      @portal_eligible_created_user_ids << user_id.to_s if user_id.present?
+    def track_email_backed_portal_created_user_id(user_id)
+      @email_backed_portal_created_user_ids << user_id.to_s if user_id.present?
     end
 
     def add_error?(message)

--- a/app/services/applications/paper_application_service.rb
+++ b/app/services/applications/paper_application_service.rb
@@ -949,7 +949,7 @@ module Applications
       return unless send_account_created_notice?
 
       new_user_accounts.each do |user|
-        next unless user.email_backed_portal_account?
+        next unless user.email_backed_public_portal_account?
 
         append_account_access_warning(user) if quick_created_portal_user?(user)
 
@@ -999,7 +999,7 @@ module Applications
     end
 
     def account_created_notice_candidate?(user)
-      return false unless user.email_backed_portal_account?
+      return false unless user.email_backed_public_portal_account?
       return false unless account_access_instructions_deliverable?(user)
 
       @created_portal_user_ids.include?(user.id.to_s) || quick_created_portal_user?(user)

--- a/app/services/applications/paper_application_service.rb
+++ b/app/services/applications/paper_application_service.rb
@@ -286,7 +286,7 @@ module Applications
         @guardian_user_for_app = result.data[:guardian]
         @constituent = result.data[:dependent]
 
-        track_portal_eligible_created_user_ids(result.data[:portal_eligible_created_user_ids])
+        track_email_backed_portal_created_user_ids(result.data[:email_backed_portal_created_user_ids])
 
         validate_no_active_application('dependent')
       else
@@ -309,7 +309,7 @@ module Applications
 
       if result.success?
         @constituent = result.data[:user]
-        track_portal_eligible_created_user_id(result.data[:portal_eligible_created_user_id])
+        track_email_backed_portal_created_user_id(result.data[:email_backed_portal_created_user_id])
 
         return false unless validate_no_active_application('constituent')
         return false unless waiting_period_eligible?(@constituent)
@@ -333,11 +333,11 @@ module Applications
       Applications::PaperContactFlags.new(params, scope: scope)
     end
 
-    def track_portal_eligible_created_user_ids(user_ids)
-      Array(user_ids).each { |user_id| track_portal_eligible_created_user_id(user_id) }
+    def track_email_backed_portal_created_user_ids(user_ids)
+      Array(user_ids).each { |user_id| track_email_backed_portal_created_user_id(user_id) }
     end
 
-    def track_portal_eligible_created_user_id(user_id)
+    def track_email_backed_portal_created_user_id(user_id)
       @created_portal_user_ids << user_id.to_s if user_id.present?
     end
 
@@ -949,7 +949,7 @@ module Applications
       return unless send_account_created_notice?
 
       new_user_accounts.each do |user|
-        next unless user.portal_access_eligible?
+        next unless user.email_backed_portal_account?
 
         append_account_access_warning(user) if quick_created_portal_user?(user)
 
@@ -999,7 +999,7 @@ module Applications
     end
 
     def account_created_notice_candidate?(user)
-      return false unless user.portal_access_eligible?
+      return false unless user.email_backed_portal_account?
       return false unless account_access_instructions_deliverable?(user)
 
       @created_portal_user_ids.include?(user.id.to_s) || quick_created_portal_user?(user)

--- a/app/services/applications/user_creation_service.rb
+++ b/app/services/applications/user_creation_service.rb
@@ -83,7 +83,7 @@ module Applications
       user = build_user
 
       if user.save
-        Rails.logger.info { "Created user #{user.id} (email_backed_portal=#{user.email_backed_portal_account?})" }
+        Rails.logger.info { "Created user #{user.id} (email_backed_portal=#{user.email_backed_public_portal_account?})" }
         user
       else
         @errors << "Failed to create user: #{user.errors.full_messages.join(', ')}"
@@ -136,11 +136,11 @@ module Applications
     end
 
     def email_backed_portal_created_user_id(user)
-      user.email_backed_portal_account? ? user.id : nil
+      user.email_backed_public_portal_account? ? user.id : nil
     end
 
     def email_backed_portal_account_from_attrs?
-      User.new(email: attrs[:email], phone: attrs[:phone], phone_type: attrs[:phone_type]).email_backed_portal_account?
+      User.new(email: attrs[:email], phone: attrs[:phone], phone_type: attrs[:phone_type]).email_backed_public_portal_account?
     end
 
     def normalize_contact_attrs!

--- a/app/services/applications/user_creation_service.rb
+++ b/app/services/applications/user_creation_service.rb
@@ -31,7 +31,7 @@ module Applications
             success: true,
             data: {
               user: existing,
-              portal_eligible_created_user_id: nil,
+              email_backed_portal_created_user_id: nil,
               existing_user: true
             }
           )
@@ -45,7 +45,7 @@ module Applications
           success: true,
           data: {
             user: user,
-            portal_eligible_created_user_id: portal_eligible_created_user_id(user)
+            email_backed_portal_created_user_id: email_backed_portal_created_user_id(user)
           }
         )
       else
@@ -83,7 +83,7 @@ module Applications
       user = build_user
 
       if user.save
-        Rails.logger.info { "Created user #{user.id} (portal_eligible=#{user.portal_access_eligible?})" }
+        Rails.logger.info { "Created user #{user.id} (email_backed_portal=#{user.email_backed_portal_account?})" }
         user
       else
         @errors << "Failed to create user: #{user.errors.full_messages.join(', ')}"
@@ -120,7 +120,7 @@ module Applications
       user.verified = true
       user.instance_variable_set(:@validate_disability_required, true) if @require_disability_validation
 
-      if portal_eligible_from_attrs?
+      if email_backed_portal_account_from_attrs?
         initial_password = SecureRandom.hex(8)
         user.password = initial_password
         user.password_confirmation = initial_password
@@ -135,12 +135,12 @@ module Applications
       user
     end
 
-    def portal_eligible_created_user_id(user)
-      user.portal_access_eligible? ? user.id : nil
+    def email_backed_portal_created_user_id(user)
+      user.email_backed_portal_account? ? user.id : nil
     end
 
-    def portal_eligible_from_attrs?
-      User.new(email: attrs[:email], phone: attrs[:phone], phone_type: attrs[:phone_type]).portal_access_eligible?
+    def email_backed_portal_account_from_attrs?
+      User.new(email: attrs[:email], phone: attrs[:phone], phone_type: attrs[:phone_type]).email_backed_portal_account?
     end
 
     def normalize_contact_attrs!

--- a/app/services/concerns/secure_error_sanitizer.rb
+++ b/app/services/concerns/secure_error_sanitizer.rb
@@ -11,6 +11,8 @@ module SecureErrorSanitizer
     secure_token
     secure_upload_url
     secure_url
+    reset_url
+    verification_url
     token
   ].freeze
 

--- a/app/views/account_recovery/confirmation.html.erb
+++ b/app/views/account_recovery/confirmation.html.erb
@@ -3,15 +3,15 @@
     <svg class="mx-auto h-12 w-12 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
     </svg>
-    
-    <h1 class="mt-4 text-xl font-semibold text-gray-900">Recovery Request Submitted</h1>
-    
+
+    <h1 class="mt-4 text-xl font-semibold text-gray-900"><%= t("portal_self_service.account_recovery.confirmation_title") %></h1>
+
     <p class="mt-2 text-sm text-gray-600">
-      An administrator will review your request and contact you shortly. Please check your email for updates.
+      <%= t("portal_self_service.account_recovery.confirmation_body") %>
     </p>
-    
+
     <div class="mt-6">
-      <%= link_to "Return to Sign In", sign_in_path, 
+      <%= link_to t("portal_self_service.account_recovery.back_to_sign_in"), sign_in_path,
                  class: "inline-block py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700" %>
     </div>
   </div>

--- a/app/views/account_recovery/new.html.erb
+++ b/app/views/account_recovery/new.html.erb
@@ -10,8 +10,9 @@
     
     <%= form_with url: request_security_key_reset_path, local: true, class: "space-y-6" do |form| %>
       <div class="space-y-1">
-        <%= form.label :email, "Email Address", class: "block text-sm font-medium text-gray-700" %>
-        <%= form.email_field :email, class: "mt-1 block w-full px-4 py-2 border rounded-md", required: true %>
+        <%= form.label :contact, "Email Address or Phone Number", class: "block text-sm font-medium text-gray-700" %>
+        <%= form.text_field :contact, class: "mt-1 block w-full px-4 py-2 border rounded-md", required: true, autofocus: true %>
+        <p class="text-xs text-gray-500">Portal accounts require an email address on file. Enter that email, or the phone number on the same account.</p>
       </div>
       
       <div class="space-y-1">

--- a/app/views/account_recovery/new.html.erb
+++ b/app/views/account_recovery/new.html.erb
@@ -1,35 +1,40 @@
 <div class="min-h-screen flex items-center justify-center bg-gray-100 px-4 py-12">
   <div class="bg-white p-6 sm:p-8 rounded-lg shadow-md w-full max-w-md">
-    <h1 class="text-2xl font-semibold mb-6 text-center text-gray-900">Security Key Recovery</h1>
+    <h1 class="text-2xl font-semibold mb-6 text-center text-gray-900"><%= t("portal_self_service.account_recovery.title") %></h1>
     
     <div class="mb-6 p-4 bg-yellow-50 border border-yellow-300 rounded-md">
       <p class="text-sm text-yellow-700">
-        <strong>Note:</strong> Lost security keys cannot be recovered. An administrator will need to verify your identity and reset your 2FA enrollment.
+        <strong>Note:</strong> <%= t("portal_self_service.account_recovery.note") %>
       </p>
     </div>
     
     <%= form_with url: request_security_key_reset_path, local: true, class: "space-y-6" do |form| %>
       <div class="space-y-1">
-        <%= form.label :contact, "Email Address or Phone Number", class: "block text-sm font-medium text-gray-700" %>
-        <%= form.text_field :contact, class: "mt-1 block w-full px-4 py-2 border rounded-md", required: true, autofocus: true %>
-        <p class="text-xs text-gray-500">Portal accounts require an email address on file. Enter that email, or the phone number on the same account.</p>
+        <%= form.label :contact, t("portal_self_service.contact_label"), class: "block text-sm font-medium text-gray-700" %>
+        <%= form.text_field :contact,
+            id: "account-recovery-contact",
+            class: "mt-1 block w-full px-4 py-2 border rounded-md",
+            required: true,
+            autofocus: true,
+            aria: { describedby: "account-recovery-contact-hint" } %>
+        <p id="account-recovery-contact-hint" class="text-xs text-gray-500"><%= t("sessions.form.contact_hint") %></p>
       </div>
       
       <div class="space-y-1">
-        <%= form.label :details, "Additional Details", class: "block text-sm font-medium text-gray-700" %>
+        <%= form.label :details, t("portal_self_service.account_recovery.details_label"), class: "block text-sm font-medium text-gray-700" %>
         <%= form.text_area :details, 
                            class: "mt-1 block w-full px-4 py-2 border rounded-md h-24", 
-                           placeholder: "Please provide any details that will help verify your identity (e.g., reason for reset, when you last accessed the system, etc.)" %>
+                           placeholder: t("portal_self_service.account_recovery.details_placeholder") %>
       </div>
       
-      <%= form.submit "Submit Recovery Request", 
+      <%= form.submit t("portal_self_service.account_recovery.submit"), 
                      class: "w-full py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700" %>
     <% end %>
     
     <div class="mt-6 text-center">
       <p class="text-sm text-gray-600">
         Remember your security key?
-        <%= link_to "Back to sign in", sign_in_path, class: "text-indigo-600 hover:text-indigo-500" %>
+        <%= link_to t("portal_self_service.account_recovery.back_to_sign_in"), sign_in_path, class: "text-indigo-600 hover:text-indigo-500" %>
       </p>
     </div>
   </div>

--- a/app/views/account_recovery/new.html.erb
+++ b/app/views/account_recovery/new.html.erb
@@ -1,13 +1,13 @@
 <div class="min-h-screen flex items-center justify-center bg-gray-100 px-4 py-12">
   <div class="bg-white p-6 sm:p-8 rounded-lg shadow-md w-full max-w-md">
     <h1 class="text-2xl font-semibold mb-6 text-center text-gray-900"><%= t("portal_self_service.account_recovery.title") %></h1>
-    
+
     <div class="mb-6 p-4 bg-yellow-50 border border-yellow-300 rounded-md">
       <p class="text-sm text-yellow-700">
         <strong>Note:</strong> <%= t("portal_self_service.account_recovery.note") %>
       </p>
     </div>
-    
+
     <%= form_with url: request_security_key_reset_path, local: true, class: "space-y-6" do |form| %>
       <div class="space-y-1">
         <%= form.label :contact, t("portal_self_service.contact_label"), class: "block text-sm font-medium text-gray-700" %>
@@ -19,18 +19,18 @@
             aria: { describedby: "account-recovery-contact-hint" } %>
         <p id="account-recovery-contact-hint" class="text-xs text-gray-500"><%= t("sessions.form.contact_hint") %></p>
       </div>
-      
+
       <div class="space-y-1">
         <%= form.label :details, t("portal_self_service.account_recovery.details_label"), class: "block text-sm font-medium text-gray-700" %>
-        <%= form.text_area :details, 
-                           class: "mt-1 block w-full px-4 py-2 border rounded-md h-24", 
+        <%= form.text_area :details,
+                           class: "mt-1 block w-full px-4 py-2 border rounded-md h-24",
                            placeholder: t("portal_self_service.account_recovery.details_placeholder") %>
       </div>
-      
-      <%= form.submit t("portal_self_service.account_recovery.submit"), 
+
+      <%= form.submit t("portal_self_service.account_recovery.submit"),
                      class: "w-full py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700" %>
     <% end %>
-    
+
     <div class="mt-6 text-center">
       <p class="text-sm text-gray-600">
         Remember your security key?

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <div class="min-h-screen flex items-center justify-center bg-gray-100">
   <div class="bg-white p-8 rounded shadow-md w-full max-w-md">
-    <h2 class="text-2xl font-semibold mb-6 text-center">Account Access</h2>
+    <h2 class="text-2xl font-semibold mb-6 text-center"><%= t("portal_self_service.account_access.title") %></h2>
 
     <% if flash[:alert] %>
       <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
@@ -10,22 +10,24 @@
 
     <%= form_with url: password_path, method: :post, class: "space-y-6" do |form| %>
       <div>
-        <%= form.label :contact, "Email Address or Phone Number", class: "block text-gray-700" %>
+        <%= form.label :contact, t("portal_self_service.contact_label"), class: "block text-gray-700" %>
         <%= form.text_field :contact,
+            id: "account-access-contact",
             class: "mt-1 block w-full px-4 py-2 bg-white border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500",
             required: true,
-            autofocus: true %>
-        <p class="mt-2 text-sm text-gray-500">
-          Portal accounts require an email address on file. Enter that email, or the phone number on the same account, and we will send account access instructions when a supported delivery method is available.
+            autofocus: true,
+            aria: { describedby: "account-access-contact-hint" } %>
+        <p id="account-access-contact-hint" class="mt-2 text-sm text-gray-500">
+          <%= t("portal_self_service.contact_hint") %>
         </p>
       </div>
 
       <div>
-        <%= form.submit "Send Account Access Link", class: "w-full bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
+        <%= form.submit t("portal_self_service.account_access.submit"), class: "w-full bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
       </div>
 
       <div class="text-center mt-4">
-        <%= link_to "Back to Sign In", sign_in_path, class: "text-sm text-indigo-600 hover:text-indigo-500" %>
+        <%= link_to t("portal_self_service.account_access.back_to_sign_in"), sign_in_path, class: "text-sm text-indigo-600 hover:text-indigo-500" %>
       </div>
     <% end %>
   </div>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -16,7 +16,7 @@
             required: true,
             autofocus: true %>
         <p class="mt-2 text-sm text-gray-500">
-          Enter the email address or phone number already on your account and we'll send account access instructions.
+          Portal accounts require an email address on file. Enter that email, or the phone number on the same account, and we will send account access instructions when a supported delivery method is available.
         </p>
       </div>
 

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -33,6 +33,14 @@
           Please contact the MAT Team at <%= mail_to @support_email %> for help accessing your account.
         </p>
       </div>
+    <% elsif @registration_requires_mat_help %>
+      <div role="alert" aria-live="assertive"
+           class="bg-yellow-50 border border-yellow-400 text-yellow-900 px-4 py-3 rounded mb-6">
+        <h2 class="font-semibold mb-2">We need help finishing your registration.</h2>
+        <p class="text-sm">
+          Portal accounts require an email address. Please contact the MAT Team at <%= mail_to @support_email %> for assistance.
+        </p>
+      </div>
     <% elsif @account_access_user.present? %>
       <section class="bg-blue-50 border border-blue-300 text-blue-900 px-4 py-4 rounded mb-6">
         <h2 id="account-access-heading" class="font-semibold mb-2">
@@ -40,16 +48,16 @@
         </h2>
         <% if @account_access_available %>
           <p class="text-sm mb-4">
-            You can log in with your email and password, or we can send an account access link to the contact information already on record.
+            You can log in with your email or phone and password, or we can send an account access link to the contact information already on record.
           </p>
         <% else %>
           <p class="text-sm mb-4">
-            You can log in with your email and password. To receive an account access link, please contact the MAT Team at <%= mail_to @support_email %>.
+            You can log in with your email or phone and password. To receive an account access link, please contact the MAT Team at <%= mail_to @support_email %>.
           </p>
         <% end %>
         <div class="space-y-3">
-          <%= link_to "Log in with your email and password",
-                      sign_in_path(email_hint: (@account_access_match_type == 'email' ? @account_access_contact : nil)),
+          <%= link_to "Log in with your email or phone and password",
+                      sign_in_path(email_hint: @account_access_contact),
                       class: "block w-full text-center bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
           <% if @account_access_available %>
             <%= form_with url: password_path, method: :post, local: true do |access_form| %>
@@ -123,11 +131,11 @@
             <% end %>
           </div>
           <div class="mb-4">
-            <%= form.label :phone, "Phone Number", class: "block text-sm font-medium text-gray-700 mb-1 required-label" %>
-            <%= form.telephone_field :phone, required: true, pattern: "[0-9]{3}-?[0-9]{3}-?[0-9]{4}", placeholder: "202-555-5555",
+            <%= form.label :phone, "Phone Number (Optional)", class: "block text-sm font-medium text-gray-700 mb-1" %>
+            <%= form.telephone_field :phone, pattern: "[0-9]{3}-?[0-9]{3}-?[0-9]{4}", placeholder: "202-555-5555",
                 class: "block w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 sm:text-sm",
-                aria: { required: "true", invalid: @user.errors[:phone].any?, errormessage: "phone-error", describedby: "phone-hint" } %>
-            <p id="phone-hint" class="text-xs text-gray-700">10-digit number</p>
+                aria: { invalid: @user.errors[:phone].any?, errormessage: "phone-error", describedby: "phone-hint" } %>
+            <p id="phone-hint" class="text-xs text-gray-700">Optional. 10-digit number. When provided, you can also sign in with your phone number.</p>
             <% if @user.errors[:phone].any? %>
               <p id="phone-error" role="alert" class="mt-1 text-sm text-red-600"><%= @user.errors[:phone].join(", ") %></p>
             <% end %>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -28,41 +28,36 @@
     <% if @account_access_conflict %>
       <div role="alert" aria-live="assertive"
            class="bg-yellow-50 border border-yellow-400 text-yellow-900 px-4 py-3 rounded mb-6">
-        <h2 class="font-semibold mb-2">We found conflicting account information.</h2>
+        <h2 class="font-semibold mb-2"><%= t("portal_self_service.registrations.duplicate_conflict_heading") %></h2>
         <p class="text-sm">
-          Please contact the MAT Team at <%= mail_to @support_email %> for help accessing your account.
-        </p>
-      </div>
-    <% elsif @registration_requires_mat_help %>
-      <div role="alert" aria-live="assertive"
-           class="bg-yellow-50 border border-yellow-400 text-yellow-900 px-4 py-3 rounded mb-6">
-        <h2 class="font-semibold mb-2">We need help finishing your registration.</h2>
-        <p class="text-sm">
-          Portal accounts require an email address. Please contact the MAT Team at <%= mail_to @support_email %> for assistance.
+          <%= t("portal_self_service.registrations.duplicate_conflict_body", support_email: mail_to(@support_email)).html_safe %>
         </p>
       </div>
     <% elsif @account_access_user.present? %>
       <section class="bg-blue-50 border border-blue-300 text-blue-900 px-4 py-4 rounded mb-6">
         <h2 id="account-access-heading" class="font-semibold mb-2">
-          An account already exists with that <%= @account_access_match_type %>.
+          <%= t(
+                "portal_self_service.registrations.duplicate_exists_heading",
+                match_type: t("portal_self_service.registrations.match_type.#{@account_access_match_type}")
+              ) %>
         </h2>
         <% if @account_access_available %>
           <p class="text-sm mb-4">
-            You can log in with your email or phone and password, or we can send an account access link to the contact information already on record.
+            <%= t("portal_self_service.registrations.duplicate_available_body") %>
           </p>
         <% else %>
           <p class="text-sm mb-4">
-            You can log in with your email or phone and password. To receive an account access link, please contact the MAT Team at <%= mail_to @support_email %>.
+            <%= t("portal_self_service.registrations.duplicate_no_link_body", support_email: mail_to(@support_email)).html_safe %>
           </p>
         <% end %>
         <div class="space-y-3">
-          <%= link_to "Log in with your email or phone and password",
+          <%= link_to t("portal_self_service.registrations.log_in_cta"),
                       sign_in_path(email_hint: @account_access_contact),
                       class: "block w-full text-center bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
           <% if @account_access_available %>
             <%= form_with url: password_path, method: :post, local: true do |access_form| %>
               <%= access_form.hidden_field :contact, value: @account_access_contact %>
-              <%= access_form.submit "Send account access link",
+              <%= access_form.submit t("portal_self_service.registrations.send_access_link"),
                   class: "w-full bg-white text-indigo-700 border border-indigo-500 px-4 py-2 rounded-md hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
             <% end %>
           <% end %>
@@ -119,7 +114,7 @@
         </fieldset>
 
         <!-- Contact Fields -->
-        <fieldset class="mb-4">
+        <fieldset class="mb-4" data-controller="optional-phone-type">
           <legend class="sr-only">Contact Information</legend>
           <div class="mb-4">
             <%= form.label :email, "Email Address", class: "block text-sm font-medium text-gray-700 mb-1 required-label" %>
@@ -134,28 +129,34 @@
             <%= form.label :phone, "Phone Number (Optional)", class: "block text-sm font-medium text-gray-700 mb-1" %>
             <%= form.telephone_field :phone, pattern: "[0-9]{3}-?[0-9]{3}-?[0-9]{4}", placeholder: "202-555-5555",
                 class: "block w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 sm:text-sm",
-                aria: { invalid: @user.errors[:phone].any?, errormessage: "phone-error", describedby: "phone-hint" } %>
-            <p id="phone-hint" class="text-xs text-gray-700">Optional. 10-digit number. When provided, you can also sign in with your phone number.</p>
+                aria: { invalid: @user.errors[:phone].any?, errormessage: "phone-error", describedby: "phone-hint" },
+                data: { optional_phone_type_target: "phoneInput", action: "input->optional-phone-type#toggle change->optional-phone-type#toggle" } %>
+            <p id="phone-hint" class="text-xs text-gray-700"><%= t("portal_self_service.registrations.phone_hint") %></p>
             <% if @user.errors[:phone].any? %>
               <p id="phone-error" role="alert" class="mt-1 text-sm text-red-600"><%= @user.errors[:phone].join(", ") %></p>
             <% end %>
           </div>
-          <div class="mb-4">
-            <%= form.label :phone_type, "Phone Type", id: "phone-type-legend", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <div class="mb-4 <%= 'hidden' if @user.phone.blank? %>"
+               data-optional-phone-type-target="phoneTypeFields"
+               aria-hidden="<%= @user.phone.blank? %>">
+            <%= form.label :phone_type, t("portal_self_service.registrations.phone_type_label"), id: "phone-type-legend", class: "block text-sm font-medium text-gray-700 mb-1" %>
             <div class="space-y-2">
               <div class="flex items-center">
-                <%= form.radio_button :phone_type, "voice", id: "phone_type_voice", checked: true,
-                       class: "h-4 w-4 focus:ring-indigo-500" %>
+                <%= form.radio_button :phone_type, "voice", id: "phone_type_voice", checked: @user.phone.present?,
+                       class: "h-4 w-4 focus:ring-indigo-500",
+                       disabled: @user.phone.blank? %>
                 <%= form.label :phone_type_voice, "Voice", for: "phone_type_voice", class: "ml-3 text-sm text-gray-700" %>
               </div>
                           <div class="flex items-center">
               <%= form.radio_button :phone_type, "videophone", id: "phone_type_videophone",
-                     class: "h-4 w-4 focus:ring-indigo-500" %>
+                     class: "h-4 w-4 focus:ring-indigo-500",
+                     disabled: @user.phone.blank? %>
               <%= form.label :phone_type_videophone, "Videophone", for: "phone_type_videophone", class: "ml-3 text-sm text-gray-700" %>
             </div>
             <div class="flex items-center">
               <%= form.radio_button :phone_type, "text", id: "phone_type_text",
-                     class: "h-4 w-4 focus:ring-indigo-500" %>
+                     class: "h-4 w-4 focus:ring-indigo-500",
+                     disabled: @user.phone.blank? %>
               <%= form.label :phone_type_text, "Text/SMS", for: "phone_type_text", class: "ml-3 text-sm text-gray-700" %>
             </div>
             </div>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -52,7 +52,7 @@
         <% end %>
         <div class="space-y-3">
           <%= link_to t("portal_self_service.registrations.log_in_cta"),
-                      sign_in_path(email_hint: @account_access_contact),
+                      sign_in_path,
                       class: "block w-full text-center bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
           <% if @account_access_available %>
             <%= form_with url: password_path, method: :post, local: true do |access_form| %>
@@ -114,7 +114,8 @@
         </fieldset>
 
         <!-- Contact Fields -->
-        <fieldset class="mb-4" data-controller="optional-phone-type">
+        <div data-controller="optional-phone-type">
+        <fieldset class="mb-4">
           <legend class="sr-only">Contact Information</legend>
           <div class="mb-4">
             <%= form.label :email, "Email Address", class: "block text-sm font-medium text-gray-700 mb-1 required-label" %>
@@ -130,7 +131,7 @@
             <%= form.telephone_field :phone, pattern: "[0-9]{3}-?[0-9]{3}-?[0-9]{4}", placeholder: "202-555-5555",
                 class: "block w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 sm:text-sm",
                 aria: { invalid: @user.errors[:phone].any?, errormessage: "phone-error", describedby: "phone-hint" },
-                data: { optional_phone_type_target: "phoneInput", action: "input->optional-phone-type#toggle change->optional-phone-type#toggle" } %>
+                data: { optional_phone_type_target: "phoneInput" } %>
             <p id="phone-hint" class="text-xs text-gray-700"><%= t("portal_self_service.registrations.phone_hint") %></p>
             <% if @user.errors[:phone].any? %>
               <p id="phone-error" role="alert" class="mt-1 text-sm text-red-600"><%= @user.errors[:phone].join(", ") %></p>
@@ -142,7 +143,7 @@
             <%= form.label :phone_type, t("portal_self_service.registrations.phone_type_label"), id: "phone-type-legend", class: "block text-sm font-medium text-gray-700 mb-1" %>
             <div class="space-y-2">
               <div class="flex items-center">
-                <%= form.radio_button :phone_type, "voice", id: "phone_type_voice", checked: @user.phone.present?,
+                <%= form.radio_button :phone_type, "voice", id: "phone_type_voice",
                        class: "h-4 w-4 focus:ring-indigo-500",
                        disabled: @user.phone.blank? %>
                 <%= form.label :phone_type_voice, "Voice", for: "phone_type_voice", class: "ml-3 text-sm text-gray-700" %>
@@ -165,6 +166,7 @@
             <% end %>
           </div>
         </fieldset>
+        </div>
 
         <!-- Security Fields -->
         <fieldset class="mb-4">

--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -29,7 +29,7 @@
     <%= form.text_field :contact,
         id: "contact-input",
         class: "mt-1 block w-full px-4 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm",
-        value: params[:email_hint].presence || "",
+        value: "",
         required: true,
         autocomplete: "username",
         autofocus: true,

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -35,6 +35,7 @@
 
     <div>
       <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+      <p class="text-sm text-gray-600 mb-1">On file: <%= display_contact_email(@user) %></p>
       <%= f.email_field :email,
             class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
             'aria-invalid': @user.errors[:email].any?,
@@ -43,6 +44,7 @@
 
     <div>
       <%= f.label :phone, class: "block text-sm font-medium text-gray-700" %>
+      <p class="text-sm text-gray-600 mb-1">On file: <%= display_contact_phone(@user) %></p>
       <%= f.telephone_field :phone,
             class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
             placeholder: "555-555-5555",

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,8 +11,8 @@ Rails.application.configure do
   # recommend that you enable it in continuous integration systems to ensure eager loading is working properly before deploying your code.
   config.eager_load = ENV['CI'].present?
 
-  # Configure public file server for tests with cache-control for performance.
-  config.public_file_server.headers = { 'cache-control' => 'public, max-age=3600' }
+  # Avoid caching fingerprinted assets in system tests; stale JS breaks Stimulus verification.
+  config.public_file_server.headers = { 'cache-control' => 'no-store' }
   config.public_file_server.enabled = true
 
   # Enable serving of assets in test environment (Propshaft configuration)

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -10,7 +10,7 @@ Rails.application.config.filter_parameters += [
   :password, :password_confirmation, :current_password, :password_digest,
 
   # PII fields (plaintext) - User model
-  :email, :phone, :contact, :ssn_last4, :date_of_birth,
+  :email, :phone, :contact, :details, :email_hint, :ssn_last4, :date_of_birth,
   :physical_address_1, :physical_address_2, :city, :state, :zip_code,
 
   # SMS credential specific field

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,10 +38,43 @@ en:
   sessions:
     form:
       contact_label: "Email Address or Phone Number"
-      contact_hint: "Portal accounts require an email address on file. Enter that email, or the phone number on the same account."
+      contact_hint: "Use your account email. If your account also has a phone number, you can use that instead."
+  portal_self_service:
+    contact_label: "Email Address or Phone Number"
+    contact_hint: "Use your account email. If your account also has a phone number, you can use that instead."
+    account_access:
+      title: "Account Access"
+      submit: "Send Account Access Link"
+      back_to_sign_in: "Back to Sign In"
+      confirmation: "If you need help signing in, contact the MAT Team at %{support_email}. Portal accounts require an email address on file. If the information you entered matches such an account, account access instructions may have been sent when email or text-capable phone delivery is available."
+    account_recovery:
+      title: "Security Key Recovery"
+      note: "Lost security keys cannot be recovered. An administrator will need to verify your identity and reset your 2FA enrollment."
+      details_label: "Additional Details"
+      details_placeholder: "Please provide any details that will help verify your identity (e.g., reason for reset, when you last accessed the system, etc.)"
+      submit: "Submit Recovery Request"
+      back_to_sign_in: "Back to sign in"
+    registrations:
+      duplicate_conflict_heading: "We found conflicting account information."
+      duplicate_conflict_body: "Please contact the MAT Team at %{support_email} for help accessing your account."
+      duplicate_exists_heading: "An account already exists with that %{match_type}."
+      duplicate_available_body: "You can log in with your email or phone and password, or we can send an account access link to the contact information already on record."
+      duplicate_no_link_body: "You can log in with your email or phone and password. To receive an account access link, please contact the MAT Team at %{support_email}."
+      log_in_cta: "Log in with your email or phone and password"
+      send_access_link: "Send account access link"
+      phone_hint: "Optional. Enter 10 digits. You can use this number to sign in."
+      phone_type_label: "Phone Type"
+      match_type:
+        email: "email"
+        phone: "phone"
   activerecord:
     errors:
       models:
+        user:
+          attributes:
+            base:
+              portal_self_registration_requires_email: "A portal account requires an email address. If you do not have email, please contact MAT for assistance with a paper application."
+              portal_self_registration_unavailable_contact: "We couldn't complete your registration with the information provided. Portal accounts require an email address. Please contact the MAT Team at %{support_email} for assistance."
         application:
           attributes:
             base:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,10 +38,10 @@ en:
   sessions:
     form:
       contact_label: "Email Address or Phone Number"
-      contact_hint: "Use your account email. If your account also has a phone number, you can use that instead."
+      contact_hint: "Use your account email to sign in or request access. If your account has a phone number on file, you can also use that to identify your account. Account access links by text are sent only to text-capable phone numbers."
   portal_self_service:
     contact_label: "Email Address or Phone Number"
-    contact_hint: "Use your account email. If your account also has a phone number, you can use that instead."
+    contact_hint: "Use your account email to sign in or request access. If your account has a phone number on file, you can also use that to identify your account. Account access links by text are sent only to text-capable phone numbers."
     account_access:
       title: "Account Access"
       submit: "Send Account Access Link"
@@ -54,16 +54,19 @@ en:
       details_placeholder: "Please provide any details that will help verify your identity (e.g., reason for reset, when you last accessed the system, etc.)"
       submit: "Submit Recovery Request"
       back_to_sign_in: "Back to sign in"
+      confirmation_title: "Recovery Request Submitted"
+      confirmation_body: "An administrator will review your request and contact you using the information on file for your account."
     registrations:
       duplicate_conflict_heading: "We found conflicting account information."
       duplicate_conflict_body: "Please contact the MAT Team at %{support_email} for help accessing your account."
       duplicate_exists_heading: "An account already exists with that %{match_type}."
-      duplicate_available_body: "You can log in with your email or phone and password, or we can send an account access link to the contact information already on record."
-      duplicate_no_link_body: "You can log in with your email or phone and password. To receive an account access link, please contact the MAT Team at %{support_email}."
-      log_in_cta: "Log in with your email or phone and password"
+      duplicate_available_body: "You can sign in with your email address and password. If your account has a phone number on file, you can also use that to sign in. We can send an account access link when email or text-capable phone delivery is available on your account."
+      duplicate_no_link_body: "You can sign in with your email address and password. If your account has a phone number on file, you can also use that to sign in. To receive an account access link, please contact the MAT Team at %{support_email}."
+      log_in_cta: "Sign in with your email address and password"
       send_access_link: "Send account access link"
       phone_hint: "Optional. Enter 10 digits. You can use this number to sign in."
       phone_type_label: "Phone Type"
+      phone_type_required: "Select a phone type when providing a phone number."
       match_type:
         email: "email"
         phone: "phone"
@@ -75,6 +78,8 @@ en:
             base:
               portal_self_registration_requires_email: "A portal account requires an email address. If you do not have email, please contact MAT for assistance with a paper application."
               portal_self_registration_unavailable_contact: "We couldn't complete your registration with the information provided. Portal accounts require an email address. Please contact the MAT Team at %{support_email} for assistance."
+            phone_type:
+              portal_self_registration_phone_type_required: "must be selected when a phone number is provided"
         application:
           attributes:
             base:
@@ -687,6 +692,7 @@ en:
     recovery_requests:
       approve:
         recovery_approved: "Security key recovery request approved successfully. The user can register a new security key."
+        not_pending: "This recovery request has already been resolved and cannot be approved again."
     users:
       update:
         user_update_pass: "User was successfully updated."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ en:
   sessions:
     form:
       contact_label: "Email Address or Phone Number"
-      contact_hint: "Enter the email address or phone number associated with your account"
+      contact_hint: "Portal accounts require an email address on file. Enter that email, or the phone number on the same account."
   activerecord:
     errors:
       models:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -9,7 +9,7 @@ es:
   sessions:
     form:
       contact_label: "Correo electrónico o número de teléfono"
-      contact_hint: "Ingrese el correo electrónico o número de teléfono asociado con su cuenta"
+      contact_hint: "Las cuentas del portal requieren un correo electrónico registrado. Ingrese ese correo o el número de teléfono de la misma cuenta."
   activerecord:
     errors:
       models:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -9,10 +9,43 @@ es:
   sessions:
     form:
       contact_label: "Correo electrónico o número de teléfono"
-      contact_hint: "Las cuentas del portal requieren un correo electrónico registrado. Ingrese ese correo o el número de teléfono de la misma cuenta."
+      contact_hint: "Use el correo electrónico de su cuenta. Si su cuenta también tiene un número de teléfono, puede usarlo."
+  portal_self_service:
+    contact_label: "Correo electrónico o número de teléfono"
+    contact_hint: "Use el correo electrónico de su cuenta. Si su cuenta también tiene un número de teléfono, puede usarlo."
+    account_access:
+      title: "Acceso a la cuenta"
+      submit: "Enviar enlace de acceso a la cuenta"
+      back_to_sign_in: "Volver a iniciar sesión"
+      confirmation: "Si necesita ayuda para iniciar sesión, comuníquese con el equipo MAT en %{support_email}. Las cuentas del portal requieren un correo electrónico registrado. Si la información ingresada coincide con dicha cuenta, es posible que se hayan enviado instrucciones de acceso por correo electrónico o por teléfono con capacidad de texto."
+    account_recovery:
+      title: "Recuperación de llave de seguridad"
+      note: "Las llaves de seguridad perdidas no se pueden recuperar. Un administrador deberá verificar su identidad y restablecer su inscripción de 2FA."
+      details_label: "Detalles adicionales"
+      details_placeholder: "Proporcione detalles que ayuden a verificar su identidad (por ejemplo, motivo del restablecimiento, cuándo accedió por última vez al sistema, etc.)."
+      submit: "Enviar solicitud de recuperación"
+      back_to_sign_in: "Volver a iniciar sesión"
+    registrations:
+      duplicate_conflict_heading: "Encontramos información de cuenta en conflicto."
+      duplicate_conflict_body: "Comuníquese con el equipo MAT en %{support_email} para obtener ayuda para acceder a su cuenta."
+      duplicate_exists_heading: "Ya existe una cuenta con ese %{match_type}."
+      duplicate_available_body: "Puede iniciar sesión con su correo electrónico o teléfono y contraseña, o podemos enviar un enlace de acceso a la cuenta a la información de contacto registrada."
+      duplicate_no_link_body: "Puede iniciar sesión con su correo electrónico o teléfono y contraseña. Para recibir un enlace de acceso a la cuenta, comuníquese con el equipo MAT en %{support_email}."
+      log_in_cta: "Iniciar sesión con su correo electrónico o teléfono y contraseña"
+      send_access_link: "Enviar enlace de acceso a la cuenta"
+      phone_hint: "Opcional. Ingrese 10 dígitos. Puede usar este número para iniciar sesión."
+      phone_type_label: "Tipo de teléfono"
+      match_type:
+        email: "correo electrónico"
+        phone: "teléfono"
   activerecord:
     errors:
       models:
+        user:
+          attributes:
+            base:
+              portal_self_registration_requires_email: "Una cuenta del portal requiere una dirección de correo electrónico. Si no tiene correo electrónico, comuníquese con MAT para obtener ayuda con una solicitud en papel."
+              portal_self_registration_unavailable_contact: "No pudimos completar su registro con la información proporcionada. Las cuentas del portal requieren una dirección de correo electrónico. Comuníquese con el equipo MAT en %{support_email} para obtener ayuda."
         application:
           attributes:
             base:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -9,10 +9,10 @@ es:
   sessions:
     form:
       contact_label: "Correo electrónico o número de teléfono"
-      contact_hint: "Use el correo electrónico de su cuenta. Si su cuenta también tiene un número de teléfono, puede usarlo."
+      contact_hint: "Use el correo electrónico de su cuenta para iniciar sesión o solicitar acceso. Si su cuenta tiene un número de teléfono registrado, también puede usarlo para identificar su cuenta. Los enlaces de acceso por mensaje de texto solo se envían a números con capacidad de texto."
   portal_self_service:
     contact_label: "Correo electrónico o número de teléfono"
-    contact_hint: "Use el correo electrónico de su cuenta. Si su cuenta también tiene un número de teléfono, puede usarlo."
+    contact_hint: "Use el correo electrónico de su cuenta para iniciar sesión o solicitar acceso. Si su cuenta tiene un número de teléfono registrado, también puede usarlo para identificar su cuenta. Los enlaces de acceso por mensaje de texto solo se envían a números con capacidad de texto."
     account_access:
       title: "Acceso a la cuenta"
       submit: "Enviar enlace de acceso a la cuenta"
@@ -25,16 +25,19 @@ es:
       details_placeholder: "Proporcione detalles que ayuden a verificar su identidad (por ejemplo, motivo del restablecimiento, cuándo accedió por última vez al sistema, etc.)."
       submit: "Enviar solicitud de recuperación"
       back_to_sign_in: "Volver a iniciar sesión"
+      confirmation_title: "Solicitud de recuperación enviada"
+      confirmation_body: "Un administrador revisará su solicitud y se comunicará con usted usando la información registrada en su cuenta."
     registrations:
       duplicate_conflict_heading: "Encontramos información de cuenta en conflicto."
       duplicate_conflict_body: "Comuníquese con el equipo MAT en %{support_email} para obtener ayuda para acceder a su cuenta."
       duplicate_exists_heading: "Ya existe una cuenta con ese %{match_type}."
-      duplicate_available_body: "Puede iniciar sesión con su correo electrónico o teléfono y contraseña, o podemos enviar un enlace de acceso a la cuenta a la información de contacto registrada."
-      duplicate_no_link_body: "Puede iniciar sesión con su correo electrónico o teléfono y contraseña. Para recibir un enlace de acceso a la cuenta, comuníquese con el equipo MAT en %{support_email}."
-      log_in_cta: "Iniciar sesión con su correo electrónico o teléfono y contraseña"
+      duplicate_available_body: "Puede iniciar sesión con su correo electrónico y contraseña. Si su cuenta tiene un número de teléfono registrado, también puede usarlo para iniciar sesión. Podemos enviar un enlace de acceso a la cuenta cuando haya entrega por correo electrónico o por teléfono con capacidad de texto."
+      duplicate_no_link_body: "Puede iniciar sesión con su correo electrónico y contraseña. Si su cuenta tiene un número de teléfono registrado, también puede usarlo para iniciar sesión. Para recibir un enlace de acceso a la cuenta, comuníquese con el equipo MAT en %{support_email}."
+      log_in_cta: "Iniciar sesión con su correo electrónico y contraseña"
       send_access_link: "Enviar enlace de acceso a la cuenta"
       phone_hint: "Opcional. Ingrese 10 dígitos. Puede usar este número para iniciar sesión."
       phone_type_label: "Tipo de teléfono"
+      phone_type_required: "Seleccione un tipo de teléfono cuando proporcione un número de teléfono."
       match_type:
         email: "correo electrónico"
         phone: "teléfono"
@@ -46,6 +49,8 @@ es:
             base:
               portal_self_registration_requires_email: "Una cuenta del portal requiere una dirección de correo electrónico. Si no tiene correo electrónico, comuníquese con MAT para obtener ayuda con una solicitud en papel."
               portal_self_registration_unavailable_contact: "No pudimos completar su registro con la información proporcionada. Las cuentas del portal requieren una dirección de correo electrónico. Comuníquese con el equipo MAT en %{support_email} para obtener ayuda."
+            phone_type:
+              portal_self_registration_phone_type_required: "debe seleccionarse cuando se proporciona un número de teléfono"
         application:
           attributes:
             base:

--- a/db/migrate/20260701120000_coalesce_duplicate_pending_recovery_requests_and_add_unique_index.rb
+++ b/db/migrate/20260701120000_coalesce_duplicate_pending_recovery_requests_and_add_unique_index.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class CoalesceDuplicatePendingRecoveryRequestsAndAddUniqueIndex < ActiveRecord::Migration[8.1]
+  def up
+    say_with_time 'Coalescing duplicate pending recovery requests' do
+      execute <<~SQL.squish
+        UPDATE recovery_requests
+        SET status = 'rejected',
+            resolved_at = CURRENT_TIMESTAMP,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id IN (
+          SELECT id
+          FROM (
+            SELECT id,
+                   ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY created_at ASC, id ASC) AS row_num
+            FROM recovery_requests
+            WHERE status = 'pending'
+          ) ranked
+          WHERE row_num > 1
+        )
+      SQL
+    end
+
+    add_index :recovery_requests, :user_id,
+              unique: true,
+              where: "status = 'pending'",
+              name: 'index_recovery_requests_one_pending_per_user'
+  end
+
+  def down
+    remove_index :recovery_requests, name: 'index_recovery_requests_one_pending_per_user'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_27_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_01_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -436,6 +436,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_27_120000) do
     t.text "user_agent"
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_recovery_requests_on_user_id"
+    t.index ["user_id"], name: "index_recovery_requests_one_pending_per_user", unique: true, where: "((status)::text = 'pending'::text)"
   end
 
   create_table "rejection_reasons", force: :cascade do |t|

--- a/docs/development/guardian_relationship_system.md
+++ b/docs/development/guardian_relationship_system.md
@@ -79,7 +79,7 @@ dependent.effective_communication_preference  # uses guardian's preference if de
 dependent.guardian_for_contact  # returns primary guardian for contact purposes
 ```
 
-These effective-contact helpers are for communication, display, and notification routing. They are not login identifiers; auth and password recovery use `real_email?`, `real_phone?`, and `User.find_by_login_identifier`.
+These effective-contact helpers are for communication, display, and notification routing. They are not login identifiers. Public portal auth and recovery require an email-backed account (`real_email?` via `User.find_by_login_identifier`); phone is an alternate identifier only when the same user also has `real_phone?`.
 
 *Avoids uniqueness violations and supports real-world family setups.*
 

--- a/docs/development/paper_application_architecture.md
+++ b/docs/development/paper_application_architecture.md
@@ -55,7 +55,7 @@ The controller does not own the main paper-application side effects after create
 - sets `submission_method` to `paper`
 - stamps `fulfillment_type` as `voucher` only when vouchers are enabled; otherwise paper applications remain equipment-fulfillment
 - processes income, residency, ID, and disability certification actions
-- sends account-creation notifications after a successful create for email-backed portal users only (`email_backed_portal_account?` / `real_email?`)
+- sends account-creation notifications after a successful create for email-backed portal users only (`email_backed_public_portal_account?` / `real_email?`)
 - logs `application_created` after create
 - performs reconciliation after the transaction commits
 

--- a/docs/development/paper_application_architecture.md
+++ b/docs/development/paper_application_architecture.md
@@ -55,7 +55,7 @@ The controller does not own the main paper-application side effects after create
 - sets `submission_method` to `paper`
 - stamps `fulfillment_type` as `voucher` only when vouchers are enabled; otherwise paper applications remain equipment-fulfillment
 - processes income, residency, ID, and disability certification actions
-- sends account-creation notifications after a successful create for portal-eligible users only (`portal_access_eligible?`)
+- sends account-creation notifications after a successful create for email-backed portal users only (`email_backed_portal_account?` / `real_email?`)
 - logs `application_created` after create
 - performs reconciliation after the transaction commits
 
@@ -68,7 +68,7 @@ Paper intake deliberately branches before it writes the application:
 | Existing self applicant | Admin selects an existing adult constituent for their own application. | Requires contact verification, checks waiting-period eligibility, and blocks when `blocking_new_submission` is true. |
 | Existing dependent | Admin selects an existing dependent through `dependent_id`. | Reuses the dependent and relationship, verifies contact strategy, checks waiting-period eligibility, and writes the application for the dependent with the managing guardian. |
 | New guardian/dependent | Admin enters guardian and dependent details. | Uses `GuardianDependentManagementService` to create or reuse the guardian, create the dependent, apply contact strategies, create the relationship, and return the dependent/guardian pair to `PaperApplicationService`. |
-| New self applicant | No existing applicant is selected. | Always creates a new constituent through `Applications::UserCreationService` with `skip_user_lookup: true`. Duplicate email or phone fails validation instead of silently attaching an unrelated user. Reuse an existing adult only through the explicit existing-applicant branch. Supports phone-only (`no_email_address`) and address-only (`no_email_address` + `no_phone_number`) adults with NULL stored contacts when appropriate. Portal-eligible users get internal forced-change account setup; address-only users do not get portal access. No-phone intake clears stored phone and sets `phone_type` to `email` when a real email remains, or `letter` when both contacts are absent. |
+| New self applicant | No existing applicant is selected. | Always creates a new constituent through `Applications::UserCreationService` with `skip_user_lookup: true`. Duplicate email or phone fails validation instead of silently attaching an unrelated user. Supports phone-only and address-only adults with NULL stored contacts when appropriate. Email-backed portal users get internal forced-change account setup; phone-only and address-only users do not. No-phone intake sets `phone_type` to `email` when a real email remains, or `letter` when both contacts are absent. |
 
 The admin search/decorated candidate payload exposes whether a candidate is blocked by a waiting period or other `blocking_new_submission` reason. The create path must honor those flags instead of relying only on UI hiding.
 
@@ -76,16 +76,16 @@ Contact verification matters for existing adults because paper intake can change
 
 ## Account-Created Notices And Quick-Create Markers
 
-Paper intake routes are `new` and `create` only (`config/routes.rb`). Quick-created portal-eligible user markers are wired through `PaperApplicationsController#create` and cleared after a successful create.
+Paper intake routes are `new` and `create` only (`config/routes.rb`). Quick-created **email-backed** portal user markers are wired through `PaperApplicationsController#create` and cleared after a successful create.
 
-When vouchers are enabled and the application is voucher scope, `PaperApplicationService` sends `account_created` notices for portal-eligible users created in the same submission or quick-created in the same browser session. The notice confirms application receipt; it does **not** include temporary passwords or sign-in links.
+When vouchers are enabled and the application is voucher scope, `PaperApplicationService` sends `account_created` notices for email-backed portal users created in the same submission or quick-created in the same browser session. The notice confirms application receipt; it does **not** include temporary passwords or sign-in links.
 
-`Applications::UserCreationService` sets an internal initial password and `force_password_change` for portal-eligible users, but does not return the raw password. Quick-create markers store only user ids plus timestamps in the admin session (30-minute TTL):
+`Applications::UserCreationService` sets an internal initial password and `force_password_change` for email-backed portal users, but does not return the raw password. Quick-create markers store only email-backed portal user ids plus timestamps in the admin session (30-minute TTL):
 
-- On create, quick-created portal-eligible user ids are passed into the service.
+- On create, quick-created email-backed portal user ids are passed into the service.
 - For marked users, the admin warning reminds staff that no temporary password is retained and account help should use the existing account access link flow.
 
-Equipment-fulfillment applications skip account-created messaging even when a portal-eligible user is created.
+Equipment-fulfillment applications skip account-created messaging even when an email-backed portal user is created.
 
 ## Provider-Info Follow-Up
 

--- a/docs/development/user_management_features.md
+++ b/docs/development/user_management_features.md
@@ -25,7 +25,7 @@ Admin user pages run through `Admin::BaseController`, which requires an authenti
 | Area | Path | Current behavior |
 |------|------|------------------|
 | Routes | `config/routes.rb` | Defines `sign_up`, profile/password routes, `admin/users`, and member routes such as `mfa_tokens_admin_user_path`, `update_role_admin_user_path`, and `history_admin_user_path`. |
-| Public signup | `app/controllers/registrations_controller.rb` | Builds a `Users::Constituent`, blocks exact email/phone duplicates with an account-access prompt, flags name+DOB matches for review, creates the session, and sends registration confirmation. |
+| Public signup | `app/controllers/registrations_controller.rb` | Builds a `Users::Constituent`, blocks exact email or **email-backed** phone duplicates with an account-access prompt, flags name+DOB matches for review, creates the session, and sends registration confirmation. Phone-only and address-only paper records never match public duplicate handoff. |
 | Admin users | `app/controllers/admin/users_controller.rb` | Lists, filters, shows, edits, creates, role-converts, capability-updates, deletes MFA tokens, deletes users, and serves guardian/dependent helper endpoints. |
 | User model | `app/models/user.rb` | Base STI model. Includes authentication, roles/capabilities, profile validation, contact predicates, guardian/dependent logic, and email search tokens. |
 | Contact predicates | `app/models/concerns/user_contact_predicates.rb` | Canonical contact truth: `real_email?`, `real_phone?`, `sms_capable_phone?`, `portal_access_eligible?`. Portal eligibility is computed from stored contact, not faked with synthetic values. |
@@ -51,6 +51,7 @@ Email and phone are stored with deterministic Rails encryption so exact lookups 
 - matching text-capable phone can offer an account-access link by SMS only when the existing account is email-backed and `sms_capable_phone?`
 - `PasswordsController#create` uses the same email-backed resolver: SMS is sent only when the matched account has `real_email?` and `sms_capable_phone?`; all outcomes show the same public confirmation (delivery details stay in audit logs only)
 - conflicting matches, where email and phone belong to different users, show a support-contact prompt
+- phone matching a non-email-backed paper/admin record does not enter duplicate handoff; portal self-registration surfaces a generic base error with MAT support contact instead of a public phone-taken message
 
 `UserProfile` also validates unique email and phone through `User.exists_with_email?` and `User.exists_with_phone?`. The database has unique indexes on `users.email` and on non-null `users.phone` values.
 

--- a/docs/development/user_management_features.md
+++ b/docs/development/user_management_features.md
@@ -35,7 +35,7 @@ Admin user pages run through `Admin::BaseController`, which requires an authenti
 | Email search concern | `app/models/concerns/user_email_search.rb` | Stores HMAC email-search tokens for admin search, including dependent email and guardian fallback email search. |
 | Constituent subclass | `app/models/users/constituent.rb` | Adds application/evaluation associations and a create-time name+DOB duplicate check. |
 | Admin filtering | `app/services/users/filter_service.rb` | Applies admin users search, role, needs-review, relationship, and sorting filters. |
-| User creation service | `app/services/applications/user_creation_service.rb` | Creates or reuses constituent users for paper/admin flows. Email-backed portal users (`email_backed_portal_account?`) get internal forced-change account setup, but raw passwords are not returned; phone-only and address-only users get internal passwords only and no email-backed portal setup. Phone-only lookup works when email is absent; phone lookup is skipped when primary email is system-generated. |
+| User creation service | `app/services/applications/user_creation_service.rb` | Creates or reuses constituent users for paper/admin flows. Email-backed portal users (`email_backed_public_portal_account?`) get internal forced-change account setup, but raw passwords are not returned; phone-only and address-only users get internal passwords only and no email-backed portal setup. Phone-only lookup works when email is absent; phone lookup is skipped when primary email is system-generated. |
 | Admin views | `app/views/admin/users/index.html.erb`, `app/views/admin/users/_users_table.html.erb`, `app/views/admin/users/show.html.erb` | Render the user list, duplicate-review badge/filter, role/capability controls, guardian/dependent detail, MFA token deletion, and user deletion controls. |
 
 ## 3 · Signup And Duplicate Handling
@@ -67,7 +67,7 @@ Blank phone numbers are allowed. Non-blank phones must normalize to a 10-digit U
 | `real_phone?` | Present, valid 10-digit US, not synthetic `000-…` prefix |
 | `sms_capable_phone?` | `real_phone?` and `phone_type == 'text'` |
 | `portal_access_eligible?` | `real_email?` or `real_phone?` (PR2 stored-contact truth) |
-| `email_backed_portal_account?` | `real_email?` only — required for public portal sign-in, account access, and paper/admin portal setup markers |
+| `email_backed_public_portal_account?` | `real_email?` only — required for public portal sign-in, account access, and paper/admin portal setup markers |
 
 Paper/admin intake supports:
 
@@ -82,7 +82,7 @@ Admin display helpers (`display_contact_email`, `display_contact_phone`) hide sy
 | Concept | Source of truth |
 | --- | --- |
 | Stored contact truth (PR2) | `portal_access_eligible?` from `real_email?` / `real_phone?` |
-| Email-backed portal account (PR3) | `email_backed_portal_account?` (`real_email?`) for sign-in, account access, paper portal setup, and account-created notices |
+| Email-backed portal account (PR3) | `email_backed_public_portal_account?` (`real_email?`) for sign-in, account access, paper portal setup, and account-created notices |
 | Delivery route | `communication_preference` plus effective contact fallback for dependents |
 | Record truth | Stored email/phone values and explicit paper no-contact flags |
 

--- a/docs/development/user_management_features.md
+++ b/docs/development/user_management_features.md
@@ -35,7 +35,7 @@ Admin user pages run through `Admin::BaseController`, which requires an authenti
 | Email search concern | `app/models/concerns/user_email_search.rb` | Stores HMAC email-search tokens for admin search, including dependent email and guardian fallback email search. |
 | Constituent subclass | `app/models/users/constituent.rb` | Adds application/evaluation associations and a create-time name+DOB duplicate check. |
 | Admin filtering | `app/services/users/filter_service.rb` | Applies admin users search, role, needs-review, relationship, and sorting filters. |
-| User creation service | `app/services/applications/user_creation_service.rb` | Creates or reuses constituent users for paper/admin flows. Portal-eligible users get internal forced-change account setup, but raw passwords are not returned; address-only users get internal passwords only and no portal access. Phone-only lookup works when email is absent; phone lookup is skipped when primary email is system-generated. |
+| User creation service | `app/services/applications/user_creation_service.rb` | Creates or reuses constituent users for paper/admin flows. Email-backed portal users (`email_backed_portal_account?`) get internal forced-change account setup, but raw passwords are not returned; phone-only and address-only users get internal passwords only and no email-backed portal setup. Phone-only lookup works when email is absent; phone lookup is skipped when primary email is system-generated. |
 | Admin views | `app/views/admin/users/index.html.erb`, `app/views/admin/users/_users_table.html.erb`, `app/views/admin/users/show.html.erb` | Render the user list, duplicate-review badge/filter, role/capability controls, guardian/dependent detail, MFA token deletion, and user deletion controls. |
 
 ## 3 · Signup And Duplicate Handling
@@ -46,10 +46,10 @@ Email and phone are stored with deterministic Rails encryption so exact lookups 
 
 `RegistrationsController#create` calls `duplicate_account_match?` before saving:
 
-- matching email or phone renders the signup page with an account-access prompt instead of creating another user
-- matching email can offer an account-access link by email
-- matching text-capable phone can offer an account-access link by SMS
-- `PasswordsController#create` applies the same text-capable rule: account-access SMS is sent only when the matched user's `phone_type` is `text`
+- matching email or phone on an **email-backed** existing account renders the signup page with an account-access prompt instead of creating another user
+- matching email can offer an account-access link by email when the existing account is email-backed
+- matching text-capable phone can offer an account-access link by SMS only when the existing account is email-backed and `sms_capable_phone?`
+- `PasswordsController#create` uses the same email-backed resolver: SMS is sent only when the matched account has `real_email?` and `sms_capable_phone?`; all outcomes show the same public confirmation (delivery details stay in audit logs only)
 - conflicting matches, where email and phone belong to different users, show a support-contact prompt
 
 `UserProfile` also validates unique email and phone through `User.exists_with_email?` and `User.exists_with_phone?`. The database has unique indexes on `users.email` and on non-null `users.phone` values.
@@ -65,11 +65,12 @@ Blank phone numbers are allowed. Non-blank phones must normalize to a 10-digit U
 | `real_email?` | Present, valid format, not `@system.matvulcan.local` |
 | `real_phone?` | Present, valid 10-digit US, not synthetic `000-…` prefix |
 | `sms_capable_phone?` | `real_phone?` and `phone_type == 'text'` |
-| `portal_access_eligible?` | `real_email?` or `real_phone?` |
+| `portal_access_eligible?` | `real_email?` or `real_phone?` (PR2 stored-contact truth) |
+| `email_backed_portal_account?` | `real_email?` only — required for public portal sign-in, account access, and paper/admin portal setup markers |
 
 Paper/admin intake supports:
 
-- **Phone-only adults** — `no_email_address=1` strips email; user remains portal-eligible when a real phone is stored. Preferred contact method stays on voice/text/videophone.
+- **Phone-only adults** — `no_email_address=1` strips email; user may still be `portal_access_eligible?` for record truth, but is **not** an email-backed portal account. No forced-change portal setup, quick-create markers, or account-created notices.
 - **Address-only adults** — `no_email_address=1` and `no_phone_number=1` store NULL email/phone, force letter delivery, set `phone_type` to `letter`, and create users without exposed/temp passwords or portal access.
 - **Dependents** — synthetic primary email/phone remain dependent-only placeholders; adults never receive synthetic contacts when NULL is valid. Notifications and display use **effective contact** helpers (`effective_email`, `effective_phone`, `effective_phone_type`, `effective_communication_preference`), which prefer dependent-owned contact fields and fall back to the managing guardian for communication only—not for portal login identifiers.
 
@@ -79,17 +80,18 @@ Admin display helpers (`display_contact_email`, `display_contact_phone`) hide sy
 
 | Concept | Source of truth |
 | --- | --- |
-| Login identity | `portal_access_eligible?` from real email/phone predicates |
+| Stored contact truth (PR2) | `portal_access_eligible?` from `real_email?` / `real_phone?` |
+| Email-backed portal account (PR3) | `email_backed_portal_account?` (`real_email?`) for sign-in, account access, paper portal setup, and account-created notices |
 | Delivery route | `communication_preference` plus effective contact fallback for dependents |
 | Record truth | Stored email/phone values and explicit paper no-contact flags |
 
 Voucher-gated `account_created` notices are sent only when `FeatureFlag.enabled?(:vouchers_enabled)` and the paper application is voucher-fulfillment scope. Equipment-scope paper intake does not announce portal accounts the applicant cannot use.
 
-Portal-eligible users created during paper intake get an internal initial password and `force_password_change`, but the raw password is not returned, cached, or stored in session. When an admin quick-creates a guardian in the same browser session, the session stores only a short-lived quick-created portal-eligible user id marker. `PaperApplicationsController#create` passes those user ids into `PaperApplicationService`; if a constituent needs help signing in, staff should use the existing account access link flow.
+Email-backed portal users created during paper intake get an internal initial password and `force_password_change`, but the raw password is not returned, cached, or stored in session. When an admin quick-creates a guardian in the same browser session, the session stores only a short-lived quick-created **email-backed** portal user id marker. `PaperApplicationsController#create` passes those user ids into `PaperApplicationService`; if a constituent needs help signing in, staff should use the existing account access link flow.
 
 Persisted address-only constituents remain editable in admin user edit (name, address, letter preference) without requiring email. Normal admin edit cannot clear all contact information or keep email delivery without a real email; those transitions are reserved for paper intake with explicit no-contact flags.
 
-Public portal self-registration still requires both email and phone until a later PR changes that UI.
+Public portal self-registration requires a real email address; phone is optional and may serve as an alternate login identifier when also on file.
 
 ### 3.2 Name and DOB review flag
 
@@ -143,7 +145,7 @@ The admin user show page displays:
 - application history for the selected user
 - edit, delete MFA tokens, and delete user actions
 
-Admin-created users go through `UserServiceIntegration#create_user_with_service`, which calls `Applications::UserCreationService`. Portal-eligible service-created constituents get internal forced-change account setup, `verified: true`, and `force_password_change: true`; raw passwords are not returned or stored for handoff. Address-only users get internal passwords only and no portal access. Phone-only users store NULL email and remain portal-eligible via `real_phone?`.
+Admin-created users go through `UserServiceIntegration#create_user_with_service`, which calls `Applications::UserCreationService`. Email-backed portal constituents get internal forced-change account setup, `verified: true`, and `force_password_change: true`; raw passwords are not returned or stored for handoff. Address-only and phone-only users get internal passwords only and no email-backed portal account setup. Phone-only users may still be `portal_access_eligible?` for record truth but cannot use public portal sign-in or account access without a real email.
 
 The admin user show page displays contact through `display_contact_email` and `display_contact_phone`, which hide synthetic values and show “No email on file” / “No phone on file” when appropriate.
 

--- a/docs/features/email_uniqueness_for_dependents.md
+++ b/docs/features/email_uniqueness_for_dependents.md
@@ -35,7 +35,7 @@ The `User` model includes logic to manage dependent-specific contact information
 - **Validation**: The model validates the format of `dependent_email` and `dependent_phone` (implemented in `UserProfile` concern).
 - **Helper Methods** (implemented in `UserGuardianship` concern):
   - `effective_email`, `effective_phone`, `effective_phone_type`, and `effective_communication_preference` are **communication-only** helpers for notifications, mailers, and admin display. They prefer dependent-owned fields, then guardian fallback, then the user's own fields.
-  - Portal sign-in and password recovery still use primary `email`/`phone` through `User.find_by_login_identifier`; synthetic dependent primaries are excluded from those auth paths even when effective contact resolves to a guardian address.
+  - Portal sign-in, account access, and WebAuthn recovery use `User.find_by_login_identifier` on stored primary contact. Public portal lookup requires an **email-backed** account (`real_email?`); phone matches only when the same user also has `real_phone?`. Synthetic dependent primaries are excluded even when effective contact resolves to a guardian address.
   - `guardian_for_contact`: Returns the primary guardian for contact purposes.
 
 - **Contact predicates** (implemented in `UserContactPredicates` concern):

--- a/docs/security/authentication_system.md
+++ b/docs/security/authentication_system.md
@@ -20,7 +20,7 @@ The controller:
 
 User password/session behavior lives in `UserAuthentication`.
 
-Account access (the “Forgot password?” / send reset link flow) lives in `PasswordsController#create`. It uses `User.find_for_account_access`, which delegates identity lookup to `find_by_login_identifier` and selects delivery separately: email for email-shaped contact on an email-backed account, SMS only when the same account has `sms_capable_phone?` and phone-shaped contact was entered. Every outcome returns the same public confirmation; delivery attempts are recorded in audit logs only. WebAuthn recovery in `AccountRecoveryController` uses the same email-backed login lookup via a contact field.
+Account access (the “Forgot password?” / send reset link flow) lives in `PasswordsController#create`. It uses `User.find_for_account_access`, which delegates identity lookup to `find_by_login_identifier` and selects delivery separately: email for email-shaped contact on an email-backed account, SMS only when the same account has `sms_capable_phone?` and phone-shaped contact was entered. Every outcome returns the same public confirmation; delivery attempts, including matched accounts with no available delivery route, are recorded in audit logs only. WebAuthn recovery in `AccountRecoveryController` uses the same email-backed login lookup via a contact field; throttling keys and unmatched rate-limit audit metadata use digests of submitted contacts rather than raw identifiers.
 
 Current account-lock behavior:
 

--- a/docs/security/authentication_system.md
+++ b/docs/security/authentication_system.md
@@ -205,6 +205,6 @@ When changing authentication:
 - Do not count unverified SMS credentials as enabled.
 - Do not store SMS codes in our database.
 - Use `User.find_by_login_identifier` for password sign-in lookup instead of calling `User.find_by_email` or `User.find_by_phone` directly.
-- Keep account-access lookup aligned with the same contact guards even if it remains in `PasswordsController#find_user_for_account_access` for now.
+- Delegate account-access identity lookup and delivery selection to `User.find_for_account_access` from `PasswordsController#create`; do not reimplement parallel lookup rules in the controller.
 - Do not add role-based MFA exceptions without updating tests.
 - Be careful with direct column writes in auth bookkeeping; the existing uses are narrow and documented in code.

--- a/docs/security/authentication_system.md
+++ b/docs/security/authentication_system.md
@@ -10,8 +10,9 @@ Password sign-in starts in `SessionsController#create`.
 
 The controller:
 
-- looks up users through `User.find_by_login_identifier`, which accepts email or phone, normalizes input, rejects malformed `@` input, and rejects users whose stored contact fails `real_email?` or `real_phone?` (covering synthetic dependent emails and placeholder phones), and works with encrypted email storage
-- does not change portal registration rules; signup still requires both email and phone in the public UI
+- looks up users through `User.find_by_login_identifier`, which accepts email or phone for **email-backed portal accounts** (`real_email?` required; phone match also requires `real_phone?` on the same user), normalizes input, rejects malformed `@` input, rejects synthetic dependent emails and placeholder phones, and works with encrypted email storage
+- **does not** treat phone-only or address-only records as portal accounts — those truthful paper/admin records do not match public sign-in, account access, or WebAuthn recovery
+- public self-registration requires a real email address; phone is optional and adds an alternate login identifier when present
 - checks account lock state before password authentication
 - records failed password attempts
 - signs the user in immediately when no second factor is enabled
@@ -19,7 +20,7 @@ The controller:
 
 User password/session behavior lives in `UserAuthentication`.
 
-Account access (the “Forgot password?” / send reset link flow) lives in `PasswordsController#create`. It uses parallel contact lookup logic in `find_user_for_account_access` with the same malformed-`@` guards plus instance predicates (`real_email?`, `real_phone?`, `sms_capable_phone?`), but it does not call `User.find_by_login_identifier` directly. WebAuthn recovery in `AccountRecoveryController` is email-only.
+Account access (the “Forgot password?” / send reset link flow) lives in `PasswordsController#create`. It uses `User.find_for_account_access`, which delegates identity lookup to `find_by_login_identifier` and selects delivery separately: email for email-shaped contact on an email-backed account, SMS only when the same account has `sms_capable_phone?` and phone-shaped contact was entered. Every outcome returns the same public confirmation; delivery attempts are recorded in audit logs only. WebAuthn recovery in `AccountRecoveryController` uses the same email-backed login lookup via a contact field.
 
 Current account-lock behavior:
 

--- a/docs/security/pii_encryption.md
+++ b/docs/security/pii_encryption.md
@@ -67,7 +67,7 @@ Use the helper methods on `User` for contact lookup:
 
 - `User.find_by_email(value)`
 - `User.find_by_phone(value)`
-- `User.find_by_login_identifier(value)` — password sign-in lookup in `SessionsController`; treats any `@` input as email-shaped, rejects malformed email strings without falling back to phone, and blocks synthetic dependent contacts
+- `User.find_by_login_identifier(value)` — public sign-in, account recovery, and other login-identity lookups; email-backed portal accounts only for phone-shaped input (`real_email?` and `real_phone?` required on the matched user); treats any `@` input as email-shaped, rejects malformed email strings without falling back to phone, and blocks synthetic dependent contacts
 - `User.exists_with_email?(value, excluding_id: nil)`
 - `User.exists_with_phone?(value, excluding_id: nil)`
 

--- a/docs/security/pii_encryption.md
+++ b/docs/security/pii_encryption.md
@@ -75,9 +75,9 @@ These helpers normalize email and phone values before querying and rescue lookup
 
 Current adoption by path:
 
-- `User.find_by_login_identifier` — `SessionsController` sign-in only
-- `User.find_by_email` / `User.find_by_phone` — registration duplicate checks, paper intake, WebAuthn recovery, and other existing lookup paths
-- `PasswordsController#find_user_for_account_access` — parallel account-access lookup with equivalent guards, but not yet routed through `find_by_login_identifier`
+- `User.find_by_login_identifier` — public sign-in and account recovery (email-backed portal accounts only; phone lookup requires `real_email?` and `real_phone?` on the matched user)
+- `User.find_by_email` / `User.find_by_phone` — registration duplicate checks, paper intake, and other existing lookup paths
+- `User.find_for_account_access` — account-access identity lookup plus separate delivery selection in `PasswordsController#create`
 
 Direct Rails equality queries on deterministic encrypted fields can work, but new code should use the helpers where contact lookup or uniqueness is the point. That keeps normalization and failure behavior consistent.
 
@@ -93,7 +93,7 @@ Important behavior:
 
 - email is normalized to lowercase before validation
 - phone is normalized to `XXX-XXX-XXXX` when it has a valid 10-digit US shape
-- email is required unless paper context allows a no-email paper flow, the user is a phone-only portal user (`email_optional?` — NULL email with `real_phone?`), or the user is a persisted address-only constituent (`real_email?` and `real_phone?` both false with letter delivery)
+- email is required unless paper context allows a no-email paper flow, the user is a persisted phone-only record (`email_optional?` — NULL email with `real_phone?`, not an email-backed portal account), or the user is a persisted address-only constituent (`real_email?` and `real_phone?` both false with letter delivery)
 - phone and dependent phone must be valid 10-digit US numbers when present
 - dependent email/phone are encrypted too
 

--- a/test/controllers/account_recovery_controller_test.rb
+++ b/test/controllers/account_recovery_controller_test.rb
@@ -62,6 +62,62 @@ class AccountRecoveryControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Lost key; submitting phone on file for email-backed account', recovery_request.details
   end
 
+  test 'coalesces duplicate pending recovery requests without duplicate admin notifications' do
+    create(:recovery_request, user: @user, status: 'pending')
+
+    assert_no_difference('RecoveryRequest.count') do
+      assert_no_difference -> { Notification.where(action: 'security_key_recovery_requested').count } do
+        post request_security_key_reset_path, params: {
+          contact: @user.phone,
+          details: 'Repeat while pending'
+        }
+      end
+    end
+
+    assert_redirected_to account_recovery_confirmation_path
+  end
+
+  test 'allows new recovery request after prior request is resolved' do
+    create(:recovery_request, :approved, user: @user)
+
+    assert_difference('RecoveryRequest.count', 1) do
+      post request_security_key_reset_path, params: {
+        contact: @user.email,
+        details: 'New request after approval'
+      }
+    end
+
+    assert_redirected_to account_recovery_confirmation_path
+    assert_equal 'pending', RecoveryRequest.order(:created_at).last.status
+  end
+
+  test 'rate limits new recovery requests per user and ip' do
+    old_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+
+    AccountRecoveryController::RECOVERY_REQUEST_RATE_LIMIT.times do |i|
+      RecoveryRequest.where(user: @user).update_all(status: 'approved', resolved_at: Time.current, resolved_by_id: @admin.id)
+
+      assert_difference('RecoveryRequest.count', 1) do
+        post request_security_key_reset_path, params: {
+          contact: @user.email,
+          details: "Attempt #{i}"
+        }
+      end
+    end
+
+    RecoveryRequest.where(user: @user).update_all(status: 'approved', resolved_at: Time.current, resolved_by_id: @admin.id)
+
+    assert_no_difference('RecoveryRequest.count') do
+      post request_security_key_reset_path, params: {
+        contact: @user.email,
+        details: 'Over limit'
+      }
+    end
+  ensure
+    Rails.cache = old_cache
+  end
+
   test 'should not create recovery request for phone-only record' do
     phone = '410-555-0210'
     Current.paper_context = true
@@ -135,8 +191,55 @@ class AccountRecoveryControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     # Check for confirmation message content
-    assert_select 'h1', /confirmation|submitted|recovery/i
+    assert_select 'h1', /Recovery Request Submitted/i
+    assert_match(/administrator will review your request/i, response.body)
+    assert_no_match(/check your email/i, response.body)
     assert_select 'a[href=?]', sign_in_path
+  end
+
+  test 'does not leave pending recovery request when admin notification raises' do
+    NotificationService::NotificationBuilder.any_instance
+                                            .expects(:create_and_deliver!)
+                                            .once
+                                            .raises(StandardError.new('notification failed'))
+
+    assert_no_difference('RecoveryRequest.count') do
+      post request_security_key_reset_path, params: {
+        contact: @user.email,
+        details: 'Notification exception should roll back pending request'
+      }
+    end
+
+    assert_redirected_to account_recovery_confirmation_path
+  end
+
+  test 'does not leave pending recovery request when admin notification returns nil' do
+    NotificationService::NotificationBuilder.any_instance
+                                            .expects(:create_and_deliver!)
+                                            .once
+                                            .returns(nil)
+
+    assert_no_difference('RecoveryRequest.count') do
+      post request_security_key_reset_path, params: {
+        contact: @user.email,
+        details: 'Notification nil return should roll back pending request'
+      }
+    end
+
+    assert_redirected_to account_recovery_confirmation_path
+  end
+
+  test 'handles RecordNotUnique during create as coalesced duplicate pending' do
+    RecoveryRequest.any_instance.stubs(:save!).raises(ActiveRecord::RecordNotUnique.new('duplicate pending key'))
+
+    assert_no_difference('RecoveryRequest.count') do
+      post request_security_key_reset_path, params: {
+        contact: @user.email,
+        details: 'Concurrent duplicate pending'
+      }
+    end
+
+    assert_redirected_to account_recovery_confirmation_path
   end
 
   test 'should handle missing contact parameter' do

--- a/test/controllers/account_recovery_controller_test.rb
+++ b/test/controllers/account_recovery_controller_test.rb
@@ -16,7 +16,7 @@ class AccountRecoveryControllerTest < ActionDispatch::IntegrationTest
 
     # Check that the form contains the necessary fields
     assert_select 'form'
-    assert_select 'input[type=email]'
+    assert_select 'input[name=?]', 'contact'
     assert_select 'textarea' # For details field
     # Form submission could be either button or input
     assert(css_select('button[type=submit]').any? || css_select('input[type=submit]').any?,
@@ -26,7 +26,7 @@ class AccountRecoveryControllerTest < ActionDispatch::IntegrationTest
   test 'should create recovery request for existing user' do
     assert_difference('RecoveryRequest.count', 1) do
       post request_security_key_reset_path, params: {
-        email: @user.email,
+        contact: @user.email,
         details: 'I lost my security key during travel'
       }
     end
@@ -43,10 +43,57 @@ class AccountRecoveryControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil recovery_request.user_agent
   end
 
+  test 'should create recovery request for email-backed user via phone contact' do
+    assert @user.real_email?
+    assert @user.real_phone?
+
+    assert_difference('RecoveryRequest.count', 1) do
+      post request_security_key_reset_path, params: {
+        contact: @user.phone,
+        details: 'Lost key; submitting phone on file for email-backed account'
+      }
+    end
+
+    assert_redirected_to account_recovery_confirmation_path
+
+    recovery_request = RecoveryRequest.last
+    assert_equal @user.id, recovery_request.user_id
+    assert_equal 'pending', recovery_request.status
+    assert_equal 'Lost key; submitting phone on file for email-backed account', recovery_request.details
+  end
+
+  test 'should not create recovery request for phone-only record' do
+    phone = '410-555-0210'
+    Current.paper_context = true
+    begin
+      Users::Constituent.create!(
+        first_name: 'Phone', last_name: 'OnlyRecovery',
+        phone: phone,
+        phone_type: 'text',
+        communication_preference: :letter,
+        physical_address_1: '123 Main St', city: 'Baltimore', state: 'MD', zip_code: '21201',
+        date_of_birth: Date.new(1950, 1, 1),
+        password: 'password123', password_confirmation: 'password123',
+        hearing_disability: true
+      )
+    ensure
+      Current.reset
+    end
+
+    assert_no_difference('RecoveryRequest.count') do
+      post request_security_key_reset_path, params: {
+        contact: phone,
+        details: 'Lost key'
+      }
+    end
+
+    assert_redirected_to account_recovery_confirmation_path
+  end
+
   test 'should still redirect to confirmation page for non-existent user' do
     assert_no_difference('RecoveryRequest.count') do
       post request_security_key_reset_path, params: {
-        email: 'nonexistent@example.com',
+        contact: 'nonexistent@example.com',
         details: 'Test details'
       }
     end
@@ -60,7 +107,7 @@ class AccountRecoveryControllerTest < ActionDispatch::IntegrationTest
     assert_no_enqueued_jobs only: ActionMailer::MailDeliveryJob do
       assert_difference -> { Notification.where(action: 'security_key_recovery_requested', recipient: @admin).count }, 1 do
         post request_security_key_reset_path, params: {
-          email: @user.email,
+          contact: @user.email,
           details: 'Test notification'
         }
       end
@@ -70,13 +117,14 @@ class AccountRecoveryControllerTest < ActionDispatch::IntegrationTest
     assert_equal RecoveryRequest.last, notification.notifiable
     assert_equal @user, notification.actor
     assert_equal RecoveryRequest.last.id, notification.metadata['recovery_request_id']
+    assert_equal @user.mfa_account_name, notification.metadata['requester_identifier']
     assert_nil notification.delivery_status
   end
 
   test 'should not create admin notification for non-existent user' do
     assert_no_difference -> { Notification.where(action: 'security_key_recovery_requested').count } do
       post request_security_key_reset_path, params: {
-        email: 'nonexistent@example.com',
+        contact: 'nonexistent@example.com',
         details: 'Test notification'
       }
     end
@@ -91,14 +139,25 @@ class AccountRecoveryControllerTest < ActionDispatch::IntegrationTest
     assert_select 'a[href=?]', sign_in_path
   end
 
-  test 'should handle missing email parameter' do
+  test 'should handle missing contact parameter' do
     assert_no_difference('RecoveryRequest.count') do
       post request_security_key_reset_path, params: {
-        details: 'Missing email parameter test'
+        details: 'Missing contact parameter test'
       }
     end
 
     # Should still redirect to confirmation page
+    assert_redirected_to account_recovery_confirmation_path
+  end
+
+  test 'ignores legacy email parameter without contact' do
+    assert_no_difference('RecoveryRequest.count') do
+      post request_security_key_reset_path, params: {
+        email: @user.email,
+        details: 'Legacy email param'
+      }
+    end
+
     assert_redirected_to account_recovery_confirmation_path
   end
 
@@ -109,7 +168,7 @@ class AccountRecoveryControllerTest < ActionDispatch::IntegrationTest
 
     # Verify that unauthenticated users can submit recovery request
     post request_security_key_reset_path, params: {
-      email: @user.email,
+      contact: @user.email,
       details: 'Unauthenticated access test'
     }
     assert_redirected_to account_recovery_confirmation_path

--- a/test/controllers/account_recovery_controller_test.rb
+++ b/test/controllers/account_recovery_controller_test.rb
@@ -114,6 +114,38 @@ class AccountRecoveryControllerTest < ActionDispatch::IntegrationTest
         details: 'Over limit'
       }
     end
+
+    assert_equal 1, Event.where(action: 'security_key_recovery_request_rate_limited', user: @user).count
+  ensure
+    Rails.cache = old_cache
+  end
+
+  test 'rate limits unmatched recovery contacts without storing raw identifier' do
+    old_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    contact = "unknown-#{SecureRandom.hex(4)}@example.com"
+
+    AccountRecoveryController::RECOVERY_REQUEST_RATE_LIMIT.times do
+      assert_no_difference('RecoveryRequest.count') do
+        post request_security_key_reset_path, params: {
+          contact: contact,
+          details: 'Unknown repeated recovery'
+        }
+      end
+    end
+
+    assert_difference -> { Event.where(action: 'security_key_recovery_unmatched_rate_limited').count }, 1 do
+      assert_no_difference('RecoveryRequest.count') do
+        post request_security_key_reset_path, params: {
+          contact: contact,
+          details: 'Unknown over limit'
+        }
+      end
+    end
+
+    event = Event.where(action: 'security_key_recovery_unmatched_rate_limited').last
+    assert event.metadata['submitted_contact_digest'].present?
+    assert_not_includes event.metadata.values.join(' '), contact
   ensure
     Rails.cache = old_cache
   end
@@ -210,6 +242,7 @@ class AccountRecoveryControllerTest < ActionDispatch::IntegrationTest
       }
     end
 
+    assert_equal 1, Event.where(action: 'security_key_recovery_request_failed', user: @user).count
     assert_redirected_to account_recovery_confirmation_path
   end
 

--- a/test/controllers/admin/paper_applications_controller_test.rb
+++ b/test/controllers/admin/paper_applications_controller_test.rb
@@ -1392,7 +1392,7 @@ module Admin
       assert user, 'Expected phone-only user to be created'
       assert_nil user.email
       assert user.portal_access_eligible?
-      assert_not user.email_backed_portal_account?
+      assert_not user.email_backed_public_portal_account?
       assert user.deliver_via_letter?
       assert_not user.force_password_change?
     end

--- a/test/controllers/admin/paper_applications_controller_test.rb
+++ b/test/controllers/admin/paper_applications_controller_test.rb
@@ -1392,8 +1392,9 @@ module Admin
       assert user, 'Expected phone-only user to be created'
       assert_nil user.email
       assert user.portal_access_eligible?
+      assert_not user.email_backed_portal_account?
       assert user.deliver_via_letter?
-      assert user.force_password_change?
+      assert_not user.force_password_change?
     end
 
     test 'creates email-only self-applicant without phone' do

--- a/test/controllers/admin/recovery_requests_controller_test.rb
+++ b/test/controllers/admin/recovery_requests_controller_test.rb
@@ -51,6 +51,27 @@ module Admin
       assert_equal 0, @user.reload.webauthn_credentials.count
     end
 
+    test 'cannot replay approval on already resolved recovery request' do
+      @recovery_request.update!(
+        status: 'approved',
+        resolved_at: Time.current,
+        resolved_by_id: @admin.id
+      )
+      setup_webauthn_credential(@user)
+
+      assert_no_difference '@user.webauthn_credentials.count' do
+        post approve_admin_recovery_request_path(@recovery_request)
+      end
+
+      assert_redirected_to admin_recovery_request_path(@recovery_request)
+      assert_match(/already been resolved/i, flash[:alert])
+
+      @recovery_request.reload
+      assert_equal 'approved', @recovery_request.status
+      assert_equal @admin.id, @recovery_request.resolved_by_id
+      assert @user.webauthn_credentials.exists?
+    end
+
     test 'should not allow non-admins to access requests' do
       # Sign out admin
       delete sign_out_path

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -213,7 +213,7 @@ module Admin
       assert User.exists?(user.id)
 
       event = Event.find_by!(action: 'admin_user_deletion_failed', auditable: user)
-      assert_equal 'ActiveRecord::InvalidForeignKey', event.metadata['error_class']
+      assert_equal 'ActiveRecord::DeleteRestrictionError', event.metadata['error_class']
     end
 
     test 'admin deletion failure logs voucher blockers for constituent applications' do

--- a/test/controllers/concerns/paper_quick_create_portal_markers_test.rb
+++ b/test/controllers/concerns/paper_quick_create_portal_markers_test.rb
@@ -3,9 +3,9 @@
 require 'test_helper'
 
 class PaperQuickCreatePortalMarkersTest < ActiveSupport::TestCase
-  FakeUser = Struct.new(:id, :portal_eligible) do
-    def portal_access_eligible?
-      portal_eligible
+  FakeUser = Struct.new(:id, :email_backed) do
+    def email_backed_portal_account?
+      email_backed
     end
   end
 
@@ -36,7 +36,7 @@ class PaperQuickCreatePortalMarkersTest < ActiveSupport::TestCase
     assert_empty @controller.quick_created_portal_user_ids
   end
 
-  test 'does not store marker for address-only user' do
+  test 'does not store marker for non-email-backed user' do
     @controller.store_quick_created_portal_user_marker!(FakeUser.new(99, false))
 
     assert_empty @controller.quick_created_portal_user_ids

--- a/test/controllers/concerns/paper_quick_create_portal_markers_test.rb
+++ b/test/controllers/concerns/paper_quick_create_portal_markers_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class PaperQuickCreatePortalMarkersTest < ActiveSupport::TestCase
   FakeUser = Struct.new(:id, :email_backed) do
-    def email_backed_portal_account?
+    def email_backed_public_portal_account?
       email_backed
     end
   end

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -430,10 +430,10 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   def account_access_confirmation_message
-    support_email = Policy.get('support_email') || 'mat.program1@maryland.gov'
-    "If you need help signing in, contact the MAT Team at #{support_email}. " \
-      'Portal accounts require an email address on file. If the information you entered matches such an account, ' \
-      'account access instructions may have been sent when email or text-capable phone delivery is available.'
+    I18n.t(
+      'portal_self_service.account_access.confirmation',
+      support_email: Policy.get('support_email') || 'mat.program1@maryland.gov'
+    )
   end
 
   private

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -359,8 +359,10 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     SmsService.expects(:send_message).never
 
-    assert_no_enqueued_emails do
-      post password_path, params: { contact: user.phone }
+    assert_difference -> { Event.where(action: 'account_access_instructions_delivery_unavailable', user: user).count }, 1 do
+      assert_no_enqueued_emails do
+        post password_path, params: { contact: user.phone }
+      end
     end
 
     assert_redirected_to sign_in_path

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -73,7 +73,9 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     SmsService.expects(:send_message)
               .with(@user.phone,
-                    regexp_matches(%r{MAT account access link to set your password: https?://\S+ This link expires in 20 minutes\.}))
+                    regexp_matches(%r{MAT account access link to set your password: https?://\S+ This link expires in 20 minutes\.}),
+                    sensitive: true,
+                    context: { recipient_id: @user.id, recipient_channel: 'account_access_sms' })
               .returns(true)
 
     assert_difference -> { Event.where(action: 'account_access_instructions_sent', user: @user).count }, 1 do

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -65,8 +65,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to sign_in_path
-    assert_equal 'If the information you entered matches an account, we sent account access instructions to the contact information on record.',
-                 flash[:notice]
+    assert_equal account_access_confirmation_message, flash[:notice]
   end
 
   def test_should_send_account_access_sms_for_existing_phone
@@ -96,8 +95,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to sign_in_path
-    assert_equal 'If the information you entered matches an account, we sent account access instructions to the contact information on record.',
-                 flash[:notice]
+    assert_equal account_access_confirmation_message, flash[:notice]
   end
 
   def test_should_rate_limit_repeated_account_access_sms_requests
@@ -125,8 +123,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to sign_in_path
-    assert_equal 'If the information you entered matches an account, we sent account access instructions to the contact information on record.',
-                 flash[:notice]
+    assert_equal account_access_confirmation_message, flash[:notice]
   end
 
   def test_should_update_password_with_valid_token_without_current_password
@@ -252,6 +249,35 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @original_password_digest, @user.password_digest
   end
 
+  def test_phone_only_record_does_not_receive_account_access
+    sign_out if respond_to?(:sign_out)
+
+    phone = '410-555-0177'
+    Current.paper_context = true
+    begin
+      Users::Constituent.create!(
+        first_name: 'Phone', last_name: 'OnlyAccess',
+        phone: phone,
+        phone_type: 'text',
+        communication_preference: :letter,
+        physical_address_1: '123 Main St', city: 'Baltimore', state: 'MD', zip_code: '21201',
+        date_of_birth: Date.new(1950, 1, 1),
+        password: 'password123', password_confirmation: 'password123',
+        hearing_disability: true
+      )
+    ensure
+      Current.reset
+    end
+
+    SmsService.expects(:send_message).never
+
+    assert_no_enqueued_emails do
+      post password_path, params: { contact: phone }
+    end
+
+    assert_redirected_to sign_in_path
+    assert_equal account_access_confirmation_message, flash[:notice]
+  end
 
   def test_system_email_does_not_fall_through_to_phone_for_account_access
     sign_out if respond_to?(:sign_out)
@@ -293,11 +319,11 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   def test_guardian_generated_synthetic_phone_does_not_receive_account_access_sms
     sign_out if respond_to?(:sign_out)
 
-    user = create(:constituent,
-                  phone: '000-345-6789',
-                  email: "real.#{SecureRandom.hex(3)}@example.com",
-                  password: 'password123',
-                  password_confirmation: 'password123')
+    create(:constituent,
+           phone: '000-345-6789',
+           email: "real.#{SecureRandom.hex(3)}@example.com",
+           password: 'password123',
+           password_confirmation: 'password123')
 
     SmsService.expects(:send_message).never
 
@@ -404,7 +430,10 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   def account_access_confirmation_message
-    'If the information you entered matches an account, we sent account access instructions to the contact information on record.'
+    support_email = Policy.get('support_email') || 'mat.program1@maryland.gov'
+    "If you need help signing in, contact the MAT Team at #{support_email}. " \
+      'Portal accounts require an email address on file. If the information you entered matches such an account, ' \
+      'account access instructions may have been sent when email or text-capable phone delivery is available.'
   end
 
   private

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -53,6 +53,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
         last_name: 'User',
         date_of_birth: '1990-01-01',
         phone: '555-555-5555',
+        phone_type: 'voice',
         timezone: 'Eastern Time (US & Canada)',
         locale: 'en',
         # Disabilities are required for constituents
@@ -85,6 +86,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
         last_name: 'User',
         date_of_birth: '01/15/1990',
         phone: '555-555-5565',
+        phone_type: 'voice',
         timezone: 'Eastern Time (US & Canada)',
         locale: 'en',
         hearing_disability: true
@@ -105,6 +107,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
         last_name: 'User',
         date_of_birth: 'January 15 1990',
         phone: '555-555-5566',
+        phone_type: 'voice',
         timezone: 'Eastern Time (US & Canada)',
         locale: 'en',
         hearing_disability: true
@@ -127,6 +130,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
         last_name: 'User',
         date_of_birth: '1990-01-01',
         phone: '555-555-5555',
+        phone_type: 'voice',
         timezone: 'Eastern Time (US & Canada)',
         locale: 'en',
         hearing_disability: false, # No disability selected
@@ -156,6 +160,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
         last_name: 'Only',
         date_of_birth: '1990-01-01',
         phone: '555-555-5555',
+        phone_type: 'voice',
         timezone: 'Eastern Time (US & Canada)',
         locale: 'en',
         hearing_disability: true
@@ -176,6 +181,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
         last_name: 'User',
         date_of_birth: '1990-01-01',
         phone: 'invalid-phone', # Invalid format
+        phone_type: 'voice',
         timezone: 'Eastern Time (US & Canada)',
         locale: 'en',
         hearing_disability: true
@@ -200,6 +206,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
         last_name: 'User',
         date_of_birth: '1990-01-01',
         phone: "555-#{rand(100..999)}-#{rand(1000..9999)}",
+        phone_type: 'voice',
         timezone: 'Eastern Time (US & Canada)',
         locale: 'en',
         hearing_disability: true
@@ -208,7 +215,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_content
     assert_select 'h2', /An account already exists with that email/
-    assert_select 'a', 'Log in with your email or phone and password'
+    assert_select 'a', I18n.t('portal_self_service.registrations.log_in_cta')
     assert_select 'input[value=?]', 'Send account access link'
   end
 
@@ -229,6 +236,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
         last_name: 'User',
         date_of_birth: '1990-01-01',
         phone: test_phone, # Already exists
+        phone_type: 'text',
         timezone: 'Eastern Time (US & Canada)',
         locale: 'en',
         hearing_disability: true
@@ -237,7 +245,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_content
     assert_select 'h2', /An account already exists with that phone/
-    assert_select 'a', 'Log in with your email or phone and password'
+    assert_select 'a', I18n.t('portal_self_service.registrations.log_in_cta')
     assert_select 'input[value=?]', 'Send account access link'
   end
 
@@ -357,6 +365,26 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes response.body, 'has already been taken'
   end
 
+  def test_re_render_preserves_submitted_phone_type_selection
+    post sign_up_path, params: { user: {
+      email: "phone-type-rerender-#{SecureRandom.hex(4)}@example.com",
+      password: 'password123',
+      password_confirmation: 'wrong-password',
+      first_name: 'Phone',
+      last_name: 'Type',
+      date_of_birth: '1990-01-01',
+      phone: '555-555-7777',
+      phone_type: 'text',
+      timezone: 'Eastern Time (US & Canada)',
+      locale: 'en',
+      hearing_disability: true
+    } }
+
+    assert_response :unprocessable_content
+    assert_select 'input#phone_type_text[checked=checked]'
+    assert_select 'input#phone_type_voice[checked=checked]', count: 0
+  end
+
   def test_should_not_offer_account_access_link_for_non_sms_phone_match
     test_phone = "555-#{rand(100..999)}-#{rand(1000..9999)}"
     create(:constituent,
@@ -373,6 +401,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
         last_name: 'User',
         date_of_birth: '1990-01-01',
         phone: test_phone,
+        phone_type: 'voice',
         timezone: 'Eastern Time (US & Canada)',
         locale: 'en',
         hearing_disability: true
@@ -381,7 +410,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_content
     assert_select 'h2', /An account already exists with that phone/
-    assert_select 'a', 'Log in with your email or phone and password'
+    assert_select 'a', I18n.t('portal_self_service.registrations.log_in_cta')
     assert_select 'a[href^=?]', 'mailto:'
     assert_select 'input[value=?]', 'Send account access link', count: 0
   end
@@ -400,6 +429,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
         last_name: 'User',
         date_of_birth: '1990-01-01',
         phone: phone_user.phone,
+        phone_type: 'text',
         timezone: 'Eastern Time (US & Canada)',
         locale: 'en',
         hearing_disability: true
@@ -439,6 +469,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
         last_name: 'USER',       # Same last name (case difference handled by controller)
         date_of_birth: '1985-05-15', # Same DOB
         phone: '555-123-4567', # Unique phone
+        phone_type: 'voice',
         timezone: 'Eastern Time (US & Canada)',
         locale: 'en',
         hearing_disability: true
@@ -465,6 +496,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
         last_name: 'User',
         date_of_birth: '1990-01-01',
         phone: '555-555-5555',
+        phone_type: 'voice',
         timezone: 'Eastern Time (US & Canada)',
         locale: 'en',
         hearing_disability: true
@@ -490,6 +522,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
       last_name: 'User',
       date_of_birth: '1990-01-01',
       phone: '555-555-5555',
+      phone_type: 'voice',
       timezone: 'Eastern Time (US & Canada)',
       locale: 'en',
       communication_preference: 'email', # Ensure email is sent
@@ -588,6 +621,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
           last_name: 'Usuario',
           date_of_birth: '1990-01-01',
           phone: '555-555-5555',
+          phone_type: 'voice',
           timezone: 'Eastern Time (US & Canada)',
           locale: 'es',
           communication_preference: 'email',

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -385,6 +385,53 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'input#phone_type_voice[checked=checked]', count: 0
   end
 
+  def test_requires_explicit_phone_type_when_phone_is_present
+    assert_no_difference('User.count') do
+      post sign_up_path, params: { user: {
+        email: "missing-phone-type-#{SecureRandom.hex(4)}@example.com",
+        password: 'password123',
+        password_confirmation: 'password123',
+        first_name: 'Phone',
+        last_name: 'Type',
+        date_of_birth: '1990-01-01',
+        phone: '555-555-7788',
+        timezone: 'Eastern Time (US & Canada)',
+        locale: 'en',
+        hearing_disability: true
+      } }
+    end
+
+    assert_response :unprocessable_content
+    assert_includes assigns(:user).errors[:phone_type],
+                    I18n.t('activerecord.errors.models.user.attributes.phone_type.portal_self_registration_phone_type_required')
+    assert_nil assigns(:user).phone_type
+    assert_select 'input#phone_type_voice[checked=checked]', count: 0
+  end
+
+  def test_rejects_blank_phone_type_when_phone_is_present
+    assert_no_difference('User.count') do
+      post sign_up_path, params: { user: {
+        email: "blank-phone-type-#{SecureRandom.hex(4)}@example.com",
+        password: 'password123',
+        password_confirmation: 'password123',
+        first_name: 'Phone',
+        last_name: 'Type',
+        date_of_birth: '1990-01-01',
+        phone: '555-555-7789',
+        phone_type: '',
+        timezone: 'Eastern Time (US & Canada)',
+        locale: 'en',
+        hearing_disability: true
+      } }
+    end
+
+    assert_response :unprocessable_content
+    assert_includes assigns(:user).errors[:phone_type],
+                    I18n.t('activerecord.errors.models.user.attributes.phone_type.portal_self_registration_phone_type_required')
+    assert_nil assigns(:user).phone_type
+    assert_select 'input#phone_type_voice[checked=checked]', count: 0
+  end
+
   def test_should_not_offer_account_access_link_for_non_sms_phone_match
     test_phone = "555-#{rand(100..999)}-#{rand(1000..9999)}"
     create(:constituent,

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -208,7 +208,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_content
     assert_select 'h2', /An account already exists with that email/
-    assert_select 'a', 'Log in with your email and password'
+    assert_select 'a', 'Log in with your email or phone and password'
     assert_select 'input[value=?]', 'Send account access link'
   end
 
@@ -237,8 +237,118 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_content
     assert_select 'h2', /An account already exists with that phone/
-    assert_select 'a', 'Log in with your email and password'
+    assert_select 'a', 'Log in with your email or phone and password'
     assert_select 'input[value=?]', 'Send account access link'
+  end
+
+  def test_should_create_constituent_with_email_only_without_phone
+    assert_difference('User.count') do
+      post sign_up_path, params: { user: {
+        email: "email-only-#{SecureRandom.hex(4)}@example.com",
+        password: 'password123',
+        password_confirmation: 'password123',
+        first_name: 'Email',
+        last_name: 'Only',
+        date_of_birth: '1990-01-01',
+        timezone: 'Eastern Time (US & Canada)',
+        locale: 'en',
+        hearing_disability: true
+      } }
+    end
+
+    assert_redirected_to welcome_path
+    user = User.last
+    assert_nil user.phone
+    assert user.real_email?
+  end
+
+  def test_should_not_create_address_only_registration
+    assert_no_difference('User.count') do
+      post sign_up_path, params: { user: {
+        password: 'password123',
+        password_confirmation: 'password123',
+        first_name: 'Address',
+        last_name: 'Only',
+        date_of_birth: '1990-01-01',
+        communication_preference: 'letter',
+        physical_address_1: '123 Main St',
+        city: 'Baltimore',
+        state: 'MD',
+        zip_code: '21201',
+        timezone: 'Eastern Time (US & Canada)',
+        locale: 'en',
+        hearing_disability: true
+      } }
+    end
+
+    assert_response :unprocessable_content
+    assert_includes assigns(:user).errors[:base].join, 'A portal account requires an email address'
+  end
+
+  def test_should_not_create_address_and_phone_without_email_registration
+    assert_no_difference('User.count') do
+      post sign_up_path, params: { user: {
+        password: 'password123',
+        password_confirmation: 'password123',
+        first_name: 'Address',
+        last_name: 'AndPhone',
+        date_of_birth: '1990-01-01',
+        phone: '555-555-5599',
+        phone_type: 'voice',
+        communication_preference: 'letter',
+        physical_address_1: '123 Main St',
+        city: 'Baltimore',
+        state: 'MD',
+        zip_code: '21201',
+        timezone: 'Eastern Time (US & Canada)',
+        locale: 'en',
+        hearing_disability: true
+      } }
+    end
+
+    assert_response :unprocessable_content
+    assert_includes assigns(:user).errors[:base].join, 'A portal account requires an email address'
+    assert_includes assigns(:user).errors[:email], "can't be blank"
+  end
+
+  def test_should_not_create_registration_when_phone_matches_phone_only_paper_record
+    phone = '410-555-0199'
+    Current.paper_context = true
+    begin
+      Users::Constituent.create!(
+        first_name: 'Paper', last_name: 'PhoneOnly',
+        phone: phone,
+        phone_type: 'text',
+        communication_preference: :letter,
+        physical_address_1: '123 Main St', city: 'Baltimore', state: 'MD', zip_code: '21201',
+        date_of_birth: Date.new(1950, 1, 1),
+        password: 'password123', password_confirmation: 'password123',
+        hearing_disability: true
+      )
+    ensure
+      Current.reset
+    end
+
+    assert_no_difference('User.count') do
+      post sign_up_path, params: { user: {
+        email: "new-signup-#{SecureRandom.hex(4)}@example.com",
+        password: 'password123',
+        password_confirmation: 'password123',
+        first_name: 'New',
+        last_name: 'Registrant',
+        date_of_birth: '1990-01-01',
+        phone: phone,
+        phone_type: 'text',
+        timezone: 'Eastern Time (US & Canada)',
+        locale: 'en',
+        hearing_disability: true
+      } }
+    end
+
+    assert_response :unprocessable_content
+    assert_select 'h2', /We need help finishing your registration/
+    assert_select 'p', /Portal accounts require an email address/
+    assert_not_includes response.body, 'has already been taken'
   end
 
   def test_should_not_offer_account_access_link_for_non_sms_phone_match
@@ -265,7 +375,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_content
     assert_select 'h2', /An account already exists with that phone/
-    assert_select 'a', 'Log in with your email and password'
+    assert_select 'a', 'Log in with your email or phone and password'
     assert_select 'a[href^=?]', 'mailto:'
     assert_select 'input[value=?]', 'Send account access link', count: 0
   end

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -311,7 +311,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     assert_includes assigns(:user).errors[:email], "can't be blank"
   end
 
-  def test_should_not_create_registration_when_phone_matches_phone_only_paper_record
+  def test_phone_only_paper_record_does_not_get_public_match_or_account_access_prompt
     phone = '410-555-0199'
     Current.paper_context = true
     begin
@@ -346,8 +346,14 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :unprocessable_content
-    assert_select 'h2', /We need help finishing your registration/
-    assert_select 'p', /Portal accounts require an email address/
+    assert_nil assigns(:account_access_user)
+    assert_not assigns(:account_access_conflict)
+    assert_select 'h2', { text: /We need help finishing your registration/, count: 0 }
+    assert_select 'h2', { text: /An account already exists/, count: 0 }
+    assert_select 'input[value=?]', 'Send account access link', count: 0
+    assert_empty assigns(:user).errors[:phone]
+    assert_includes assigns(:user).errors[:base].join, 'Portal accounts require an email address'
+    assert_includes assigns(:user).errors[:base].join, 'contact the MAT Team'
     assert_not_includes response.body, 'has already been taken'
   end
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -102,7 +102,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_should_sign_in_with_normalized_phone
-    user = create(:constituent, phone: '410-555-0100')
+    create(:constituent, phone: '410-555-0100')
 
     post sign_in_path, params: { contact: '4105550100', password: 'password123' }
 
@@ -117,7 +117,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to constituent_portal_dashboard_path
   end
 
-  def test_paper_no_email_user_signs_in_with_phone
+  def test_paper_no_email_user_cannot_sign_in_with_phone
     user = nil
     Current.paper_context = true
     begin
@@ -137,10 +137,12 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     post sign_in_path, params: { contact: user.phone, password: 'password123' }
 
-    assert_redirected_to constituent_portal_dashboard_path
+    assert_redirected_to sign_in_path
+    follow_redirect!
+    assert_match I18n.t('controllers.sessions.invalid_credentials'), flash[:alert]
   end
 
-  def test_paper_no_email_user_signs_in_with_phone_then_sms_2fa
+  def test_paper_no_email_user_cannot_start_sms_2fa_by_phone
     user = nil
     Current.paper_context = true
     begin
@@ -164,12 +166,11 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       verified_at: Time.current
     )
 
-    SessionsController.any_instance.stubs(:ensure_sms_challenge_for_user).returns(:sending)
-
     post sign_in_path, params: { contact: user.phone, password: 'password123' }
 
-    assert_redirected_to verify_method_two_factor_authentication_path(type: 'sms')
-    assert_equal user.id, session[TwoFactorAuth::SESSION_KEYS[:temp_user_id]]
+    assert_redirected_to sign_in_path
+    follow_redirect!
+    assert_match I18n.t('controllers.sessions.invalid_credentials'), flash[:alert]
   end
 
   def test_failed_login_by_phone_increments_failed_attempts
@@ -203,7 +204,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_guardian_generated_synthetic_phone_cannot_sign_in
-    user = create(:constituent, phone: '000-234-5678', email: "dep.#{SecureRandom.hex(3)}@system.matvulcan.local")
+    create(:constituent, phone: '000-234-5678', email: "dep.#{SecureRandom.hex(3)}@system.matvulcan.local")
 
     post sign_in_path, params: { contact: '0002345678', password: 'password123' }
 

--- a/test/javascript/controllers/rejection_form_controller_test.js
+++ b/test/javascript/controllers/rejection_form_controller_test.js
@@ -4,21 +4,42 @@ import RejectionFormController from "controllers/forms/rejection_form_controller
 describe("RejectionFormController", () => {
   let application
   let element
-  let incomeOnlyReasons
+  let generalReasons
+  let medicalOnlyReasons
 
   beforeEach(() => {
     // Set up DOM
     document.body.innerHTML = `
       <div data-controller="rejection-form">
         <input type="hidden" id="rejection-proof-type" value="" data-rejection-form-target="proofType">
+        <input type="hidden" data-rejection-form-target="reasonCode">
         <textarea data-rejection-form-target="reasonField"></textarea>
-        <div class="income-only-reasons hidden" data-rejection-form-target="incomeOnlyReasons">
-          <button data-reason-type="missingAmount">Missing Amount</button>
-          <button data-reason-type="exceedsThreshold">Income Exceeds Threshold</button>
-          <button data-reason-type="outdatedSsAward">Outdated SS Award Letter</button>
+        <p data-rejection-form-target="codeStatus"></p>
+        <p class="hidden" data-rejection-form-target="languageNotice"></p>
+        <p data-rejection-form-target="liveRegion"></p>
+        <div class="general-reasons hidden" data-rejection-form-target="generalReasons">
+          <button
+            data-action="click->rejection-form#selectPredefinedReason"
+            data-rejection-form-target="reasonButton"
+            data-reason-code="address_mismatch"
+            data-reason-text="Address mismatch general text"
+            data-proof-types="income,residency">
+            Address mismatch
+          </button>
+        </div>
+        <div class="medical-only-reasons hidden" data-rejection-form-target="medicalOnlyReasons">
+          <button
+            data-action="click->rejection-form#selectPredefinedReason"
+            data-rejection-form-target="reasonButton"
+            data-reason-code="medical_missing"
+            data-reason-text="Medical missing text"
+            data-proof-types="medical">
+            Medical missing
+          </button>
         </div>
         <button data-action="click->rejection-form#handleProofTypeClick" data-proof-type="income">Income Proof</button>
         <button data-action="click->rejection-form#handleProofTypeClick" data-proof-type="residency">Residency Proof</button>
+        <button data-action="click->rejection-form#handleProofTypeClick" data-proof-type="medical">Medical Proof</button>
       </div>
     `
 
@@ -27,10 +48,16 @@ describe("RejectionFormController", () => {
     application.register("rejection-form", RejectionFormController)
 
     element = document.querySelector("[data-controller='rejection-form']")
-    incomeOnlyReasons = document.querySelector(".income-only-reasons")
+    generalReasons = document.querySelector(".general-reasons")
+    medicalOnlyReasons = document.querySelector(".medical-only-reasons")
   })
 
-  test("shows income-only reasons when income proof type is selected", () => {
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+  })
+
+  test("shows general reasons when income proof type is selected", () => {
     const controller = application.getControllerForElementAndIdentifier(element, "rejection-form")
     const proofTypeInput = controller.proofTypeTarget
     
@@ -38,10 +65,11 @@ describe("RejectionFormController", () => {
     incomeButton.click()
     
     expect(proofTypeInput.value).toBe("income")
-    expect(incomeOnlyReasons.classList.contains("hidden")).toBe(false)
+    expect(generalReasons.classList.contains("hidden")).toBe(false)
+    expect(medicalOnlyReasons.classList.contains("hidden")).toBe(true)
   })
 
-  test("hides income-only reasons when residency proof type is selected", () => {
+  test("shows general reasons when residency proof type is selected", () => {
     const controller = application.getControllerForElementAndIdentifier(element, "rejection-form")
     const proofTypeInput = controller.proofTypeTarget
     
@@ -49,49 +77,58 @@ describe("RejectionFormController", () => {
     residencyButton.click()
     
     expect(proofTypeInput.value).toBe("residency")
-    expect(incomeOnlyReasons.classList.contains("hidden")).toBe(true)
+    expect(generalReasons.classList.contains("hidden")).toBe(false)
+    expect(medicalOnlyReasons.classList.contains("hidden")).toBe(true)
   })
 
-  test("initializes with income-only reasons hidden by default", () => {
+  test("initializes with reason groups hidden by default", () => {
     const controller = application.getControllerForElementAndIdentifier(element, "rejection-form")
     // The controller's connect method should handle initial visibility
-    expect(incomeOnlyReasons.classList.contains("hidden")).toBe(true)
+    expect(generalReasons.classList.contains("hidden")).toBe(true)
+    expect(medicalOnlyReasons.classList.contains("hidden")).toBe(true)
   })
 
-  test("updates income-only reasons visibility when proof type changes", () => {
+  test("updates reason group visibility when proof type changes", () => {
     const controller = application.getControllerForElementAndIdentifier(element, "rejection-form")
     const incomeButton = document.querySelector("[data-proof-type='income']")
     const residencyButton = document.querySelector("[data-proof-type='residency']")
+    const medicalButton = document.querySelector("[data-proof-type='medical']")
     
     incomeButton.click()
-    expect(incomeOnlyReasons.classList.contains("hidden")).toBe(false)
+    expect(generalReasons.classList.contains("hidden")).toBe(false)
+    expect(medicalOnlyReasons.classList.contains("hidden")).toBe(true)
+
+    medicalButton.click()
+    expect(generalReasons.classList.contains("hidden")).toBe(true)
+    expect(medicalOnlyReasons.classList.contains("hidden")).toBe(false)
     
     residencyButton.click()
-    expect(incomeOnlyReasons.classList.contains("hidden")).toBe(true)
+    expect(generalReasons.classList.contains("hidden")).toBe(false)
+    expect(medicalOnlyReasons.classList.contains("hidden")).toBe(true)
   })
 
   test("selects predefined reason text when button is clicked", () => {
     const controller = application.getControllerForElementAndIdentifier(element, "rejection-form")
     const proofTypeInput = controller.proofTypeTarget
     const reasonField = controller.reasonFieldTarget
-    
-    controller.addressMismatchIncomeValue = "Address mismatch income text"
-    controller.addressMismatchResidencyValue = "Address mismatch residency text"
+    const reasonCodeInput = controller.reasonCodeTarget
     
     const incomeButton = document.querySelector("[data-proof-type='income']")
     incomeButton.click() // Set proofTypeInput.value to "income"
     
-    const reasonButton = document.createElement("button")
-    reasonButton.dataset.reasonType = "addressMismatch"
+    const reasonButton = document.querySelector("[data-reason-code='address_mismatch']")
     
     controller.selectPredefinedReason({ currentTarget: reasonButton })
-    expect(reasonField.value).toBe("Address mismatch income text")
+    expect(reasonField.value).toBe("Address mismatch general text")
+    expect(reasonCodeInput.value).toBe("address_mismatch")
     
-    const residencyButton = document.querySelector("[data-proof-type='residency']")
-    residencyButton.click() // Set proofTypeInput.value to "residency"
+    const medicalButton = document.querySelector("[data-proof-type='medical']")
+    medicalButton.click() // Set proofTypeInput.value to "medical"
     
-    controller.selectPredefinedReason({ currentTarget: reasonButton })
-    expect(reasonField.value).toBe("Address mismatch residency text")
+    const medicalReasonButton = document.querySelector("[data-reason-code='medical_missing']")
+    controller.selectPredefinedReason({ currentTarget: medicalReasonButton })
+    expect(reasonField.value).toBe("Medical missing text")
+    expect(reasonCodeInput.value).toBe("medical_missing")
   })
 
   test("validates form submission", () => {

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -189,4 +189,46 @@ class UserMailerTest < ActionMailer::TestCase
     assert_equal [user.email], email.to
     assert_equal 'Verificacion de correo electronico', email.subject
   end
+
+  test 'password_reset mailer error audit metadata redacts reset URLs' do
+    user = create(:user)
+    raw_url = 'http://example.com/password/edit?token=secret-token'
+
+    UserMailer.any_instance.stubs(:send_email).raises(StandardError.new("boom #{raw_url}"))
+
+    assert_difference -> { Event.where(action: 'email_delivery_error', auditable: user).count }, 1 do
+      assert_raises(StandardError) do
+        UserMailer.with(user: user).password_reset.deliver_now
+      end
+    end
+
+    event = Event.where(action: 'email_delivery_error', auditable: user).last
+    variables_json = event.metadata.fetch('variables').to_json
+
+    assert_includes event.metadata.fetch('error_message'), '[REDACTED_URL]'
+    assert_not_includes event.metadata.fetch('error_message'), raw_url
+    assert_not_includes variables_json, raw_url
+    assert_not_includes variables_json, 'secret-token'
+    assert_includes variables_json, '[REDACTED]'
+  end
+
+  test 'email_verification mailer error audit metadata redacts verification URLs' do
+    user = create(:user)
+    raw_url = 'http://example.com/constituent_portal/applications/verify?token=secret-token'
+
+    UserMailer.any_instance.stubs(:send_email).raises(StandardError.new("boom #{raw_url}"))
+
+    assert_difference -> { Event.where(action: 'email_delivery_error', auditable: user).count }, 1 do
+      assert_raises(StandardError) do
+        UserMailer.with(user: user).email_verification.deliver_now
+      end
+    end
+
+    event = Event.where(action: 'email_delivery_error', auditable: user).last
+    variables_json = event.metadata.fetch('variables').to_json
+
+    assert_includes event.metadata.fetch('error_message'), '[REDACTED_URL]'
+    assert_not_includes variables_json, raw_url
+    assert_not_includes variables_json, 'secret-token'
+  end
 end

--- a/test/models/user_contact_predicates_test.rb
+++ b/test/models/user_contact_predicates_test.rb
@@ -71,6 +71,19 @@ class UserContactPredicatesTest < ActiveSupport::TestCase
     assert user.portal_access_eligible?
   end
 
+  test 'email_backed_portal_account? requires real email' do
+    assert build(:constituent, email: 'portal@example.com').email_backed_portal_account?
+    assert_not build(:constituent, email: nil, phone: '410-555-0103').email_backed_portal_account?
+  end
+
+  test 'mfa_account_name prefers real email then phone then name' do
+    email_user = build(:constituent, email: 'mfa@example.com', phone: '410-555-0104')
+    assert_equal 'mfa@example.com', email_user.mfa_account_name
+
+    phone_user = build(:constituent, email: nil, phone: '410-555-0105', first_name: 'Pat', last_name: 'Lee')
+    assert_equal '410-555-0105', phone_user.mfa_account_name
+  end
+
   test 'portal_access_eligible? is true with real phone only' do
     user = build(:constituent, email: nil, phone: '410-555-0103')
 

--- a/test/models/user_contact_predicates_test.rb
+++ b/test/models/user_contact_predicates_test.rb
@@ -71,9 +71,9 @@ class UserContactPredicatesTest < ActiveSupport::TestCase
     assert user.portal_access_eligible?
   end
 
-  test 'email_backed_portal_account? requires real email' do
-    assert build(:constituent, email: 'portal@example.com').email_backed_portal_account?
-    assert_not build(:constituent, email: nil, phone: '410-555-0103').email_backed_portal_account?
+  test 'email_backed_public_portal_account? requires real email' do
+    assert build(:constituent, email: 'portal@example.com').email_backed_public_portal_account?
+    assert_not build(:constituent, email: nil, phone: '410-555-0103').email_backed_public_portal_account?
   end
 
   test 'mfa_account_name prefers real email then phone then name' do

--- a/test/models/user_login_identifier_test.rb
+++ b/test/models/user_login_identifier_test.rb
@@ -9,11 +9,91 @@ class UserLoginIdentifierTest < ActiveSupport::TestCase
     assert_equal user, User.find_by_login_identifier(user.email)
   end
 
-  test 'find_by_login_identifier matches normalized phone' do
+  test 'find_by_login_identifier matches phone only for email-backed accounts' do
     user = create(:constituent, phone: '410-555-0198')
 
+    assert user.real_email?
     assert_equal user, User.find_by_login_identifier('4105550198')
     assert_equal user, User.find_by_login_identifier(user.phone)
+  end
+
+  test 'find_by_login_identifier rejects phone-only records' do
+    phone = '410-555-0199'
+    user = nil
+    Current.paper_context = true
+    begin
+      user = Users::Constituent.create!(
+        first_name: 'Phone', last_name: 'Only',
+        phone: phone,
+        phone_type: 'voice',
+        communication_preference: :letter,
+        physical_address_1: '123 Main St', city: 'Baltimore', state: 'MD', zip_code: '21201',
+        date_of_birth: Date.new(1950, 1, 1),
+        password: 'password123', password_confirmation: 'password123',
+        hearing_disability: true
+      )
+    ensure
+      Current.reset
+    end
+
+    assert_nil user.email
+    assert user.real_phone?
+    assert_not user.email_backed_portal_account?
+    assert_nil User.find_by_login_identifier(phone)
+  end
+
+  test 'find_for_account_access sends email delivery for email-shaped contact' do
+    user = create(:constituent, email: "access.#{SecureRandom.hex(3)}@example.com")
+
+    found_user, delivery = User.find_for_account_access(user.email)
+
+    assert_equal user, found_user
+    assert_equal :email, delivery
+  end
+
+  test 'find_for_account_access sends sms for email-backed text phone contact' do
+    user = create(:constituent, phone: '410-555-0201', phone_type: 'text')
+
+    found_user, delivery = User.find_for_account_access(user.phone)
+
+    assert_equal user, found_user
+    assert_equal :sms, delivery
+  end
+
+  test 'find_for_account_access does not deliver for voice phone on email-backed account' do
+    user = create(:constituent,
+                  phone: '410-555-0202',
+                  phone_type: 'voice',
+                  email: "voice.#{SecureRandom.hex(3)}@example.com")
+
+    found_user, delivery = User.find_for_account_access(user.phone)
+
+    assert_equal user, found_user
+    assert_nil delivery
+  end
+
+  test 'find_for_account_access does not match phone-only records' do
+    phone = '410-555-0203'
+    Current.paper_context = true
+    begin
+      Users::Constituent.create!(
+        first_name: 'Phone', last_name: 'OnlyAccess',
+        phone: phone,
+        phone_type: 'text',
+        communication_preference: :letter,
+        physical_address_1: '123 Main St', city: 'Baltimore', state: 'MD', zip_code: '21201',
+        date_of_birth: Date.new(1950, 1, 1),
+        password: 'password123', password_confirmation: 'password123',
+        hearing_disability: true
+      )
+    ensure
+      Current.reset
+    end
+
+    found_user, delivery = User.find_for_account_access(phone)
+
+    assert_nil found_user
+    assert_nil delivery
   end
 
   test 'email_shaped_identifier_does_not_fall_back_to_phone' do
@@ -37,7 +117,7 @@ class UserLoginIdentifierTest < ActiveSupport::TestCase
 
     assert_nil user.email
     assert_nil User.find_by_login_identifier('4105550197@example.com')
-    assert_equal user, User.find_by_login_identifier(phone)
+    assert_nil User.find_by_login_identifier(phone)
   end
 
   test 'login_identifier_looks_like_email? treats any at sign as email shaped' do
@@ -71,7 +151,7 @@ class UserLoginIdentifierTest < ActiveSupport::TestCase
 
     assert_nil user.email
     assert_nil User.find_by_login_identifier('4105550195@')
-    assert_equal user, User.find_by_login_identifier(phone)
+    assert_nil User.find_by_login_identifier(phone)
   end
 
   test 'find_by_login_identifier rejects placeholder phone' do

--- a/test/models/user_login_identifier_test.rb
+++ b/test/models/user_login_identifier_test.rb
@@ -3,6 +3,36 @@
 require 'test_helper'
 
 class UserLoginIdentifierTest < ActiveSupport::TestCase
+  test 'find_by_login_identifier is public portal email-backed lookup only' do
+    phone = '410-555-0199'
+    phone_only = nil
+    email_backed = create(:constituent, phone: '410-555-0198')
+
+    Current.paper_context = true
+    begin
+      phone_only = Users::Constituent.create!(
+        first_name: 'Phone', last_name: 'Only',
+        phone: phone,
+        phone_type: 'voice',
+        communication_preference: :letter,
+        physical_address_1: '123 Main St', city: 'Baltimore', state: 'MD', zip_code: '21201',
+        date_of_birth: Date.new(1950, 1, 1),
+        password: 'password123', password_confirmation: 'password123',
+        hearing_disability: true
+      )
+    ensure
+      Current.reset
+    end
+
+    assert phone_only.portal_access_eligible?
+    assert_not phone_only.email_backed_public_portal_account?
+    assert_nil User.find_by_login_identifier(phone)
+
+    assert email_backed.email_backed_public_portal_account?
+    assert_equal email_backed, User.find_by_login_identifier(email_backed.email)
+    assert_equal email_backed, User.find_by_login_identifier(email_backed.phone)
+  end
+
   test 'find_by_login_identifier matches email' do
     user = create(:constituent, email: "login.email.#{SecureRandom.hex(3)}@example.com")
 
@@ -38,7 +68,7 @@ class UserLoginIdentifierTest < ActiveSupport::TestCase
 
     assert_nil user.email
     assert user.real_phone?
-    assert_not user.email_backed_portal_account?
+    assert_not user.email_backed_public_portal_account?
     assert_nil User.find_by_login_identifier(phone)
   end
 

--- a/test/services/applications/paper_application_service_test.rb
+++ b/test/services/applications/paper_application_service_test.rb
@@ -772,7 +772,7 @@ module Applications
 
       service = PaperApplicationService.new(params: {}, admin: @admin)
       service.instance_variable_set(:@guardian_user_for_app, guardian)
-      service.send(:track_portal_eligible_created_user_id, guardian.id)
+      service.send(:track_email_backed_portal_created_user_id, guardian.id)
 
       assert_includes service.send(:new_user_accounts), guardian
     end

--- a/test/services/applications/user_creation_service_test.rb
+++ b/test/services/applications/user_creation_service_test.rb
@@ -117,7 +117,7 @@ module Applications
       assert result.success?
       assert result.data[:existing_user]
       assert_equal existing.id, result.data[:user].id
-      assert_nil result.data[:portal_eligible_created_user_id]
+      assert_nil result.data[:email_backed_portal_created_user_id]
       assert_not_includes result.data, :temp_password
     end
 
@@ -144,7 +144,7 @@ module Applications
       end
     end
 
-    test 'creates portal-eligible phone-only user with created portal marker' do
+    test 'creates phone-only user without email-backed portal account setup' do
       phone = "410-555-#{SecureRandom.random_number(9000) + 1000}"
 
       Current.paper_context = true
@@ -164,12 +164,13 @@ module Applications
       assert_nil user.email
       assert user.phone.present?
       assert user.portal_access_eligible?
-      assert_equal user.id, result.data[:portal_eligible_created_user_id]
+      assert_not user.email_backed_portal_account?
+      assert_nil result.data[:email_backed_portal_created_user_id]
       assert_not_includes result.data, :temp_password
-      assert user.force_password_change?
+      assert_not user.force_password_change?
     end
 
-    test 'creates portal-eligible user when email has surrounding whitespace' do
+    test 'creates email-backed portal user when email has surrounding whitespace' do
       phone = "410-555-#{SecureRandom.random_number(9000) + 1000}"
       email = " padded-#{SecureRandom.hex(4)}@example.com "
 
@@ -188,7 +189,8 @@ module Applications
       user = result.data[:user]
       assert_equal email.strip.downcase, user.email
       assert user.portal_access_eligible?
-      assert_equal user.id, result.data[:portal_eligible_created_user_id]
+      assert user.email_backed_portal_account?
+      assert_equal user.id, result.data[:email_backed_portal_created_user_id]
       assert_not_includes result.data, :temp_password
     end
 
@@ -211,7 +213,7 @@ module Applications
       assert_nil user.email
       assert_nil user.phone
       assert_not user.portal_access_eligible?
-      assert_nil result.data[:portal_eligible_created_user_id]
+      assert_nil result.data[:email_backed_portal_created_user_id]
       assert_not_includes result.data, :temp_password
       assert_not user.force_password_change?
       assert user.deliver_via_letter?

--- a/test/services/applications/user_creation_service_test.rb
+++ b/test/services/applications/user_creation_service_test.rb
@@ -164,7 +164,7 @@ module Applications
       assert_nil user.email
       assert user.phone.present?
       assert user.portal_access_eligible?
-      assert_not user.email_backed_portal_account?
+      assert_not user.email_backed_public_portal_account?
       assert_nil result.data[:email_backed_portal_created_user_id]
       assert_not_includes result.data, :temp_password
       assert_not user.force_password_change?
@@ -189,7 +189,7 @@ module Applications
       user = result.data[:user]
       assert_equal email.strip.downcase, user.email
       assert user.portal_access_eligible?
-      assert user.email_backed_portal_account?
+      assert user.email_backed_public_portal_account?
       assert_equal user.id, result.data[:email_backed_portal_created_user_id]
       assert_not_includes result.data, :temp_password
     end

--- a/test/services/sms_service_sensitive_logging_test.rb
+++ b/test/services/sms_service_sensitive_logging_test.rb
@@ -20,4 +20,23 @@ class SmsServiceSensitiveLoggingTest < ActiveSupport::TestCase
       context: { secure_request_form_id: 123, application_id: 456 }
     )
   end
+
+  test 'sensitive SMS logging omits account access reset URLs' do
+    SmsService.stubs(:twilio_configured?).returns(false)
+
+    reset_url = 'https://example.test/password/edit?token=secret-reset-token'
+    Rails.logger.expects(:info).with do |message|
+      message.include?('SMS delivery requested') &&
+        message.exclude?(reset_url) &&
+        message.exclude?('secret-reset-token') &&
+        message.include?('recipient_id')
+    end
+
+    SmsService.send_message(
+      '410-555-0199',
+      "MAT account access link: #{reset_url}",
+      sensitive: true,
+      context: { recipient_id: 42, recipient_channel: 'account_access_sms' }
+    )
+  end
 end

--- a/test/system/registrations_test.rb
+++ b/test/system/registrations_test.rb
@@ -114,4 +114,33 @@ class RegistrationsTest < ApplicationSystemTestCase
     assert_equal 'password', find_field('Password')[:type]
     assert_equal 'password', find_field('Confirm Password')[:type]
   end
+
+  test 'registration optional phone type shows phone type when phone entered' do
+    visit sign_up_path
+    ensure_stimulus_loaded
+
+    assert page.has_css?('[data-controller~="optional-phone-type"]', wait: 5)
+    wait_until(time: 5) do
+      page.evaluate_script(<<~JS)
+        (function() {
+          var el = document.querySelector('[data-controller~="optional-phone-type"]');
+          return el && el.dataset.optionalPhoneTypeConnected === 'true';
+        })();
+      JS
+    end
+
+    phone_type_fields = find('[data-optional-phone-type-target="phoneTypeFields"]', visible: :all)
+    assert phone_type_fields[:class].include?('hidden')
+
+    find_by_id('user_phone').set('4105550123')
+
+    assert_no_selector('[data-optional-phone-type-target="phoneTypeFields"].hidden', wait: 5)
+    assert_not find_by_id('phone_type_voice', visible: :all)[:disabled]
+    assert_not find_by_id('phone_type_text', visible: :all)[:disabled]
+    assert_not find_by_id('phone_type_voice', visible: :all)[:checked]
+    assert_not find_by_id('phone_type_text', visible: :all)[:checked]
+
+    choose 'Text/SMS'
+    assert find_by_id('phone_type_text')[:checked]
+  end
 end

--- a/test/system/webauthn_recovery_flow_test.rb
+++ b/test/system/webauthn_recovery_flow_test.rb
@@ -33,7 +33,7 @@ class WebauthnRecoveryFlowTest < ApplicationSystemTestCase
 
     # Check for form elements
     assert_selector 'h1', text: 'Security Key Recovery'
-    assert_field 'email'
+    assert_field 'contact'
     assert_field 'details'
     assert_button 'Submit Recovery Request'
   end
@@ -78,7 +78,7 @@ class WebauthnRecoveryFlowTest < ApplicationSystemTestCase
     visit lost_security_key_path
 
     # Fill out the form
-    fill_in 'email', with: @user.email
+    fill_in 'contact', with: @user.email
     fill_in 'details', with: 'I lost my security key during travel.'
     click_button 'Submit Recovery Request'
 


### PR DESCRIPTION
- public paths require real_email?; phone is an alternate login/recovery identifier only on the same email-backed account.
- Phone-only and address-only paper records remain valid for intake but cannot self-register or use public portal paths.
- Paper/admin portal setup and markers use email_backed_portal_account? instead of portal_access_eligible?